### PR TITLE
Fix few visualizations, cli duration calculation in LFA rule

### DIFF
--- a/juniper_official/LFA/Core.json
+++ b/juniper_official/LFA/Core.json
@@ -446,7 +446,7 @@
                   {
                      "type" : "integer",
                      "name" : "duration",
-                     "insert" : "1",
+                     "insert" : "&if(%HostUserLogin(\\1,\\2), 1, 0)",
                      "value" : "&elapsed(%HostUserLogin(\\1,\\2))"
                   }
                ]
@@ -877,14 +877,15 @@
          "visState" : "{\"title\":\"FPC Offline with reason\",\"type\":\"pie\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"host\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"reason\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
          "title" : "FPC Offline with reason"
       },
-      "d00e3280-bdae-11e7-ad82-7131f0cb1410" : {
-         "kibanaSavedObjectMeta" : {
-            "searchSourceJSON" : "{\"index\":\"lfa\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+      "21c3de20-4c2b-11e9-8f23-bf70eceaf08e": {
+         "description": "",
+         "kibanaSavedObjectMeta": {
+               "searchSourceJSON": "{\"index\":\"lfa\",\"query\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true,\"default_field\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
          },
-         "description" : "",
-         "title" : "Host by type",
-         "uiStateJSON" : "{}",
-         "visState" : "{\"title\":\"Host by type\",\"type\":\"pie\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"host\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"_type\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
+         "title": "Host by event type",
+         "uiStateJSON": "{}",
+         "version": 1,
+         "visState": "{\"title\":\"Host by event type\",\"type\":\"pie\",\"params\":{\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false,\"type\":\"pie\",\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"host\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"event\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}]}"
       },
       "e4925050-bdaf-11e7-ad82-7131f0cb1410" : {
          "visState" : "{\"title\":\"Host by event count\",\"type\":\"histogram\",\"params\":{\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"host: Descending\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"host\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"event\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
@@ -904,14 +905,15 @@
          "title" : "CLI Activity",
          "uiStateJSON" : "{}"
       },
-      "77562db0-1663-11e8-adec-45ccc8248448" : {
-         "visState" : "{\"title\":\"CLI Concurrent Users\",\"type\":\"metric\",\"params\":{\"addLegend\":false,\"addTooltip\":true,\"gauge\":{\"autoExtend\":false,\"backStyle\":\"Full\",\"colorSchema\":\"Green to Red\",\"colorsRange\":[{\"from\":0,\"to\":100}],\"gaugeColorMode\":\"None\",\"gaugeStyle\":\"Full\",\"gaugeType\":\"Metric\",\"invertColors\":false,\"labels\":{\"color\":\"black\",\"show\":false},\"orientation\":\"vertical\",\"percentageMode\":false,\"scale\":{\"color\":\"#333\",\"labels\":false,\"show\":false,\"width\":2},\"style\":{\"bgColor\":false,\"bgFill\":\"#000\",\"fontSize\":\"72\",\"labelColor\":false,\"subText\":\"\"},\"type\":\"simple\",\"useRange\":false,\"verticalSplit\":false},\"type\":\"gauge\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"concurrentUsers\",\"customLabel\":\"Concurrent Users\"}}],\"listeners\":{}}",
-         "uiStateJSON" : "{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}",
-         "title" : "CLI Concurrent Users",
-         "description" : "",
+      "57acbcb0-4c25-11e9-8f23-bf70eceaf08e" : {
          "kibanaSavedObjectMeta" : {
-            "searchSourceJSON" : "{\"index\":\"lfa\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
-         }
+            "searchSourceJSON" : "{\"index\":\"lfa\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+         },
+         "version" : 1,
+         "title" : "Concurrent users",
+         "description" : "",
+         "visState" : "{\"title\":\"Concurrent users\",\"type\":\"metric\",\"params\":{\"addLegend\":false,\"addTooltip\":true,\"metric\":{\"colorSchema\":\"Green to Red\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"invertColors\":false,\"labels\":{\"show\":true},\"metricColorMode\":\"None\",\"percentageMode\":false,\"style\":{\"bgColor\":false,\"bgFill\":\"#000\",\"fontSize\":60,\"labelColor\":false,\"subText\":\"\"},\"useRanges\":false},\"type\":\"metric\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max_bucket\",\"schema\":\"metric\",\"params\":{\"customBucket\":{\"id\":\"1-bucket\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"bucketAgg\",\"params\":{\"field\":\"timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},\"customMetric\":{\"id\":\"1-metric\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metricAgg\",\"params\":{\"field\":\"concurrentUsers\"}},\"customLabel\":\"Maximum concurrent users\"}}]}",
+         "uiStateJSON" : "{}"
       },
       "7fe007b0-bf8a-11e7-8ff7-efb5d88c748e" : {
          "title" : "Target events by severity",
@@ -963,7 +965,7 @@
             "searchSourceJSON" : "{\"filter\":[{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}],\"highlightAll\":true,\"version\":true}"
          },
          "optionsJSON" : "{\"darkTheme\":false}",
-         "panelsJSON" : "[{\"size_x\":3,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"c52352c0-1663-11e8-adec-45ccc8248448\",\"col\":1,\"row\":1},{\"size_x\":3,\"size_y\":3,\"panelIndex\":2,\"type\":\"visualization\",\"id\":\"d55f3500-1663-11e8-adec-45ccc8248448\",\"col\":7,\"row\":1},{\"size_x\":3,\"size_y\":3,\"panelIndex\":3,\"type\":\"visualization\",\"id\":\"77562db0-1663-11e8-adec-45ccc8248448\",\"col\":4,\"row\":1},{\"size_x\":3,\"size_y\":3,\"panelIndex\":4,\"type\":\"visualization\",\"id\":\"2afe2700-1664-11e8-adec-45ccc8248448\",\"col\":10,\"row\":1},{\"size_x\":12,\"size_y\":4,\"panelIndex\":5,\"type\":\"visualization\",\"id\":\"431fa4f0-1667-11e8-81e4-b92c23d194c9\",\"col\":1,\"row\":4}]",
+         "panelsJSON" : "[{\"size_x\":3,\"size_y\":3,\"panelIndex\":1,\"type\":\"visualization\",\"id\":\"c52352c0-1663-11e8-adec-45ccc8248448\",\"col\":1,\"row\":1},{\"size_x\":3,\"size_y\":3,\"panelIndex\":2,\"type\":\"visualization\",\"id\":\"d55f3500-1663-11e8-adec-45ccc8248448\",\"col\":7,\"row\":1},{\"size_x\":3,\"size_y\":3,\"panelIndex\":3,\"type\":\"visualization\",\"id\":\"57acbcb0-4c25-11e9-8f23-bf70eceaf08e\",\"col\":4,\"row\":1},{\"size_x\":3,\"size_y\":3,\"panelIndex\":4,\"type\":\"visualization\",\"id\":\"2afe2700-1664-11e8-adec-45ccc8248448\",\"col\":10,\"row\":1},{\"size_x\":12,\"size_y\":4,\"panelIndex\":5,\"type\":\"visualization\",\"id\":\"431fa4f0-1667-11e8-81e4-b92c23d194c9\",\"col\":1,\"row\":4}]",
          "description" : "",
          "title" : "CLI Dashboard",
          "uiStateJSON" : "{\"P-1\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-2\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-3\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-4\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}}"
@@ -992,7 +994,7 @@
       "614f2e80-1664-11e8-adec-45ccc8248448" : {
          "description" : "",
          "kibanaSavedObjectMeta" : {
-            "searchSourceJSON" : "{\"index\":\"lfa\",\"highlightAll\":true,\"version\":true,\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
+            "searchSourceJSON" : "{\"index\":\"lfa\",\"highlightAll\":true,\"version\":true,\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"command:*\"}},\"filter\":[]}"
          },
          "title" : "CLI Commands",
          "sort" : [
@@ -1009,7 +1011,7 @@
          "title" : "LFA Insert Details",
          "hits" : 0,
          "kibanaSavedObjectMeta" : {
-            "searchSourceJSON" : "{\"index\":\"lfa_admin\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":{\"query_string\":{\"query\":\"action:ingest AND uuid:*\",\"analyze_wildcard\":true,\"default_field\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
+            "searchSourceJSON" : "{\"index\":\"lfa_admin\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":{\"query_string\":{\"query\":\"action:ingest\",\"analyze_wildcard\":true,\"default_field\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
          },
          "description" : "",
          "columns" : [


### PR DESCRIPTION
Has fix for the following problems:
- In the LFA logfiles when the user logout event is present without a login event, then the CLI duration was incorrectly getting calculated by the rule.
- The pie chart for `Host by event type` had `_type` as the field type for the secondary bucket split. Corrected this to `event`. Also changed the name of this visualization from `Host by type` to `Host by event type`
- The `CLI concurrent users` visualization was having `max` as the aggregator. Corrected this to `Max  Bucket` and used `Date Histogram` for the data aggregation.
- The query for the `CLI Commands` search was not having any filters. Added `command: *` to fetch only the records that has a command in it.
- The query for the `LFA Inserts` was showing only the records corresponding to the files uploaded via. web. Corrected this to show all the file inserts.