### PR TITLE
subscriber service rules are added for default playbook

### DIFF
--- a/juniper_official/Linecard/xm-li-error.yml
+++ b/juniper_official/Linecard/xm-li-error.yml
@@ -9,8 +9,7 @@ CChipLiInterruptStatsTable:
     - name
   view: CChipLiInterruptStatsView
   eval:
-    cchip-errors-from-lookup-chip:
-      "reduce(lambda x,y: x+y, [v['interrupts'] for k,v in {{ data }}.items()])"
+    cchip-errors-from-lookup-chip: "reduce(lambda x,y: x+y, [v['interrupts'] for k,v in {{ data }}.items()])"
 
 CChipLiInterruptStatsView:
   columns:

--- a/juniper_official/Linecard/xm-pt-statistics.yml
+++ b/juniper_official/Linecard/xm-pt-statistics.yml
@@ -13,7 +13,5 @@ CChipPTStatView:
     pct_wi_0: 'PCT entries used by all WI-0 streams\s+:\s?(\d+)'
     pct_fab: 'PCT entries used by all FI streams\s+:\s?(\d+)'
   eval:
-    cchip-free-internal-packet-table-wan: >
-      '4096 - {{ pct_wi_1 }} + {{ pct_wi_0 }}'
-    cchip-free-internal-packet-table-fabric: >
-      '4096- {{pct_fab}}'
+    cchip-free-internal-packet-table-wan: '4096 - {{ pct_wi_1 }} + {{ pct_wi_0 }}'
+    cchip-free-internal-packet-table-fabric: '4096 - {{pct_fab}}'

--- a/juniper_official/Linecard/xm-wo-statistics.yml
+++ b/juniper_official/Linecard/xm-wo-statistics.yml
@@ -6,8 +6,8 @@ CChipWoStatsTable:
     chip_instance: 0
   eval:
     cchip-wo-packets-sent: >
-        "{{ data }}['counter_0']['total_packets_0'] +
-        {{ data }}['counter_1']['total_packets_1']"
+        {{ data }}['counter_0']['total_packets_0'] +
+        {{ data }}['counter_1']['total_packets_1']
   view: CChipWoStatsView
 
 CChipWoStatsView:

