### PR TITLE
Modified variable values from mx960/17.X to .*

### DIFF
--- a/juniper_official/System/software-version.rule
+++ b/juniper_official/System/software-version.rule
@@ -76,12 +76,12 @@ iceberg {
                 }
             }
             variable product-value {
-                value mx960;
+                value .*;
                 description "Product model the system should be";
                 type string;
             }
             variable software-version-value {
-                value 17.4R1;
+                value .*;
                 description "Software Version the system should have";
                 type string;
             }


### PR DESCRIPTION
Addressed issue #122.
Sane default for Software_Version_Value in software-version.rule #122