### PR TITLE
Added SNMP rules for basic Junos monitoring

### DIFF
--- a/community_supplied/cpu-usage.rule
+++ b/community_supplied/cpu-usage.rule
@@ -1,0 +1,87 @@
+iceberg {
+    topic snmp.cpu {
+        rule cpu-usage {
+            keys [ l0index l1index l2index l3index ];
+            sensor jnxOperatingTable {
+                snmp {
+                    table .1.3.6.1.4.1.2636.3.1.13;
+                    frequency 60s;
+                }
+            }
+            field jnxOperating1MinLoadAvg {
+                sensor jnxOperatingTable {
+                    path jnxOperating1MinLoadAvg;
+                }
+                type integer;
+            }
+            field jnxOperatingDescr {
+                sensor jnxOperatingTable {
+                    path jnxOperatingDescr;
+                }
+                type string;
+            }
+            field l0index {
+                sensor jnxOperatingTable {
+                    path jnxOperatingContentsIndex;
+                }
+                type string;
+            }
+            field l1index {
+                sensor jnxOperatingTable {
+                    path jnxOperatingL1Index;
+                }
+                type string;
+            }
+            field l2index {
+                sensor jnxOperatingTable {
+                    path jnxOperatingL2Index;
+                }
+                type string;
+            }
+            field l3index {
+                sensor jnxOperatingTable {
+                    path jnxOperatingL1Index;
+                }
+                type string;
+            }
+            trigger cpu-trigger {
+                frequency 60s;
+                term cpu_ok {
+                    when {
+                        less-than "$jnxOperating1MinLoadAvg" 100;
+                        not-equal-to "$jnxOperating1MinLoadAvg" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "Unix-style CPU load of $jnxOperatingDescr is $jnxOperating1MinLoadAvg";
+                        }
+                    }
+                }
+                term cpu_warning {
+                    when {
+                        greater-than-or-equal-to "$jnxOperating1MinLoadAvg" 100;
+                        less-than-or-equal-to "$jnxOperating1MinLoadAvg" 300;
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "Unix-style CPU load of $jnxOperatingDescr is $jnxOperating1MinLoadAvg\n";
+                        }
+                    }
+                }
+                term cpu_critical {
+                    when {
+                        greater-than "$jnxOperating1MinLoadAvg" 300;
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Unix-style CPU load of $jnxOperatingDescr is $jnxOperating1MinLoadAvg\n";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/interface-errors.rule
+++ b/community_supplied/interface-errors.rule
@@ -1,0 +1,656 @@
+iceberg {
+    topic snmp.iferrors {
+        rule iferrors-statistics {
+            keys [ ifJnxIndex index ];
+            sensor ifJnxTable {
+                snmp {
+                    table .1.3.6.1.4.1.2636.3.3.1;
+                    frequency 300s;
+                }
+            }
+            field ifDescr {
+                reference {
+                    path "/topic[topic-name=snmp.interfaces]/rule[rule-name=interfaces-status]/field[ifIndex='$index']/ifDescr";
+                }
+                type string;
+            }
+            field ifJnxBucketDrops {
+                sensor ifJnxTable {
+                    path ifJnxBucketDrops;
+                }
+                type integer;
+            }
+            field ifJnxCarrierTrans {
+                sensor ifJnxTable {
+                    path ifJnxCarrierTrans;
+                }
+                type integer;
+            }
+            field ifJnxCollisions {
+                sensor ifJnxTable {
+                    path ifJnxCollisions;
+                }
+                type integer;
+            }
+            field ifJnxInDiscards {
+                sensor ifJnxTable {
+                    path ifJnxInDiscards;
+                }
+                type integer;
+            }
+            field ifJnxInErrors {
+                sensor ifJnxTable {
+                    path ifJnxInErrors;
+                }
+                type integer;
+            }
+            field ifJnxInFifoErrors {
+                sensor ifJnxTable {
+                    path ifJnxInFifoErrors;
+                }
+                type integer;
+            }
+            field ifJnxInFrameErrors {
+                sensor ifJnxTable {
+                    path ifJnxInFrameErrors;
+                }
+                type integer;
+            }
+            field ifJnxInGiants {
+                sensor ifJnxTable {
+                    path ifJnxInGiants;
+                }
+                type integer;
+            }
+            field ifJnxInHslCrcErrors {
+                sensor ifJnxTable {
+                    path ifJnxInHslCrcErrors;
+                }
+                type integer;
+            }
+            field ifJnxInHslFifoOverFlows {
+                sensor ifJnxTable {
+                    path ifJnxInHslFifoOverFlows;
+                }
+                type integer;
+            }
+            field ifJnxInInvalidVCs {
+                sensor ifJnxTable {
+                    path ifJnxInInvalidVCs;
+                }
+                type integer;
+            }
+            field ifJnxInL2ChanErrors {
+                sensor ifJnxTable {
+                    path ifJnxInL2ChanErrors;
+                }
+                type integer;
+            }
+            field ifJnxInL2MismatchTimeout {
+                sensor ifJnxTable {
+                    path ifJnxInL2MismatchTimeouts;
+                }
+                type integer;
+            }
+            field ifJnxInL3Incompletes {
+                sensor ifJnxTable {
+                    path ifJnxInL3Incompletes;
+                }
+                type integer;
+            }
+            field ifJnxInQDrops {
+                sensor ifJnxTable {
+                    path ifJnxInQDrops;
+                }
+                type integer;
+            }
+            field ifJnxInRunts {
+                sensor ifJnxTable {
+                    path ifJnxInRunts;
+                }
+                type integer;
+            }
+            field ifJnxOutAgedErrors {
+                sensor ifJnxTable {
+                    path ifJnxOutAgedErrors;
+                }
+                type integer;
+            }
+            field ifJnxOutErrors {
+                sensor ifJnxTable {
+                    path ifJnxOutErrors;
+                }
+                type integer;
+            }
+            field ifJnxOutFifoErrors {
+                sensor ifJnxTable {
+                    path ifJnxOutFifoErrors;
+                }
+                type integer;
+            }
+            field ifJnxOutHslCrcErrors {
+                sensor ifJnxTable {
+                    path ifJnxOutHslCrcErrors;
+                }
+                type integer;
+            }
+            field ifJnxOutHslFifoUnderFlow {
+                sensor ifJnxTable {
+                    path ifJnxOutHslFifoUnderFlows;
+                }
+                type integer;
+            }
+            field ifJnxOutQDrops {
+                sensor ifJnxTable {
+                    path ifJnxOutQDrops;
+                }
+                type integer;
+            }
+            field ifJnxSramErrors {
+                sensor ifJnxTable {
+                    path ifJnxSramErrors;
+                }
+                type integer;
+            }
+            field index {
+                sensor ifJnxTable {
+                    path index;
+                }
+                type string;
+            }
+            trigger ifJnxCarrierTrans {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxCarrierTrans" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxCarrierTrans carrier signal transitions on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxCarrierTrans" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxCarrierTrans carrier signal transitions on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxCollisions {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxCollisions" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxCollisions collisions detected on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxCollisions" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxCollisions collisions detected on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInDiscards {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInDiscards" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInGiants policed discards on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInDiscards" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInGiants policed discards on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInErrors {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInErrors" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInErrors input errors detected on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInErrors" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInErrors input errors detected on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInFifoErrors {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInFifoErrors" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInFifoErrors IN FIFO errors on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInFifoErrors" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInFifoErrors IN FIFO errors on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInFrameErrors {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInFrameErrors" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInFrameErrors input framing errors detected on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInFrameErrors" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInFrameErrors input framing errors detected on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInGiants {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInGiants" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInGiants giant input frames on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInGiants" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInGiants giant input frames on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInL2ChanErrors {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInL2ChanErrors" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInL2ChanErrors L2 channel errors on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInL2ChanErrors" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInL2ChanErrors L2 channel errors on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInL2MismatchTimeou {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInL2MismatchTimeout" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInL2MismatchTimeouts L2 mismatch timeouts on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInL2MismatchTimeout" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInL2MismatchTimeouts L2 mismatch timeouts on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInL3Incompletes {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInL3Incompletes" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInL3Incompletes L3 incompletes on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInL3Incompletes" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInL3Incompletes L3 incompletes on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInQDrops {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInQDrops" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInQDrops packets dropped by the input queue on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInQDrops" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInQDrops packets dropped by the input queue on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxInRunts {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxInRunts" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxInRunts runt input frames on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxInRunts" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxInRunts runt input frames on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxOutAgedErrors {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxOutAgedErrors" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxOutAgedErrors aged packets on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxOutAgedErrors" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxOutAgedErrors aged packets on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxOutErrors {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxOutErrors" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxOutErrors output errors detected on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxOutErrors" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxOutErrors output errors detected on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxOutFifoErrors {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxOutFifoErrors" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxOutFifoErrors OUT FIFO errors on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxOutFifoErrors" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxOutFifoErrors OUT FIFO errors on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxOutHslCrcErrors {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxOutHslCrcErrors" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxOutHslCrcErrors HS link CRC errors on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxOutHslCrcErrors" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxOutHslCrcErrors HS link CRC errors on $ifDescr";
+                        }
+                    }
+                }
+            }
+            trigger ifJnxOutQDrops {
+                frequency 300s;
+                term Term_1 {
+                    when {
+                        increasing-at-most-by-value "$ifJnxOutQDrops" {
+                            value 4;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifJnxOutQDrops packets dropped by the output queue on $ifDescr";
+                        }
+                    }
+                }
+                term Term_2 {
+                    when {
+                        increasing-at-least-by-value "$ifJnxOutQDrops" {
+                            value 5;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifJnxOutQDrops packets dropped by the output queue on $ifDescr";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/interface-status.rule
+++ b/community_supplied/interface-status.rule
@@ -1,0 +1,88 @@
+iceberg {
+    topic snmp.interfaces {
+        rule interfaces-status {
+            keys ifIndex;
+            sensor iftable {
+                snmp {
+                    table .1.3.6.1.2.1.2.2;
+                    frequency 300s;
+                }
+            }
+            field ifAdminStatus {
+                sensor iftable {
+                    path ifAdminStatus;
+                }
+                type integer;
+                description ifAdminStatus;
+            }
+            field ifDescr {
+                sensor iftable {
+                    path ifDescr;
+                }
+                type string;
+                description ifDescr;
+            }
+            field ifInUcastPkts {
+                sensor iftable {
+                    path ifInUcastPkts;
+                }
+                type integer;
+                description ifInUcastPkts;
+            }
+            field ifIndex {
+                sensor iftable {
+                    path ifIndex;
+                }
+                type string;
+                description ifIndex;
+            }
+            field ifOperStatus {
+                sensor iftable {
+                    path ifOperStatus;
+                }
+                type integer;
+                description ifOperStatus;
+            }
+            trigger check-interface-status {
+                frequency 300s;
+                term up_up {
+                    when {
+                        equal-to "$ifOperStatus" 1;
+                        equal-to "$ifAdminStatus" 1;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$ifDescr OperStatus and AdminStatus are up";
+                        }
+                    }
+                }
+                term up_down {
+                    when {
+                        equal-to "$ifAdminStatus" 1;
+                        not-equal-to "$ifOperStatus" 1;
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "$ifDescr OperStatus is up and AdminStatus is down";
+                        }
+                    }
+                }
+                term down_down {
+                    when {
+                        equal-to "$ifAdminStatus" 2;
+                        not-equal-to "$ifOperStatus" 1;
+                        not-equal-to "$ifAdminStatus" 1;
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$ifDescr OperStatus and AdminStatus are down";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/memory-usage.rule
+++ b/community_supplied/memory-usage.rule
@@ -1,0 +1,96 @@
+iceberg {
+	topic snmp.memory {
+		rule memory-usage {
+		    keys [ jnxContentsIndex jnxOperatingL1Index jnxOperatingL2Index jnxOperatingL3Index ];
+		    sensor memory-usage {
+		        snmp {
+		            table .1.3.6.1.4.1.2636.3.1.13;
+		            frequency 60s;
+		        }
+		    }
+		    field jnxContentsIndex {
+		        sensor memory-usage {
+		            path jnxOperatingContentsIndex;
+		        }
+		        type string;
+		    }
+		    field jnxOperatingBuffer {
+		        sensor memory-usage {
+		            path jnxOperatingBuffer;
+		        }
+		        type integer;
+		    }
+		    field jnxOperatingDescr {
+		        sensor memory-usage {
+		            path jnxOperatingDescr;
+		        }
+		        type string;
+		    }
+		    field jnxOperatingL1Index {
+		        sensor memory-usage {
+		            path jnxOperatingL1Index;
+		        }
+		        type string;
+		    }
+		    field jnxOperatingL2Index {
+		        sensor memory-usage {
+		            path jnxOperatingL2Index;
+		        }
+		        type string;
+		    }
+		    field jnxOperatingL3Index {
+		        sensor memory-usage {
+		            path jnxOperatingL2Index;
+		        }
+		        type string;
+		    }
+		    trigger memory_trigger {
+		        frequency 60s;
+		        term memory_ok {
+		            when {
+		                less-than "$jnxOperatingBuffer" 70;
+		                not-equal-to "$jnxOperatingBuffer" 0;
+		                matches-with "$jnxOperatingDescr" "routing engine" {
+		                    ignore-case;
+		                }
+		            }
+		            then {
+		                status {
+		                    color green;
+		                    message "$jnxOperatingBuffer % memory used on $jnxOperatingDescr";
+		                }
+		            }
+		        }
+		        term memory_warning {
+		            when {
+		                greater-than-or-equal-to "$jnxOperatingBuffer" 70;
+		                less-than-or-equal-to "$jnxOperatingBuffer" 90;
+		                matches-with "$jnxOperatingDescr" "routing engine" {
+		                    ignore-case;
+		                }
+		            }
+		            then {
+		                status {
+		                    color yellow;
+		                    message "$jnxOperatingBuffer % memory used on $jnxOperatingDescr";
+		                }
+		            }
+		        }
+		        term memory_critical {
+		            when {
+		                greater-than "$jnxOperatingBuffer" 90;
+		                matches-with "$jnxOperatingDescr" "routing engine" {
+		                    ignore-case;
+		                }
+		            }
+		            then {
+		                status {
+		                    color red;
+		                    message "$jnxOperatingBuffer % memory used on $jnxOperatingDescr";
+		                }
+		            }
+		        }
+		    }
+		}
+	}
+}

--- a/community_supplied/processes-stats.rule
+++ b/community_supplied/processes-stats.rule
@@ -1,0 +1,65 @@
+iceberg {
+    topic snmp.processes {
+        rule processes-stats {
+            keys index;
+            sensor sysApplElmtRunTable {
+                snmp {
+                    table .1.3.6.1.2.1.54.1.2.3;
+                    frequency 60s;
+                }
+            }
+            field index {
+                sensor sysApplElmtRunTable {
+                    path index;
+                }
+                type string;
+            }
+            field sysApplElmtRunCPU {
+                sensor sysApplElmtRunTable {
+                    path sysApplElmtRunCPU;
+                }
+                type integer;
+            }
+            field sysApplElmtRunMemory {
+                sensor sysApplElmtRunTable {
+                    path sysApplElmtRunMemory;
+                }
+                type integer;
+            }
+            field sysApplElmtRunName {
+                sensor sysApplElmtRunTable {
+                    path sysApplElmtRunName;
+                }
+                type string;
+            }
+            trigger cpu {
+                frequency 60s;
+                term Term_1 {
+                    when {
+                        exists "$index";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "CPU usage of $sysApplElmtRunName is $sysApplElmtRunCPU";
+                        }
+                    }
+                }
+            }
+            trigger memory {
+                frequency 60s;
+                term Term_1 {
+                    when {
+                        exists "$index";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "Memory usage of $sysApplElmtRunName is $sysApplElmtRunMemory";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/storage-usage.rule
+++ b/community_supplied/storage-usage.rule
@@ -1,0 +1,84 @@
+iceberg {
+    topic snmp.storage {
+        rule storage-usage {
+            keys hrStorageIndex;
+            function storage-percentage {
+                path used-percentage.py;
+                method used_percentage;
+                argument total {
+                    mandatory;
+                }
+                argument used {
+                    mandatory;
+                }
+            }
+            sensor hrStorageTable {
+                snmp {
+                    table .1.3.6.1.2.1.25.2.3;
+                    frequency 300s;
+                }
+            }
+            field hrStorageDescr {
+                sensor hrStorageTable {
+                    path hrStorageDescr;
+                }
+                type string;
+            }
+            field hrStorageIndex {
+                sensor hrStorageTable {
+                    path hrStorageIndex;
+                }
+                type string;
+            }
+            field hrStorageSize {
+                sensor hrStorageTable {
+                    path hrStorageSize;
+                }
+                type integer;
+            }
+            field hrStorageUsed {
+                sensor hrStorageTable {
+                    path hrStorageUsed;
+                }
+                type integer;
+            }
+            field storage_percentage {
+                formula {
+                    user-defined-function {
+                        function-name storage-percentage;
+                        argument total "$hrStorageSize";
+                        argument used "$hrStorageUsed";
+                    }
+                }
+                type integer;
+            }
+            trigger check_storage_space {
+                frequency 300s;
+                term term_space_ok {
+                    when {
+                        less-than "$storage_percentage" 70;
+                        not-equal-to "$storage_percentage" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$hrStorageDescr has $hrStorageUsed used over $hrStorageSize";
+                        }
+                    }
+                }
+                term term_space_warning {
+                    when {
+                        greater-than-or-equal-to "$storage_percentage" 70;
+                        less-than "$storage_percentage" 100;
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "$hrStorageDescr has $hrStorageUsed used over $hrStorageSize";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/temperature-levels.rule
+++ b/community_supplied/temperature-levels.rule
@@ -1,0 +1,97 @@
+iceberg {
+    topic snmp.temperatures {
+        rule temperature-level {
+            keys [ Field_rtsn6d L0Index l0index l1index l2index l3index ];
+            sensor jnxOperatingTable {
+                snmp {
+                    table .1.3.6.1.4.1.2636.3.1.13;
+                    frequency 60s;
+                }
+            }
+            field jnxOperatingDescr {
+                sensor jnxOperatingTable {
+                    path jnxOperatingDescr;
+                }
+                type string;
+                description "";
+            }
+            field jnxOperatingTemp {
+                sensor jnxOperatingTable {
+                    path jnxOperatingTemp;
+                }
+                type integer;
+            }
+            field l0index {
+                sensor jnxOperatingTable {
+                    path jnxOperatingContentsIndex;
+                }
+                type string;
+            }
+            field l1index {
+                sensor jnxOperatingTable {
+                    path jnxOperatingL1Index;
+                }
+                type string;
+            }
+            field l2index {
+                sensor jnxOperatingTable {
+                    path jnxOperatingL2Index;
+                }
+                type string;
+            }
+            field l3index {
+                sensor jnxOperatingTable {
+                    path jnxOperatingL3Index;
+                }
+                type string;
+            }
+            trigger temperature_trigger {
+                frequency 60s;
+                term temp_ok {
+                    when {
+                        less-than "$jnxOperatingTemp" 50;
+                        not-equal-to "$jnxOperatingTemp" 0;
+                        matches-with "$jnxOperatingDescr" "routing engine" {
+                            ignore-case;
+                        }
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "Temperature of $jnxOperatingDescr is $jnxOperatingTemp";
+                        }
+                    }
+                }
+                term temp_warning {
+                    when {
+                        greater-than-or-equal-to "$jnxOperatingTemp" 50;
+                        less-than-or-equal-to "$jnxOperatingTemp" 70;
+                        matches-with "$jnxOperatingDescr" "routing engine" {
+                            ignore-case;
+                        }
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "Temperature of $jnxOperatingDescr is $jnxOperatingTemp";
+                        }
+                    }
+                }
+                term temp_critical {
+                    when {
+                        greater-than "$jnxOperatingTemp" 70;
+                        matches-with "$jnxOperatingDescr" "routing engine" {
+                            ignore-case;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Temperature of $jnxOperatingDescr is $jnxOperatingTemp";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/vlan-status.rule
+++ b/community_supplied/vlan-status.rule
@@ -1,0 +1,77 @@
+iceberg {
+    topic snmp.vlan {
+        rule vlan-status {
+            keys vlanNbr;
+            sensor vlan-status {
+                snmp {
+                    table .1.3.6.1.4.1.2636.3.40.1.5.1.6;
+                    frequency 300s;
+                }
+            }
+            field ifAdminStatus {
+                sensor vlan-status {
+                    path jnxExVlanInterfaceAdminStatus;
+                }
+                type integer;
+                description "up or down";
+            }
+            field ifOperStatus {
+                sensor vlan-status {
+                    path jnxExVlanInterfaceOperStatus;
+                }
+                type integer;
+            }
+            field ipAddr {
+                sensor vlan-status {
+                    path jnxExVlanInterfaceIpAddress;
+                }
+                type string;
+            }
+            field vlanNbr {
+                sensor vlan-status {
+                    path jnxExVlanInterfaceDescription;
+                }
+                type string;
+            }
+            trigger vlan_state {
+                frequency 300s;
+                term vlan_upup {
+                    when {
+                        equal-to "$ifAdminStatus" 1;
+                        equal-to "$ifOperStatus" 1;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$jnxExVlanInterfaceDescription OperStatus is up and AdminStatus is up";
+                        }
+                    }
+                }
+                term vlan_up_down {
+                    when {
+                        equal-to "$ifAdminStatus" 0;
+                        equal-to "$ifOperStatus" 1;
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "$jnxExVlanInterfaceDescription OperStatus is up and AdminStatus is down";
+                        }
+                    }
+                }
+                term vlan_down_down {
+                    when {
+                        equal-to "$ifAdminStatus" 0;
+                        equal-to "$ifOperStatus" 0;
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$jnxExVlanInterfaceDescription OperStatus is down and AdminStatus is down";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
These rules were initially created to monitor EX3400/4200 series, but should work with every Junos devices.

Here are some important facts:
- Interface-errors rule sometimes shows red squares for every interfaces even though threshold is not reached (quite rare).
- The processes-stats rule retrieve the information correctly, but is showing only one row of the table (The SNMP table for processes is not built the same way as the others, which could explain this).
- I have to put 300s delays for many sensors to avoid DoS of the routing engine.

**I created these rules using the GUI and exported them doing copy/paste from rule builder CLI. The syntax looks good but I had an error when I tested to upload them back. No clues for now**