--- a/juniper_official/Solutions/Microburst/microburst.rule
+++ b/juniper_official/Solutions/Microburst/microburst.rule
@@ -6,15 +6,25 @@ iceberg {
         description "Interface egress queues microburst detection";
         synopsis "Microburst detector";
         rule check-queue {
-            description "Collects all interfaces egress queues data using gpb sensor and detects microbursts";
-            synopsis " Microbust detector"
             keys [ if-name queue-no ];
+            synopsis " Microbust detector";
+            description "Collects all interfaces egress queues data using gpb sensor and detects microbursts";
             sensor jnpr-qmon-ext {
                 synopsis "Qmon native gpb sensor";
                 description "Sensor configuration to get bgp data from network devices";
                 native-gpb {
                     sensor-name jnpr_qmon_ext;
-                    port 22000;
+                    port 22000; ## Warning: 'port' is deprecated
+                }
+            }
+            field buffer-percentage {
+                sensor jnpr-qmon-ext {
+                    path queue_monitor_element_info.queue_monitor_stats_egress.queue_monitor_stats_info.peak_buffer_occupancy_percent;
+                }
+            }
+            field egress-packets {
+                sensor jnpr-qmon-ext {
+                    path queue_monitor_element_info.queue_monitor_stats_egress.queue_monitor_stats_info.packets;
                 }
             }
             /*
@@ -33,6 +43,8 @@ iceberg {
                     microburst {
                         if-name "$if-name";
                         queue-no "$queue-no";
+                        percentage "$buffer-percentage";
+                        packets "$egress-packets";
                     }
                 }
                 type integer;
@@ -78,13 +90,13 @@ iceberg {
             }
             variable if-name-expr {
                 value .*;
-                type string;
                 description "Interface names to monitor, regular expression, eg 'ge-.*'";
+                type string;
             }
             variable queue-no-expr {
                 value .*;
-                type string;
                 description "Queue number or name to monitor, regular expression, eg '1|2'";
+                type string;
             }
         }
     }

--- a/juniper_official/Solutions/Microburst/microburst.rule
+++ b/juniper_official/Solutions/Microburst/microburst.rule
@@ -21,11 +21,15 @@ iceberg {
                 sensor jnpr-qmon-ext {
                     path queue_monitor_element_info.queue_monitor_stats_egress.queue_monitor_stats_info.peak_buffer_occupancy_percent;
                 }
+                type float;
+                description "Interface egress buffer percent";
             }
             field egress-packets {
                 sensor jnpr-qmon-ext {
                     path queue_monitor_element_info.queue_monitor_stats_egress.queue_monitor_stats_info.packets;
                 }
+                type float;
+                description "Interface egress packets";
             }
             /*
              * Sensor and constant fields

--- a/juniper_official/Subscriber-Service/address-pool-utilization.rule
+++ b/juniper_official/Subscriber-Service/address-pool-utilization.rule
@@ -1,0 +1,292 @@
+iceberg {
+    topic service.subscribers {
+        description "Rules related to subscribers address pool utilization";
+        synopsis "BNG subscribers address pool monitoring rules";
+        rule address-pool-utilization {
+            keys [ lsri-name pool-name ];
+            synopsis "single pool utilization";
+            description "single pool utilization, also collects info on linked pools";
+            sensor pool {
+                synopsis "subscriber-management open-config sensor definition";
+                description "subscriber-management open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool;
+                    frequency 60s;
+                }
+            }
+            field address-in-use {
+                sensor pool {
+                    path /junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool/address-in-use;
+                }
+                type integer;
+                description "address-in-use field";
+            }
+            field address-total {
+                sensor pool {
+                    path /junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool/address-total;
+                }
+                type integer;
+                description "address-total field";
+            }
+            field address-usage-ml {
+                formula {
+                    dynamic-threshold {
+                        algorithm 3sigma;
+                        learning-period 1d;
+                        pattern-periodicity 1h;
+                        field-name "$address-usage-percent";
+                    }
+                }
+                type integer;
+                description "Value calculated based on 3sigma algorithm";
+            }
+            field address-usage-percent {
+                sensor pool {
+                    path /junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool/address-usage-percent;
+                }
+                type integer;
+                description "address-usage-percent field";
+            }
+            field linked-pool {
+                sensor pool {
+                    where "/junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool/linked-pool-head =~ /{{filter-linked-pool-head}}/";
+                    path /junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool/linked-pool-name;
+                }
+                type string;
+                description "linked-pool-name field";
+            }
+            field linked-pool-head {
+                sensor pool {
+                    path /junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool/linked-pool-head;
+                }
+                type string;
+                description "linked-pool-head name field";
+            }
+            field lsri-name {
+                sensor pool {
+                    where "/junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/@name =~ /{{filter-lsri-name}}/";
+                    path "/junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/@name";
+                }
+                description "logical system routing instance name";
+            }
+            field pool-name {
+                sensor pool {
+                    where "/junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool/@pool-name =~ /{{filter-pool-name}}/";
+                    path "/junos/system/subscriber-management/aaa/address-assignment-statistics/logical-system-routing-instances/logical-system-routing-instance/pools/pool/@pool-name";
+                }
+                description "pool name to monitor";
+            }
+            field utilization-max-threshold {
+                constant {
+                    value "{{pool-utilization-max-threshold}}";
+                }
+                type integer;
+                description "address pool utilization max threshold";
+            }
+            field utilization-min-threshold {
+                constant {
+                    value "{{pool-utilization-min-threshold}}";
+                }
+                type integer;
+                description "address pool utilization min threshold";
+            }
+            trigger pool-utilization {
+                synopsis "address pool utilization kpi";
+                description "Sets health based on address pool utilization";
+                frequency 90s;
+                term is-utilization-abnormal {
+                    when {
+                        greater-than "$address-usage-percent" "$utilization-max-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Pool $pool-name  ( Pool head : $linked-pool-head) utilization % ($address-usage-percent) is abnormal";
+                        }
+                    }
+                }
+                term utilization-abnormal-ls {
+                    when {
+                        less-than "$address-usage-percent" "$utilization-min-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Pool $pool-name  ( Pool head : $linked-pool-head) utilization % ($address-usage-percent) is abnormal";
+                        }
+                    }
+                }
+                term utilization-abnormal-ml {
+                    when {
+                        equal-to "$address-usage-ml" 1 {
+                            time-range 5m;
+                        }
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "Pool $pool-name  ( Pool head : $linked-pool-head) utilization % ($address-usage-percent) is abnormal based on ML algorithm";
+                        }
+                    }
+                }
+                term pool-util-normal {
+                    then {
+                        status {
+                            color green;
+                            message "Pool $pool-name ( Pool head : $linked-pool-head) utilization % ($address-usage-percent) is normal";
+                        }
+                    }
+                }
+            }
+            variable filter-linked-pool-head {
+                value .*;
+                description "address pool header name";
+                type string;
+            }
+            variable filter-lsri-name {
+                value .*;
+                description "logical system routing instance name";
+                type string;
+            }
+            variable filter-pool-name {
+                value .*;
+                description "address pool name";
+                type string;
+            }
+            variable pool-utilization-max-threshold {
+                value 85;
+                description "address pool utilization maximum threshold value";
+                type int;
+            }
+            variable pool-utilization-min-threshold {
+                value 10;
+                description "address pool utilization minimum threshold value";
+                type int;
+            }
+        }
+        rule linked-address-pool {
+            synopsis "linked address pool utilization analyzer";
+            description "Monitors linked address pool usage percentage and notifies anomalies";
+            rule-frequency 90s;
+            function mean-pool-utilization {
+                path mean-pool-utilization.py;
+                method mean_pool_utilization;
+                argument list_pool_vector {
+                    mandatory;
+                }
+            }
+            field linked-pool-head {
+                constant {
+                    value "{{filter-linked-pool-head}}";
+                }
+                type string;
+                description "linked-pool-head name field";
+            }
+            field mean-pool-utilization {
+                formula {
+                    user-defined-function {
+                        function-name mean-pool-utilization;
+                        argument list_pool_vector "@list-pool-utilization";
+                    }
+                }
+                type integer;
+                description "average utilizaiton of linked address pool";
+            }
+            field mean-pool-utilization-ml {
+                formula {
+                    dynamic-threshold {
+                        algorithm 3sigma;
+                        learning-period 1d;
+                        pattern-periodicity 1h;
+                        field-name "$mean-pool-utilization";
+                    }
+                }
+                type integer;
+                description "Value calculated based on 3sigma algorithm";
+            }
+            field pool-maximum-utilization {
+                constant {
+                    value "{{pool-max-utilization}}";
+                }
+                description "linked address pool utilization maximum threshold";
+            }
+            field pool-minimum-util {
+                constant {
+                    value "{{pool-min-utilization}}";
+                }
+                description "linked address pool utilization minimum threshold";
+            }
+            trigger mean-pool-utilization {
+                synopsis "linked address pool utilization kpi";
+                description "Sets health based on linked address pool utilization";
+                frequency 120s;
+                term is-mean-abnormal {
+                    when {
+                        greater-than "$mean-pool-utilization" "$pool-maximum-utilization";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Linked pool average utitilization($mean-pool-utilization) is abnormal.";
+                        }
+                    }
+                }
+                term mean-abnormal-ls {
+                    when {
+                        less-than "$mean-pool-utilization" "$pool-minimum-util";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Linked pool average utitilization($mean-pool-utilization) is abnormal.";
+                        }
+                    }
+                }
+                term is-mean-abnormal-ml {
+                    when {
+                        equal-to "$mean-pool-utilization-ml" 1 {
+                            time-range 5m;
+                        }
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "Linked pool average utitilization($mean-pool-utilization) is abnormal  based on ML algorithm";
+                        }
+                    }
+                }
+                term default-term {
+                    then {
+                        status {
+                            color green;
+                            message "Linked pool average utitilization($mean-pool-utilization) is normal";
+                        }
+                    }
+                }
+            }
+            variable filter-linked-pool-head {
+                value .*;
+                description "address pool header name";
+                type string;
+            }
+            variable pool-max-utilization {
+                value 85;
+                description "linked address pool average utilization maximum threshold";
+                type int;
+            }
+            variable pool-min-utilization {
+                value 10;
+                description "linked address pool average utilization minimum threshold";
+                type int;
+            }
+            vector list-pool-name {
+                path "/topic[topic-name=service.subscribers]/rule[rule-name=address-pool-utilization]/field[linked-pool-head='{{filter-linked-pool-head}}']/pool-name";
+                time-range 90s;
+            }
+            vector list-pool-utilization {
+                path "/topic[topic-name=service.subscribers]/rule[rule-name=address-pool-utilization]/field[linked-pool-head='{{filter-linked-pool-head}}']/address-usage-percent";
+                time-range 90s;
+            }
+        }
+    }
+}

--- a/juniper_official/Subscriber-Service/address-pool-utilization.rule
+++ b/juniper_official/Subscriber-Service/address-pool-utilization.rule
@@ -2,7 +2,7 @@ iceberg {
     topic service.subscribers {
         description "Rules related to subscribers address pool utilization";
         synopsis "BNG subscribers address pool monitoring rules";
-        rule address-pool-utilization {
+        rule chk-addr-pool-util {
             keys [ lsri-name pool-name ];
             synopsis "single pool utilization";
             description "single pool utilization, also collects info on linked pools";
@@ -280,11 +280,11 @@ iceberg {
                 type int;
             }
             vector list-pool-name {
-                path "/topic[topic-name=service.subscribers]/rule[rule-name=address-pool-utilization]/field[linked-pool-head='{{filter-linked-pool-head}}']/pool-name";
+                path "/topic[topic-name=service.subscribers]/rule[rule-name=chk-addr-pool-util]/field[linked-pool-head='{{filter-linked-pool-head}}']/pool-name";
                 time-range 90s;
             }
             vector list-pool-utilization {
-                path "/topic[topic-name=service.subscribers]/rule[rule-name=address-pool-utilization]/field[linked-pool-head='{{filter-linked-pool-head}}']/address-usage-percent";
+                path "/topic[topic-name=service.subscribers]/rule[rule-name=chk-addr-pool-util]/field[linked-pool-head='{{filter-linked-pool-head}}']/address-usage-percent";
                 time-range 90s;
             }
         }

--- a/juniper_official/Subscriber-Service/address-pool-utilization.rule
+++ b/juniper_official/Subscriber-Service/address-pool-utilization.rule
@@ -220,7 +220,7 @@ iceberg {
                 synopsis "linked address pool utilization kpi";
                 description "Sets health based on linked address pool utilization";
                 frequency 120s;
-                term is-mean-abnormal {
+                term is-mean-abnormal-gr {
                     when {
                         greater-than "$mean-pool-utilization" "$pool-maximum-utilization";
                     }
@@ -231,7 +231,7 @@ iceberg {
                         }
                     }
                 }
-                term mean-abnormal-ls {
+                term is-mean-abnormal-lt {
                     when {
                         less-than "$mean-pool-utilization" "$pool-minimum-util";
                     }

--- a/juniper_official/Subscriber-Service/mean-pool-utilization.py
+++ b/juniper_official/Subscriber-Service/mean-pool-utilization.py
@@ -1,0 +1,9 @@
+from __future__ import division
+'''
+This function returns used% out of total available
+'''
+def mean_pool_utilization(list_pool_vector, **kwargs):
+    utilization = 0
+    if len(list_pool_vector) > 0:
+         utilization = sum(list_pool_vector)/len(list_pool_vector)
+    return utilization

--- a/juniper_official/Subscriber-Service/monitor-subscriber-count.rule
+++ b/juniper_official/Subscriber-Service/monitor-subscriber-count.rule
@@ -1,0 +1,109 @@
+iceberg {
+    topic service.subscribers {
+        description "Rules related to subscribers count of a JUNOS Broadband Network Gateway (BNG)";
+        synopsis "BNG subscribers count monitoring rules";
+        rule monitor-subscriber-count {
+            synopsis "subscribers count statistics analyzer";
+            description "This rule collects total subscribers and notifies in case of anomalies";
+            sensor total-subscribers {
+                synopsis "subscriber-management open-config sensor definition";
+                description "subscriber-management open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /junos/system/subscriber-management/infra/resource-monitor/chassis;
+                    frequency 60s;
+                }
+            }
+            field subscriber-count-maximum {
+                constant {
+                    value "{{subscriber-count-max}}";
+                }
+                type integer;
+                description "maximum total subscribers count";
+            }
+            field subscriber-count-minimum {
+                constant {
+                    value "{{subscriber-count-min}}";
+                }
+                type integer;
+                description "minimum total subscribers count";
+            }
+            field total-subscriber-count {
+                sensor total-subscribers {
+                    path /junos/system/subscriber-management/infra/resource-monitor/chassis/current-subscriber-count;
+                }
+                type integer;
+                description "Number of subscribers in chassis";
+            }
+            field total-subscribers-pred {
+                formula {
+                    dynamic-threshold {
+                        algorithm k-means;
+                        learning-period 1d;
+                        pattern-periodicity 1h;
+                        field-name "$total-subscriber-count";
+                    }
+                }
+                type integer;
+                description "Dynamic subscribers count threshold";
+            }
+            trigger total-subscribers-count {
+                synopsis "subscribers count threshold";
+                description "Sets health based on subscribers count";
+                frequency 90s;
+                term subscriber-abnormal-gr {
+                    when {
+                        greater-than "$total-subscriber-count" "$subscriber-count-maximum";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Total subscriber count is abnormal. Current total subscriber count is : $total-subscriber-count";
+                        }
+                    }
+                }
+                term subscriber-abnormal-ls {
+                    when {
+                        less-than "$total-subscriber-count" "$subscriber-count-minimum";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Total subscriber count is abnormal. Current total subscriber count is : $total-subscriber-count";
+                        }
+                    }
+                }
+                term subscriber-abnormal-ml {
+                    when {
+                        equal-to "$total-subscribers-pred" 1 {
+                            time-range 5m;
+                        }
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "Total subscriber count is abnormal according to ML algorithm. Current total subscriber count is : $total-subscriber-count";
+                        }
+                    }
+                }
+                term default-term {
+                    then {
+                        status {
+                            color green;
+                            message "Total subscriber count is normal. Current total subscriber count is : $total-subscriber-count";
+                        }
+                    }
+                }
+            }
+            variable subscriber-count-max {
+                value 60000;
+                description "maximum total subscribers count";
+                type int;
+            }
+            variable subscriber-count-min {
+                value 10000;
+                description "Minimum total subscribers count count";
+                type int;
+            }
+        }
+    }
+}

--- a/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
+++ b/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
@@ -41,7 +41,7 @@ iceberg {
                 type integer;
                 description "Number of generic-error-sent";
             }
-            field malformed-packets-rec {
+            field malformed-pkts-rx {
                 sensor pppoe-error-statistics {
                     path /junos/system/subscriber-management/client-protocols/pppoe/statistics/malformed-packets-received;
                 }
@@ -177,13 +177,13 @@ iceberg {
                     }
                 }
             }
-            trigger malformed-packets-rec {
-                synopsis "PPPoE malformed-packets-rec kpi";
-                description "Sets health based on the change in malformed-packets-rec count";
+            trigger malformed-packets-rx {
+                synopsis "PPPoE malformed-packets-recived kpi";
+                description "Sets health based on the change in malformed-packets-recived count";
                 frequency 90s;
                 term is-error-increasing {
                     when {
-                        increasing-at-least-by-value "$malformed-packets-rec" {
+                        increasing-at-least-by-value "$malformed-pkts-rx" {
                             value 10;
                             time-range 3m;
                         }
@@ -191,7 +191,7 @@ iceberg {
                     then {
                         status {
                             color red;
-                            message "PPPoE error statistics malformed-packets-recived is increasing. Current value : $malformed-packets-rec";
+                            message "PPPoE error statistics malformed-packets-recived is increasing. Current value : $malformed-pkts-rx";
                         }
                     }
                 }

--- a/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
+++ b/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
@@ -1,0 +1,255 @@
+iceberg {
+    topic service.protocols {
+        description "Rules related to PPPoE statistics monitoring of a JUNOS Broadband Network Gateway (BNG)";
+        synopsis "BNG PPPoE error statistics monitoring rules";
+        rule pppoe-error-statistics {
+            synopsis "Monitors PPPoE error statistics";
+            description "Collects the PPPoE error periodically and notifies in case of anomalies";
+            sensor pppoe-error-statistics {
+                synopsis "subscriber-management open-config sensor definition";
+                description "subscriber-management open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /junos/system/subscriber-management/client-protocols/pppoe/statistics;
+                    frequency 60s;
+                }
+            }
+            field ac-error-received {
+                sensor pppoe-error-statistics {
+                    path /junos/system/subscriber-management/client-protocols/pppoe/statistics/ac-error-received;
+                }
+                type integer;
+                description "Number of ac-error-received";
+            }
+            field ac-error-sent {
+                sensor pppoe-error-statistics {
+                    path /junos/system/subscriber-management/client-protocols/pppoe/statistics/ac-error-sent;
+                }
+                type integer;
+                description "Number of ac-error-sent";
+            }
+            field generic-error-received {
+                sensor pppoe-error-statistics {
+                    path /junos/system/subscriber-management/client-protocols/pppoe/statistics/generic-error-received;
+                }
+                type integer;
+                description "Number of generic-error-received";
+            }
+            field generic-error-sent {
+                sensor pppoe-error-statistics {
+                    path /junos/system/subscriber-management/client-protocols/pppoe/statistics/generic-error-sent;
+                }
+                type integer;
+                description "Number of generic-error-sent";
+            }
+            field malformed-packets-rec {
+                sensor pppoe-error-statistics {
+                    path /junos/system/subscriber-management/client-protocols/pppoe/statistics/malformed-packets-received;
+                }
+                type integer;
+                description "Number of malformed-packets-rec";
+            }
+            field service-error-received {
+                sensor pppoe-error-statistics {
+                    path /junos/system/subscriber-management/client-protocols/pppoe/statistics/service-error-received;
+                }
+                type integer;
+                description service-error-received;
+            }
+            field service-error-sent {
+                sensor pppoe-error-statistics {
+                    path /junos/system/subscriber-management/client-protocols/pppoe/statistics/service-error-sent;
+                }
+                type integer;
+                description "Number of service-error-sent";
+            }
+            field unknown-packets-received {
+                sensor pppoe-error-statistics {
+                    path /junos/system/subscriber-management/client-protocols/pppoe/statistics/unknown-packets-received;
+                }
+                type integer;
+                description "Number of unknown-packets-received";
+            }
+            trigger ac-error-received {
+                synopsis "PPPoE ac-error-received kpi";
+                description "Sets health based on the change in ac-error-received count";
+                frequency 90s;
+                term is-error-increasing {
+                    when {
+                        increasing-at-least-by-value "$ac-error-received" {
+                            value 10;
+                            time-range 3m;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "PPPoE error statistics ac-error-received is increasing. Current value : $ac-error-received";
+                        }
+                    }
+                }
+                term default-term {
+                    then {
+                        status {
+                            color green;
+                            message "PPPoE error statistics ac-error-received is not increasing. Current value : $ac-error-received";
+                        }
+                    }
+                }
+            }
+            trigger ac-error-sent {
+                synopsis "PPPoE ae-error-sent kpi";
+                description "Sets health based on the change in ae-error-sent count";
+                frequency 90s;
+                term is-error-increasing {
+                    when {
+                        increasing-at-least-by-value "$ac-error-sent" {
+                            value 10;
+                            time-range 3m;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "PPPoE error statistics ac-error-sent is increasing. Current value : $ac-error-sent";
+                        }
+                    }
+                }
+                term default-term {
+                    then {
+                        status {
+                            color green;
+                            message "PPPoE error statistics ac-error-sent is not increasing. Current value : $ac-error-sent";
+                        }
+                    }
+                }
+            }
+            trigger generic-error-received {
+                synopsis "PPPoE generic-error-received kpi";
+                description "Sets health based on the change in generic-error-received count";
+                frequency 90s;
+                term is-error-increasing {
+                    when {
+                        increasing-at-least-by-value "$generic-error-received" {
+                            value 10;
+                            time-range 3m;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "PPPoE error statistics generic-error-received is increasing. Current value : $generic-error-received";
+                        }
+                    }
+                }
+                term default-term {
+                    then {
+                        status {
+                            color green;
+                            message "PPPoE error statistics generic-error-received is not increasing. Current value : $generic-error-received";
+                        }
+                    }
+                }
+            }
+            trigger generic-error-sent {
+                synopsis "PPPoE generic-error-sent kpi";
+                description "Sets health based on the change in generic-error-sent count";
+                frequency 90s;
+                term is-error-increasing {
+                    when {
+                        increasing-at-least-by-value "$generic-error-sent" {
+                            value 10;
+                            time-range 3m;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "PPPoE error statistics generic-error-sent is increasing. Current value : $generic-error-sent";
+                        }
+                    }
+                }
+                term default-term {
+                    then {
+                        status {
+                            color green;
+                            message "PPPoE error statistics generic-error-sent is not increasing. Current value : $generic-error-sent";
+                        }
+                    }
+                }
+            }
+            trigger malformed-packets-rec {
+                synopsis "PPPoE malformed-packets-rec kpi";
+                description "Sets health based on the change in malformed-packets-rec count";
+                frequency 90s;
+                term is-error-increasing {
+                    when {
+                        increasing-at-least-by-value "$malformed-packets-rec" {
+                            value 10;
+                            time-range 3m;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "PPPoE error statistics malformed-packets-recived is increasing. Current value : $malformed-packets-rec";
+                        }
+                    }
+                }
+            }
+            trigger service-error-received {
+                synopsis "PPPoE service-error-received kpi";
+                description "Sets health based on the change in service-error-received count";
+                frequency 90s;
+                term is-error-increasing {
+                    when {
+                        increasing-at-least-by-value "$service-error-received" {
+                            value 10;
+                            time-range 3m;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "PPPoE error statistics service-error-received is increasing. Current value : $service-error-received";
+                        }
+                    }
+                }
+                term default-term {
+                    then {
+                        status {
+                            color green;
+                            message "PPPoE error statistics service-error-received is not increasing. Current value : $service-error-received";
+                        }
+                    }
+                }
+            }
+            trigger service-error-sent {
+                synopsis "PPPoE service-error-sent kpi";
+                description "Sets health based on the change in service-error-sent count";
+                frequency 90s;
+                term is-error-increasing {
+                    when {
+                        increasing-at-least-by-value "$service-error-sent" {
+                            value 10;
+                            time-range 3m;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "PPPoE error statistics service-error-sent is increasing. Current value : $service-error-sent";
+                        }
+                    }
+                }
+                term default-term {
+                    then {
+                        status {
+                            color green;
+                            message "PPPoE error statistics service-error-sent is not increasing. Current value : $service-error-sent";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
+++ b/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
@@ -48,6 +48,13 @@ iceberg {
                 type integer;
                 description "Number of malformed-packets-rec";
             }
+            field min-rate-of-increase {
+                constant {
+                    value "{{min-value-of-increase}}";
+                }
+                type integer;
+                description "Minimum value of increase in 3 minutes";
+            }
             field service-error-received {
                 sensor pppoe-error-statistics {
                     path /junos/system/subscriber-management/client-protocols/pppoe/statistics/service-error-received;
@@ -76,7 +83,7 @@ iceberg {
                 term is-error-increasing {
                     when {
                         increasing-at-least-by-value "$ac-error-received" {
-                            value 10;
+                            value "$min-rate-of-increase";
                             time-range 3m;
                         }
                     }
@@ -103,7 +110,7 @@ iceberg {
                 term is-error-increasing {
                     when {
                         increasing-at-least-by-value "$ac-error-sent" {
-                            value 10;
+                            value "$min-rate-of-increase";
                             time-range 3m;
                         }
                     }
@@ -130,7 +137,7 @@ iceberg {
                 term is-error-increasing {
                     when {
                         increasing-at-least-by-value "$generic-error-received" {
-                            value 10;
+                            value "$min-rate-of-increase";
                             time-range 3m;
                         }
                     }
@@ -157,7 +164,7 @@ iceberg {
                 term is-error-increasing {
                     when {
                         increasing-at-least-by-value "$generic-error-sent" {
-                            value 10;
+                            value "$min-rate-of-increase";
                             time-range 3m;
                         }
                     }
@@ -184,7 +191,7 @@ iceberg {
                 term is-error-increasing {
                     when {
                         increasing-at-least-by-value "$malformed-pkts-rx" {
-                            value 10;
+                            value "$min-rate-of-increase";
                             time-range 3m;
                         }
                     }
@@ -203,7 +210,7 @@ iceberg {
                 term is-error-increasing {
                     when {
                         increasing-at-least-by-value "$service-error-received" {
-                            value 10;
+                            value "$min-rate-of-increase";
                             time-range 3m;
                         }
                     }
@@ -230,7 +237,7 @@ iceberg {
                 term is-error-increasing {
                     when {
                         increasing-at-least-by-value "$service-error-sent" {
-                            value 10;
+                            value "$min-rate-of-increase";
                             time-range 3m;
                         }
                     }
@@ -249,6 +256,11 @@ iceberg {
                         }
                     }
                 }
+            }
+            variable min-value-of-increase {
+                value 10;
+                description "Minimum value of increase in 3 minutes";
+                type int;
             }
         }
     }

--- a/juniper_official/Subscriber-Service/subscriber-service.playbook
+++ b/juniper_official/Subscriber-Service/subscriber-service.playbook
@@ -1,0 +1,21 @@
+/*
+ * Playbook contains multiple rules which checks the health of BRAS system
+ * and notifies when anomalies are found.
+ * 
+ * 1) Rule pppoe-error-statistics, detects the PPPoE error statistics
+ *    and notifies anomalies.
+ * 2) Rule address-pool-utilization, detects the system pool utilization
+ *    and notifies anomalies.
+ * 3) Rule linked-address-pool, detects the system linked pool utilization 
+ *    and notifies anomalies.
+ * 4) Rule monitor-subscriber-count, detects the system total subscribers
+ *    count and notifies anomalies.
+ */
+iceberg {
+    playbook subscriber-services {
+        rules [ service.protocols/pppoe-error-statistics service.subscribers/address-pool-utilization service.subscribers/linked-address-pool service.subscribers/monitor-subscriber-count ];
+        description "The subscriber-services playbook contains rules for monitoring the health subscriber services KPI";
+        synopsis "Subscriber services KPI";
+    }
+}
+

--- a/juniper_official/Subscriber-Service/subscriber-service.playbook
+++ b/juniper_official/Subscriber-Service/subscriber-service.playbook
@@ -9,7 +9,7 @@
  * 3) Rule linked-address-pool, detects the system linked pool utilization 
  *    and notifies anomalies.
  * 4) Rule monitor-subscriber-count, detects the system total subscribers
