### PR TITLE
Changing -version to  under the message

### DIFF
--- a/juniper_official/System/software-version.rule
+++ b/juniper_official/System/software-version.rule
@@ -58,7 +58,7 @@ iceberg {
                     then {
                         status {
                             color red;
-                            message "Unauthorized Junos version ($junos-version) is being used";
+                            message "Unauthorized Junos version ($version) is being used";
                         }
                     }
                 }


### PR DESCRIPTION
This is related to https://github.com/Juniper/jfit-rules/issues/62

The issue was caused by us changing the rules to use variables - which was after we'd tested the rules.