- *    count and notifies anomalies.
+ *    count and notifies anomalies .
  */
 iceberg {
     playbook subscriber-services {

--- a/juniper_official/Subscriber-Service/subscriber-service.playbook
+++ b/juniper_official/Subscriber-Service/subscriber-service.playbook
@@ -4,7 +4,7 @@
  * 
  * 1) Rule pppoe-error-statistics, detects the PPPoE error statistics
  *    and notifies anomalies.
- * 2) Rule address-pool-utilization, detects the system pool utilization
+ * 2) Rule chk-addr-pool-util, detects the system pool utilization
  *    and notifies anomalies.
  * 3) Rule linked-address-pool, detects the system linked pool utilization 
  *    and notifies anomalies.
@@ -13,7 +13,7 @@
  */
 iceberg {
     playbook subscriber-services {
-        rules [ service.protocols/pppoe-error-statistics service.subscribers/address-pool-utilization service.subscribers/linked-address-pool service.subscribers/monitor-subscriber-count ];
+        rules [ service.protocols/pppoe-error-statistics service.subscribers/chk-addr-pool-util service.subscribers/linked-address-pool service.subscribers/monitor-subscriber-count ];
         description "The subscriber-services playbook contains rules for monitoring the health subscriber services KPI";
         synopsis "Subscriber services KPI";
     }


### PR DESCRIPTION
Following 3 rules, one playbook related these rules and one helper file are added for default playbook:- 
 1) Rule pppoe-error-statistics, detects the PPPoE error statistics
     and notifies anomalies.
  2) Rule address-pool-utilization and  linked-address-pool detects the 
    system pool utilization and notifies anomalies.
  3) Rule monitor-subscriber-count, detects the system total subscribers
     count and notifies anomalies.

It's tested and working fine one HealthBot 1.0.1-38-gde4898a.