### PR TITLE
Changed the tier of needed rules and changed the top-level from iceberg to healthbot 

### DIFF
--- a/juniper_official/Chassis/chassis-fan-health.rule
+++ b/juniper_official/Chassis/chassis-fan-health.rule
@@ -1,7 +1,7 @@
 /*
  * Monitors chassis fan health status and notifies when anomalies are found.
  */
-iceberg {
+healthbot {
     topic chassis.fan {
         description "Monitors the chassis fan status and notifies anomalies";
         synopsis "Chassis environment analyzer";

--- a/juniper_official/Chassis/chassis-kpis.playbook
+++ b/juniper_official/Chassis/chassis-kpis.playbook
@@ -19,7 +19,7 @@
  * 8) Rule "check-fan-health" Monitors the fan state changes and notifies
  *    anomalies.
  */
-iceberg {
+healthbot {
     playbook chassis-kpis-playbook {
         rules [ chassis.fan/check-fan-health chassis.temperatures/check-fpc-temperature chassis.power/check-pem-power-usage chassis.power/check-system-power-usage chassis.power/check-zone-power-usage chassis.temperatures/check-chassis-temperature chassis.temperatures/check-re-cpu-temperature chassis.temperatures/check-re-temperature ];
         description "Playbook monitor the chassis health i.e. chassis, RE, RE CPU and linecards temperatures, power and fan health";

--- a/juniper_official/Chassis/chassis-temperature.rule
+++ b/juniper_official/Chassis/chassis-temperature.rule
@@ -14,7 +14,7 @@
  *      when temperature is below high threshold. Otherwise color is set to
  *      red and notify anomaly.
  */
-iceberg {
+healthbot {
     topic chassis.temperatures {
         description "Monitors the chassis temperatures of whole chassis, REs', FPCs' & RE CPUs and notifies anomalies";
         synopsis "Chassis environment analyzer";

--- a/juniper_official/Chassis/fpc-temperature.rule
+++ b/juniper_official/Chassis/fpc-temperature.rule
@@ -18,7 +18,7 @@
  *      temperature is below high threshold. Otherwise color is set to
  *      red and notify anomaly.
  */
-iceberg {
+healthbot {
     topic chassis.temperatures {
         description "Monitors the chassis temperatures of whole chassis, REs', FPCs' & RE CPUs and notifies anomalies";
         synopsis "Chassis environment analyzer";

--- a/juniper_official/Chassis/netsvc.playbook
+++ b/juniper_official/Chassis/netsvc.playbook
@@ -4,7 +4,7 @@
  * Rule netsvc-rule, calls netsvc.py to determine the state and advise action if required
  *
  */
-iceberg {
+healthbot {
     playbook netsvc-playbook {
         rules chassis.networkservices/netsvc-rule;
     }

--- a/juniper_official/Chassis/netsvc.rule
+++ b/juniper_official/Chassis/netsvc.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic chassis.networkservices {
         rule netsvc-rule {
             sensor netsvc-sensor {
@@ -35,6 +35,59 @@ iceberg {
                             message "$proposed_action";
                         }
                     }
+                }
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products PTX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products QFX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products EX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products ACX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products SRX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                        }
+                    }
+                }
+               helper-files other {
+                    list-of-files netsvc.yml;
                 }
             }
         }

--- a/juniper_official/Chassis/pem-power-usage.rule
+++ b/juniper_official/Chassis/pem-power-usage.rule
@@ -15,7 +15,7 @@
  *      will set a dashboard color to red when PEM power usage exceed 
  *      threshold 'pem-power-usage-threshold'. Otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic chassis.power {
         description "Monitors the chassis power usage of whole system, zone & PEMs and notifies anomalies";
         synopsis "Chassis power manager";

--- a/juniper_official/Chassis/re-cpu-temperature.rule
+++ b/juniper_official/Chassis/re-cpu-temperature.rule
@@ -19,7 +19,7 @@
  *      temperature is below high threshold. Otherwise color is set to
  *      red and notify anomaly.
  */
-iceberg {
+healthbot {
     topic chassis.temperatures {
         description "Monitors the chassis temperatures of whole chassis, REs', FPCs' & RE CPUs and notifies anomalies";
         synopsis "Chassis environment analyzer";

--- a/juniper_official/Chassis/re-temperature.rule
+++ b/juniper_official/Chassis/re-temperature.rule
@@ -19,7 +19,7 @@
  *      temperature is below high threshold. Otherwise color is set to
  *      red and notify anomaly.
  */
-iceberg {
+healthbot {
     topic chassis.temperatures {
         description "Monitors the chassis temperatures of whole chassis, REs', FPCs' & RE CPUs and notifies anomalies";
         synopsis "Chassis environment analyzer";

--- a/juniper_official/Chassis/system-power-usage.rule
+++ b/juniper_official/Chassis/system-power-usage.rule
@@ -10,7 +10,7 @@
  *      remaining power is below threshold 'system-power-remaining-threshold'.
  *      Otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic chassis.power {
         description "Monitors the chassis power usage of whole system, zone & PMs and notifies anomalies";
         synopsis "Chassis power manager";

--- a/juniper_official/Chassis/system-virtual-memory.rule
+++ b/juniper_official/Chassis/system-virtual-memory.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic system.statistics {
         description "Rules relevant to metrics and KPI of the system";
         synopsis "Virtual memory information analyzer";
@@ -88,7 +88,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Chassis/zone-power-usage.rule
+++ b/juniper_official/Chassis/zone-power-usage.rule
@@ -8,7 +8,7 @@
  *      will set a dashboard color to red when power usage exceed threshold
  *      'zone-power-usage-threshold'. Otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic chassis.power {
         description "Monitors the chassis power usage of whole system, zone & PEMs and notifies anomalies";
         synopsis "Chassis power manager";

--- a/juniper_official/Interfaces/health-monitor-based-on-interface-description.rule
+++ b/juniper_official/Interfaces/health-monitor-based-on-interface-description.rule
@@ -33,7 +33,7 @@
  *      is above threshold for 60s, otherwise color is set to green. Use
  *      5000000000 octets for 10G & 50000000000 for 100G interface.
  */
-iceberg {
+healthbot {
     topic interface.monitor {
         description "Monitors only filtered interfaces based on keyword in description";
         synopsis "Selective interface KPIs monitoring";
@@ -209,6 +209,68 @@ iceberg {
                 value in-octets;
                 description "Interface statistics counter name(in-octets, out-octets, in-pkts, out-pkts, in-unicast-pkts, out-unicast-pkts, in-errors, out-errors, carrier-transitions) to monitor. Create separate instance for each kpi";
                 type string;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 16.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform MX150;
+                                }
+                            }
+                            products PTX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ PTX5000 PTX1000 PTX10000 ];
+                                }
+                            }
+                            products QFX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ QFX10000 QFX5200 ];
+                                }
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5100;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5120-48Y;
+                                }
+                            }
+                            products EX {
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX9200;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX4650;
+                                }
+                                releases 18.4R1 {
+                                    release-support min-supported-release;
+                                    platform EX4600;
+                                }
+                            }
+                        }
+                    }
+                    other-vendor cisco-IOS-XR {
+                        vendor-name cisco;
+                        operating-system IOS-XR;
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Interfaces/interface-flaps.rule
+++ b/juniper_official/Interfaces/interface-flaps.rule
@@ -14,7 +14,7 @@
  *      period of less than 180s, it'll turn the color to yellow,
  *      otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Monitors interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors and notify anomalies";
         synopsis "Interface statistics analyzer";

--- a/juniper_official/Interfaces/interface-in-errors.rule
+++ b/juniper_official/Interfaces/interface-in-errors.rule
@@ -18,7 +18,7 @@
  *      cumaulative of in-fram-errors, in-resource-errors, in-giants, in-drops,
  *      in-discards and mtu-errors. Default value is in-errors.
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Monitors and notify interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors";
         synopsis "Interface statistics analyzer";

--- a/juniper_official/Interfaces/interface-in-traffic.rule
+++ b/juniper_official/Interfaces/interface-in-traffic.rule
@@ -24,7 +24,7 @@
  *      threshold for 180 seconds period, otherwise color is set to green.
  *      Use 5000000000 octets for 10G & 50000000000 for 100G interface. 
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Monitors and notify interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors";
         synopsis "Interface statistics analyzer";

--- a/juniper_official/Interfaces/interface-kpis.playbook
+++ b/juniper_official/Interfaces/interface-kpis.playbook
@@ -21,7 +21,7 @@
  * 9) Rule check-ifl-out-traffic, monitors the logical interface out traffic 
       and notifies anomalies when out traffic exceeds threshold.
  */
-iceberg {
+healthbot {
     playbook interface-kpis-playbook {
         rules [ interface.statistics/check-in-errors interface.statistics/check-in-traffic interface.statistics/check-interface-flaps interface.statistics/check-interface-status interface.statistics/check-neighbor-state interface.statistics/check-out-errors interface.statistics/check-out-traffic interface.statistics/check-ifl-in-traffic interface.statistics/check-ifl-out-traffic];
         description "Playbook to check interface health w.r.t. links, flaps, neighbor state, input & output traffic and errors";

--- a/juniper_official/Interfaces/interface-neighbor-state.rule
+++ b/juniper_official/Interfaces/interface-neighbor-state.rule
@@ -8,7 +8,7 @@
  *      match only gigabit ethernet interfaces.
  *
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "This topic is to monitor and notify interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors";
         synopsis "Interface statistics analyzer";

--- a/juniper_official/Interfaces/interface-out-errors.rule
+++ b/juniper_official/Interfaces/interface-out-errors.rule
@@ -14,7 +14,7 @@
  *      period of less than 180s, it'll turn the color to yellow,
  *      otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Monitors and notify interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors";
         synopsis "Interface statistics analyzer";

--- a/juniper_official/Interfaces/interface-out-traffic.rule
+++ b/juniper_official/Interfaces/interface-out-traffic.rule
@@ -23,7 +23,7 @@
  *      threshold for 180s, otherwise color is set to green. Use 5000000000
  *      octets for 10G & 50000000000 for 100G interface. 
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Monitors and notify interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors";
         synopsis "Interface statistics analyzer";

--- a/juniper_official/Interfaces/interface-status.rule
+++ b/juniper_official/Interfaces/interface-status.rule
@@ -8,7 +8,7 @@
  *      match only gigabit ethernet interfaces.
  *
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Monitors and notify interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors";
         synopsis "Interface statistics analyzer";

--- a/juniper_official/Interfaces/logical-interface-in-traffic.rule
+++ b/juniper_official/Interfaces/logical-interface-in-traffic.rule
@@ -26,7 +26,7 @@
  *      will set a dashboard color to yellow when *all* the input traffic is
  *      above threshold for 60 seconds period, otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Monitors and notify interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors";
         synopsis "Sub Interface statistics analyzer";
@@ -186,6 +186,68 @@ iceberg {
                 value ".*";
                 description "Sub interfaces index to be monitored, regular expression, eg '0-10'";
                 type string;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 16.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform MX150;
+                                }
+                            }
+                            products PTX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ PTX5000 PTX1000 PTX10000 ];
+                                }
+                            }
+                            products QFX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ QFX10000 QFX5200 ];
+                                }
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5100;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5120-48Y;
+                                }
+                            }
+                            products EX {
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX9200;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX4650;
+                                }
+                                releases 18.4R1 {
+                                    release-support min-supported-release;
+                                    platform EX4600;
+                                }
+                            }
+                        }
+                    }
+                    other-vendor cisco-IOS-XR {
+                        vendor-name cisco;
+                        operating-system IOS-XR;
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Interfaces/logical-interface-out-traffic.rule
+++ b/juniper_official/Interfaces/logical-interface-out-traffic.rule
@@ -26,7 +26,7 @@
  *      will set a dashboard color to yellow when *all* the output traffic is
  *      above threshold for 60 seconds period, otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Monitors and notify interface statistics i.e. link state, flaps, neighbor state, input & output traffic and errors";
         synopsis "Sub Interface statistics analyzer";
@@ -186,6 +186,68 @@ iceberg {
                 value ".*";
                 description "Sub interfaces index to be monitored, regular expression, eg '0-10'";
                 type string;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 16.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform MX150;
+                                }
+                            }
+                            products PTX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ PTX5000 PTX1000 PTX10000 ];
+                                }
+                            }
+                            products QFX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ QFX10000 QFX5200 ];
+                                }
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5100;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5120-48Y;
+                                }
+                            }
+                            products EX {
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX9200;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX4650;
+                                }
+                                releases 18.4R1 {
+                                    release-support min-supported-release;
+                                    platform EX4600;
+                                }
+                            }
+                        }
+                    }
+                    other-vendor cisco-IOS-XR {
+                        vendor-name cisco;
+                        operating-system IOS-XR;
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Linecard/cm-error.rule
+++ b/juniper_official/Linecard/cm-error.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "CM error statistics analyzer";
@@ -44,7 +44,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/cm-events.rule
+++ b/juniper_official/Linecard/cm-events.rule
@@ -10,7 +10,7 @@
  *      increase for a period of less than 3m, it'll turn the color to yellow,
  *      otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic linecard.cm-events {
         description "Monitors linecards and detect CM errors and alarms";
         synopsis "CM error finder";
@@ -158,6 +158,26 @@ iceberg {
                 value 1;
                 description "CM error threshold: Number of errors increase between metrics, before we report anomaly";
                 type int;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 17.2 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Linecard/fi-error.rule
+++ b/juniper_official/Linecard/fi-error.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Linecard statistics analyzer";
@@ -135,7 +135,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/fi-statistics.rule
+++ b/juniper_official/Linecard/fi-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "center chip fabric-in packets statistics analyzer";
@@ -132,7 +132,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/fpc-cpu-utilization.rule
+++ b/juniper_official/Linecard/fpc-cpu-utilization.rule
@@ -19,7 +19,7 @@
  *      threshold 'fpc-cpu-low-threshold' for a period of 3 minutes.
  *      Otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic linecard.fpc {
         description "Monitors linecards memory & cpu and notifies anomalies";
         synopsis "Linecard health analyzer";

--- a/juniper_official/Linecard/fpc-memory-utilization.rule
+++ b/juniper_official/Linecard/fpc-memory-utilization.rule
@@ -32,7 +32,7 @@
  *      utilization exceed low threshold 'fpc-heap-low-threshold' for a
  *      period of 3 minutes.
  */
-iceberg {
+healthbot {
     topic linecard.fpc {
         description "Monitors linecards memory & cpu and notifies anomalies";
         synopsis "Linecard health analyzer";
@@ -270,7 +270,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/fpc-threads.rule
+++ b/juniper_official/Linecard/fpc-threads.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Linecard CPU usage analyzer";
@@ -55,7 +55,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/fpc-utilization.rule
+++ b/juniper_official/Linecard/fpc-utilization.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Linecard FPC, heap and CPU analyzer";
@@ -124,7 +124,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/host-drops.rule
+++ b/juniper_official/Linecard/host-drops.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Center chip hostpath analyzer";
@@ -47,7 +47,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/host-loopback-status.rule
+++ b/juniper_official/Linecard/host-loopback-status.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic interface.statistics {
         description "Rules relevant to metrics and KPI on the interfaces";
         synopsis "Host loopback analyzer";
@@ -68,7 +68,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/ithrottle-id.rule
+++ b/juniper_official/Linecard/ithrottle-id.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line card";
         synopsis "Throttle statistics analyzer";
@@ -224,7 +224,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/ithrottle.rule
+++ b/juniper_official/Linecard/ithrottle.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line card";
         synopsis "iThrottle statistics analyzer";
@@ -111,7 +111,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/jnh-exceptions.rule
+++ b/juniper_official/Linecard/jnh-exceptions.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "JNH packet drop analyzer";
@@ -58,7 +58,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/jnh-ifd-stream.rule
+++ b/juniper_official/Linecard/jnh-ifd-stream.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "JNH IFD stream kpi";
@@ -59,7 +59,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/li-statistics.rule
+++ b/juniper_official/Linecard/li-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Center chip lookup analyzer";
@@ -43,7 +43,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/linecard-ethernet-statistics.rule
+++ b/juniper_official/Linecard/linecard-ethernet-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "This topic is to monitors and notify linecard ethernet statistics";
         synopsis "Linecard ethernet statistics kpi";
@@ -51,7 +51,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/linecard-kpis.playbook
+++ b/juniper_official/Linecard/linecard-kpis.playbook
@@ -9,7 +9,7 @@
  * 3) Rule "check-cm-events" detects the cm errors and notifies anomalies
  *    when error count increases.
  */
-iceberg {
+healthbot {
     playbook linecard-kpis-playbook {
         rules [ linecard.cm-events/check-cm-events linecard.fpc/check-fpc-cpu linecard.fpc/check-fpc-memory ];
         description "Playbook checks linecard health i.e. cpu, memory and CM errors";

--- a/juniper_official/Linecard/lo-statistics.rule
+++ b/juniper_official/Linecard/lo-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Center chip lookup analyzer";
@@ -44,7 +44,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/online-fpc.playbook
+++ b/juniper_official/Linecard/online-fpc.playbook
@@ -3,7 +3,7 @@
  *
  * 1) Rule "update-online-fpc" finds all the online FPCs in the chassis. 
  */
-iceberg {
+healthbot {
     playbook online-fpc-playbook {
         rules linecard.statistics/update-online-fpc;
         description "Playbook collects online FPCs list";

--- a/juniper_official/Linecard/online-fpc.rule
+++ b/juniper_official/Linecard/online-fpc.rule
@@ -1,7 +1,7 @@
 /*
  * These two rules are used to collect online FPCs in network device and update dependent yml files 
  */
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "This topic has rule on collecting and updating online fpc";
         synopsis  "This topic has rule on collecting and updating online fpc";
@@ -16,6 +16,59 @@ iceberg {
                     file online_fpc.yml;
                     table UpdateTable;
                     frequency 1m;
+                }
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products PTX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products QFX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products EX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products ACX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products SRX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                        }
+                    }
+                }
+               helper-files other {
+                    list-of-files online_fpc.yml;
                 }
             }
         }

--- a/juniper_official/Linecard/pci-error.rule
+++ b/juniper_official/Linecard/pci-error.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "PCI invalid status analyzer";
@@ -44,7 +44,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/pt-statistics.rule
+++ b/juniper_official/Linecard/pt-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Center chip packet statistics analyzer";
@@ -66,7 +66,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/scheduler-info.rule
+++ b/juniper_official/Linecard/scheduler-info.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line card";
         synopsis "FPC CPU statistics analyzer";
@@ -131,7 +131,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/toe-pfe.rule
+++ b/juniper_official/Linecard/toe-pfe.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Linecard statistics analyzer";
@@ -164,7 +164,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Linecard/wo-statistics.rule
+++ b/juniper_official/Linecard/wo-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to metrics on the line-card";
         synopsis "Linecard statistics analyzer";
@@ -47,7 +47,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Protocols/Bgp/bgp-advertised-routes-kpi.rule
+++ b/juniper_official/Protocols/Bgp/bgp-advertised-routes-kpi.rule
@@ -23,7 +23,7 @@
  *      a dashboard color to red when advertised route count exceed threshold
  *      (max-advertised-route-count-threshold), otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic protocol.bgp {
         description "Monitors BGP sessions statistics i.e. neighbor state, detects flaps, route damping and max advertised-routes count and notify anomalies";
         synopsis "BGP session statistics analyzer";
@@ -187,6 +187,68 @@ iceberg {
                 value 10000;
                 type int;
                 description "BGP neighbor session advertised routes threshold: Number of advertised route count increase between metrics, before we report anomaly";
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                            products PTX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ PTX5000 PTX1000 PTX10000 ];
+                                }
+                            }
+                            products QFX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ QFX10000 QFX5200 ];
+                                }
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5110;
+                                }
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5100;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5120-48Y;
+                                }
+                            }
+                            products EX {
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX9200;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX4650;
+                                }
+                                releases 18.4R1 {
+                                    release-support min-supported-release;
+                                    platform EX4600;
+                                }
+                            }
+                        }
+                    }
+                    other-vendor cisco-IOS-XR {
+                        vendor-name cisco;
+                        operating-system IOS-XR;
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Protocols/Bgp/bgp-neighbor-flap-detection.rule
+++ b/juniper_official/Protocols/Bgp/bgp-neighbor-flap-detection.rule
@@ -14,7 +14,7 @@
  *      increase for a period of less than 60s, it'll turn the color to
  *      yellow, otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic protocol.bgp {
         description "Monitors BGP sessions statistics i.e. neighbor state, detects flaps, route damping and max received-routes count and notify anomalies";
         synopsis "BGP session statistics analyzer";

--- a/juniper_official/Protocols/Bgp/bgp-neighbor-state.rule
+++ b/juniper_official/Protocols/Bgp/bgp-neighbor-state.rule
@@ -7,7 +7,7 @@
  *      all bap neighbors. Use something like '172.16.*' to match all neighbor
  *      addresses which are in 172.16.0.0/16 network range.
  */
-iceberg {
+healthbot {
     topic protocol.bgp {
         description "Monitors BGP sessions statistics i.e. neighbor state, detects flaps, route damping and max received-routes count and notify anomalies";
         synopsis "BGP session statistics analyzer";

--- a/juniper_official/Protocols/Bgp/bgp-neighbor-stats-kpi.playbook
+++ b/juniper_official/Protocols/Bgp/bgp-neighbor-stats-kpi.playbook
@@ -11,7 +11,7 @@
  * 4) Rule "check-bgp-advertised-routes" detects the advertised route count 
  *    threshold breaches and notify anomalies.
  */
-iceberg {
+healthbot {
     playbook bgp-session-stats-playbook {
         rules [ protocol.bgp/check-bgp-session-state protocol.bgp/check-bgp-neighbor-flaps protocol.bgp/check-bgp-received-routes protocol.bgp/check-bgp-advertised-routes];
         description "Playbook checks the BGP neighbor sessions health and notify anomaly when statistics are unusual";

--- a/juniper_official/Protocols/Bgp/bgp-received-routes-kpi.rule
+++ b/juniper_official/Protocols/Bgp/bgp-received-routes-kpi.rule
@@ -23,7 +23,7 @@
  *      a dashboard color to red when received route count exceed threshold
  *      (max-received-route-count-threshold), otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic protocol.bgp {
         description "Monitors BGP sessions statistics i.e. neighbor state, detects flaps, route damping and max received-routes count and notify anomalies";
         synopsis "BGP session statistics analyzer";

--- a/juniper_official/Protocols/Fib/fib-summary.rule
+++ b/juniper_official/Protocols/Fib/fib-summary.rule
@@ -2,7 +2,7 @@
  * Detects forwarding-table of each route table and its protocol's route count
  * threshold breaches and notify anomaly when route count is aberrant.
  */
- iceberg {
+ healthbot {
     topic protocol.routesummary {
         description "Monitors each forwarding table and each protocol route count and sets dynamic thresholds and notify anomaly when route count is abnormal";
         synopsis "FIB route tables and protocols statistics analyzer";    
@@ -157,6 +157,59 @@
                  type string;
                  description "route table types to monitor, regular expression, eg 'perm|intf|user'";
              }
+             rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products PTX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products QFX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products EX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products ACX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products SRX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                        }
+                    }
+                }
+               helper-files other {
+                    list-of-files fib.yml;
+                }
+            }
         }
     }
 }

--- a/juniper_official/Protocols/Fib/forwarding-table-summary.playbook
+++ b/juniper_official/Protocols/Fib/forwarding-table-summary.playbook
@@ -8,7 +8,7 @@
  * when route count is abnormal
  *
  */
-iceberg {
+healthbot {
     playbook forwarding-table-summary {
         rules [ protocol.routesummary/check-fib-summary ];
         description "Playbook monitors forwarding-table's each protocol's route count and notifies anomaly when route count is above static or dynamic threshold";

--- a/juniper_official/Protocols/Infra/task-io.rule
+++ b/juniper_official/Protocols/Infra/task-io.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic protocol.infra {
         description "Rules relevant to protocol daemon infrastructure";
         synopsis "Task I/O statistics analyzer";
@@ -67,7 +67,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Protocols/Infra/task-memory.rule
+++ b/juniper_official/Protocols/Infra/task-memory.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic protocol.infra {
         description "Rules relevant to protocol daemon infrastructure";
         synopsis "Task memory statistics analyzer";
@@ -56,7 +56,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Protocols/Isis/isis-adjacency.rule
+++ b/juniper_official/Protocols/Isis/isis-adjacency.rule
@@ -18,7 +18,7 @@
  *      adjacencies contains gigabit ethernet interfaces.
  *
  */
- iceberg {
+ healthbot {
     topic protocol.isis {
         description "Monitors isis statitics i.e. adjacency state& statistics and notify anomalies";
         synopsis "ISIS session statistics analyzer";

--- a/juniper_official/Protocols/Isis/isis-statistics.playbook
+++ b/juniper_official/Protocols/Isis/isis-statistics.playbook
@@ -8,7 +8,7 @@
  *    csnp, esh, iih, ish, psnp and unknown drops) and notify anomalies when
  *    drop count exceeds threshold.
  */
-iceberg {
+healthbot {
     playbook isis-stats-playbook {
         rules [ protocol.isis/check-isis-adjacencies protocol.isis/check-isis-statistics];
         description "Playbook checks the ISIS adjacencies health and notify anomaly when statistics are unusual";

--- a/juniper_official/Protocols/Isis/isis-statistics.rule
+++ b/juniper_official/Protocols/Isis/isis-statistics.rule
@@ -13,7 +13,7 @@
  *      adjacencies contains gigabit ethernet interfaces.
  *
  */
- iceberg {
+ healthbot {
     topic protocol.isis {
         description "Monitors isis statitics i.e. adjacency state& statistics and notify anomalies";
         synopsis "ISIS adjacency statistics analyzer";

--- a/juniper_official/Protocols/Lldp/lldp-session-state.rule
+++ b/juniper_official/Protocols/Lldp/lldp-session-state.rule
@@ -7,7 +7,7 @@
  *      '.*', which matches all interfaces. Use something like 'ge.*' to
  *      match only gigabit ethernet interfaces.
  */
-iceberg {
+healthbot {
     topic protocol.lldp {
         description "Monitors lldp statitics i.e. neighbor state, frame discards, frame errors, tlv discards & unknown tlvs and notify anomalies";
         synopsis "LLDP session statistics analyzer";

--- a/juniper_official/Protocols/Lldp/lldp-session-statistics.rule
+++ b/juniper_official/Protocols/Lldp/lldp-session-statistics.rule
@@ -35,7 +35,7 @@
  *      red when unknown TLV count is greater than 'unknown-tlvs-threshold' 
  *      for 3 minutes period, otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic protocol.lldp {
         description "Monitors LLDP statistics i.e. neighbor state, frame discards, frame errors, TLV discards & unknown TLVs and notify anomalies";
         synopsis "LLDP session statistics analyzer";

--- a/juniper_official/Protocols/Lldp/lldp-session-stats.playbook
+++ b/juniper_official/Protocols/Lldp/lldp-session-stats.playbook
@@ -10,7 +10,7 @@
  *    "get-lld-state" and detects the LLDP neighbor session state changes and
  *    notify anomalies.
  */
-iceberg {
+healthbot {
     playbook lldp-kpis-playbook {
         rules [ protocol.lldp/check-lldp-session protocol.lldp/check-lldp-session-statistics protocol.lldp/get-lldp-state ];
         description "Playbook checks health of each lldp session and notify anomalies";

--- a/juniper_official/Protocols/Ospf/ddos-statistics.rule
+++ b/juniper_official/Protocols/Ospf/ddos-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.ospf {
         description "This topic is to monitors and notify OSPF distributed denial of service counters collected from the linecards";
         synopsis "OSPF distributed denial of service statistics analyzer";
@@ -152,7 +152,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Protocols/Ospf/fpc-link-stats.rule
+++ b/juniper_official/Protocols/Ospf/fpc-link-stats.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic protocol.ospf {
         description "This topic is to monitors and notify OSPF sessions hello packet statitics";
         synopsis "ospf session hello statistics analyzer";
@@ -50,7 +50,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Protocols/Ospf/ospf-io-statistics.rule
+++ b/juniper_official/Protocols/Ospf/ospf-io-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic protocol.ospf {
         description "Rules relevant to protocol metrics and in specific pertaining to ospf";
         synopsis "ospf session statistics analyzer";
@@ -63,6 +63,59 @@ iceberg {
                             message "RPD OSPF IO module is not functioning";
                         }
                     }
+                }
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 2;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products PTX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products QFX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products EX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products ACX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products SRX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                        }
+                    }
+                }
+               helper-files other {
+                    list-of-files ospf.yml;
                 }
             }
         }

--- a/juniper_official/Protocols/Ospf/ospf-kernel-route.rule
+++ b/juniper_official/Protocols/Ospf/ospf-kernel-route.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic protocol.ospf {
         description "Rules relevant to protocol metrics and in specific pertaining to ospf";
         synopsis "ospf session state analyzer";
@@ -68,7 +68,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Protocols/Ospf/ospf-neighbor-information.rule
+++ b/juniper_official/Protocols/Ospf/ospf-neighbor-information.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic protocol.ospf {
         description "Rules relevant to protocol metrics and in specific pertaining to ospf";
         synopsis "ospf session statistics analyzer";
@@ -76,7 +76,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Protocols/Ospf/ospf-neighbor-state.rule
+++ b/juniper_official/Protocols/Ospf/ospf-neighbor-state.rule
@@ -1,7 +1,7 @@
 /*
  *   This rule checks health of each ospf neigbor state and notify in case any of the health monitored field crosses threshold
  */
-iceberg {
+healthbot {
     topic protocol.ospf {
         description "This topic is to monitor ospf neigbor state";
         synopsis "ospf neighbor status check";
@@ -68,6 +68,59 @@ iceberg {
                 value .*;
                 description "Enter required ospf neighbor ids to be monitored using regular expression";
                 type string;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products PTX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products QFX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products EX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products ACX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products SRX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                        }
+                    }
+                }
+               helper-files other {
+                    list-of-files ospf-neighbor.yml;
+                }
             }
         }
     }

--- a/juniper_official/Protocols/Ospf/ospf-statistics.rule
+++ b/juniper_official/Protocols/Ospf/ospf-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic protocol.ospf {
         description "Rules relevant to protocol metrics and in specific pertaining to ospf";
         rule check-ospf-statistics-information {
@@ -66,6 +66,59 @@ iceberg {
                             message "RPD OSPF send module is not functioning";
                         }
                     }
+                }
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 2;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products PTX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products QFX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products EX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products ACX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products SRX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                        }
+                    }
+                }
+               helper-files other {
+                    list-of-files ospf.yml;
                 }
             }
         }

--- a/juniper_official/Protocols/Ospf/pfe-ddos-policer.rule
+++ b/juniper_official/Protocols/Ospf/pfe-ddos-policer.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic protocol.ospf {
         description "This topic is to monitors and notify ospf packets received and sent";
         synopsis "ospf session statistics analyzer";
@@ -118,7 +118,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/Protocols/Rib/route-summary.playbook
+++ b/juniper_official/Protocols/Rib/route-summary.playbook
@@ -10,7 +10,7 @@
  *    learned data (route count of each protocol) using ML(Machine Learning)
  *    algorithms and detects threshold breaches and notify anomalies.
  */
-iceberg {
+healthbot {
     playbook route-summary-playbook {
         rules [ protocol.routesummary/check-ascertain-routes protocol.routesummary/check-protocol-route-count ];
         description "Playbook checks each table's and protocol's route count and notifies anomaly when route count is above or below dynamic threshold";

--- a/juniper_official/Protocols/Rib/route-table-protocol-summary.rule
+++ b/juniper_official/Protocols/Rib/route-table-protocol-summary.rule
@@ -2,7 +2,7 @@
  * Dynamically sets the route count threshold for each protocol of each route
  * table and notify anomaly when route count is aberrant.
  */
-iceberg {
+healthbot {
     topic protocol.routesummary {
         description "Monitors each routing table and each protocol route count and sets dynamic thresholds and notify anomaly when route count is abnormal";
         synopsis "RIB route tables and protocols statistics analyzer";

--- a/juniper_official/Protocols/Rib/route-tables-summary.rule
+++ b/juniper_official/Protocols/Rib/route-tables-summary.rule
@@ -2,7 +2,7 @@
  * Dynamically sets the route count threshold for each route table and notify
  * anomaly when route count is aberrant.
  */
-iceberg {
+healthbot {
     topic protocol.routesummary {
         description "Monitors each routing table and each protocol route count and sets dynamic thresholds and notify anomaly when route count is abnormal";
         synopsis "RIB route tables and protocols statistics analyzer";

--- a/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack-v4.rule
+++ b/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack-v4.rule
@@ -1,7 +1,7 @@
 /*
  * Collects bgp session statistics and notifies when bgp v4 route hijack.
  */
-iceberg {
+healthbot {
     topic protocol.bgp {
         description "Detects ipv4 and ipv6 bgp route hijacks";
         synopsis "Bgp route hijack detector";

--- a/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack-v6.rule
+++ b/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack-v6.rule
@@ -1,7 +1,7 @@
 /*
  * Collects bgp session statistics and notifies when bgp v4 route hijacks.
  */
- iceberg {
+ healthbot {
     topic protocol.bgp {
         description "Detects ipv4 and ipv6 bgp route hijacks";
         synopsis "Bgp route hijack detector";

--- a/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack.playbook
+++ b/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack.playbook
@@ -7,7 +7,7 @@
  * 2) Rule bgp-route-hijack-v6.rule, detects the v4 route hijacks and notifies
  *     anomalies when error count increases.
  */
- iceberg {
+ healthbot {
     playbook bgp-route-hijack-detection {
         rules [ protocol.bgp/check-route-hijacking-v4 protocol.bgp/check-route-hijacking-v6 ];
         description "Playbook detects bgp ipv4 and ipv6 route hijack";

--- a/juniper_official/Solutions/Icmp-outlier/icmp.playbook
+++ b/juniper_official/Solutions/Icmp-outlier/icmp.playbook
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     playbook icmp-probe {
         rules protocol.icmp/check-icmp-statistics;
         description "Device playbook to monitor RTT response";

--- a/juniper_official/Solutions/Icmp-outlier/icmp.rule
+++ b/juniper_official/Solutions/Icmp-outlier/icmp.rule
@@ -12,7 +12,7 @@
  *      dashboard color to red when ICMP response time is greater than static
  *      threshold 'rtt-threshold-var'.
  */
- iceberg {
+ healthbot {
     topic protocol.icmp {
         description "Sends ICMP probes to destination host and notify anomalies";
         synopsis "ICMP response analyzer";
@@ -198,6 +198,9 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.0.0;
+                catalogue {
+                    tier 1;
+                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/Krt-async-stuck/krtasync-rule.conf
+++ b/juniper_official/Solutions/Krt-async-stuck/krtasync-rule.conf
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic krt-async-status-check {
         rule krt-all {
             rule-frequency 1m;

--- a/juniper_official/Solutions/Krt-async-stuck/krtasync.playbook
+++ b/juniper_official/Solutions/Krt-async-stuck/krtasync.playbook
@@ -152,7 +152,7 @@
  * then declare KRT stuck/Raise Red Alarm
  */
 
-iceberg {
+healthbot {
     playbook krtasyncstatuscheck {
         rules [ krt-async-status-check/krt-all krt-async-status-check/krtcorrtable krt-async-status-check/krtiotable krt-async-status-check/krtstate ];
     }

--- a/juniper_official/Solutions/L3-vpn-view/l3vpn-network.playbook
+++ b/juniper_official/Solutions/L3-vpn-view/l3vpn-network.playbook
@@ -8,7 +8,7 @@
  * Network rule check-l3vpn-state, Analyzes the routing instance, PE and CE
  * interface status and notifies anomalies when any of the state is down.
  */
-iceberg {
+healthbot {
     playbook get-vpn-stats {
         description "Playbook collects interface and routing instance details periodically";
         synopsis "Interface and routing instance collector";

--- a/juniper_official/Solutions/L3-vpn-view/l3vpn-network.rule
+++ b/juniper_official/Solutions/L3-vpn-view/l3vpn-network.rule
@@ -2,7 +2,7 @@
  * Collects L3VPN protocol status and PE & CE interface statistics and notifies
  * anomalies when any of the BGP session, CE or PE interface is down.
  */
-iceberg {
+healthbot {
     topic protocol.l3vpn {
         description "Collect routing instance and interfaces stats and notify anomalies";
         synopsis "L3VPN session state analyzer";
@@ -205,6 +205,68 @@ iceberg {
                 description "Router name to monitor, regular expression, e.g. 'edge-router.*'";
                 type device;
             }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                            products PTX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ PTX5000 PTX1000 PTX10000 ];
+                                }
+                            }
+                            products QFX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ QFX10000 QFX5200 ];
+                                }
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5110;
+                                }
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5100;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5120-48Y;
+                                }
+                            }
+                            products EX {
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX9200;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX4650;
+                                }
+                                releases 18.4R1 {
+                                    release-support min-supported-release;
+                                    platform EX4600;
+                                }
+                            }
+                        }
+                    }
+                    other-vendor cisco-IOS-XR {
+                        vendor-name cisco;
+                        operating-system IOS-XR;
+                    }
+                }
+            }
         }
         rule get-interface-details {
             keys [ interface-name sub-interface-index ];
@@ -259,6 +321,68 @@ iceberg {
                 description "Sub interfaces index to be monitored, regular expression, eg '0-10'";
                 type string;
             }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                            products PTX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ PTX5000 PTX1000 PTX10000 ];
+                                }
+                            }
+                            products QFX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ QFX10000 QFX5200 ];
+                                }
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5110;
+                                }
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5100;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5120-48Y;
+                                }
+                            }
+                            products EX {
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX9200;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX4650;
+                                }
+                                releases 18.4R1 {
+                                    release-support min-supported-release;
+                                    platform EX4600;
+                                }
+                            }
+                        }
+                    }
+                    other-vendor cisco-IOS-XR {
+                        vendor-name cisco;
+                        operating-system IOS-XR;
+                    }
+                }
+            }
         }
         rule get-routing-instance-details {
             keys [ instance-name neighbor-address ];
@@ -312,6 +436,68 @@ iceberg {
                 value .*;
                 description "BGP neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
                 type string;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                            products PTX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ PTX5000 PTX1000 PTX10000 ];
+                                }
+                            }
+                            products QFX {
+                                releases 17.2R1 {
+                                    release-support min-supported-release;
+                                    platform [ QFX10000 QFX5200 ];
+                                }
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5110;
+                                }
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5100;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform QFX5120-48Y;
+                                }
+                            }
+                            products EX {
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX9200;
+                                }
+                                releases 18.3R1 {
+                                    release-support min-supported-release;
+                                    platform EX4650;
+                                }
+                                releases 18.4R1 {
+                                    release-support min-supported-release;
+                                    platform EX4600;
+                                }
+                            }
+                        }
+                    }
+                    other-vendor cisco-IOS-XR {
+                        vendor-name cisco;
+                        operating-system IOS-XR;
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Solutions/Microburst/microburst.playbook
+++ b/juniper_official/Solutions/Microburst/microburst.playbook
@@ -3,7 +3,7 @@
  *
  * Rule check-queue, detects microbursts and notfies anomalies.
  */
-iceberg {
+healthbot {
     playbook microburst-playbook {
         description "Playbook detects microbursts on interface egress queues";
         synopsis "Microburst detector";

--- a/juniper_official/Solutions/Microburst/microburst.rule
+++ b/juniper_official/Solutions/Microburst/microburst.rule
@@ -1,7 +1,7 @@
 /*
  * Detects microburst in all monitored interface egress queues.
  */
-iceberg {
+healthbot {
     topic class-of-service.microburst {
         description "Interface egress queues microburst detection";
         synopsis "Microburst detector";
@@ -101,6 +101,26 @@ iceberg {
                 value .*;
                 description "Queue number or name to monitor, regular expression, eg '1|2'";
                 type string;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 17.2 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Solutions/Mpls-blackhole-detection/jnh-drop-packets.rule
+++ b/juniper_official/Solutions/Mpls-blackhole-detection/jnh-drop-packets.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.jnh-exception-packets {
     description "Detects MPLS LSP blackhole";
     synopsis "MPLS blackhole detector";
@@ -121,4 +121,3 @@ iceberg {
         }
     }
 }
- 

--- a/juniper_official/Solutions/Mpls-blackhole-detection/mpls-blackhole-detection.playbook
+++ b/juniper_official/Solutions/Mpls-blackhole-detection/mpls-blackhole-detection.playbook
@@ -7,7 +7,7 @@
  * 2) Rule rsvp-status.rule, detects the RSVP session statistics out and feeds
  *     RSVP session data to rule jnh-drop-packets.rule
  */
-iceberg {
+healthbot {
     playbook mpls-blackhole-detection-playbook {
         rules [linecard.jnh-exception-packets/check-drop-packets linecard.jnh-exception-packets/check-rsvp ];
         description "Playbook detects blackhole based on jnh exceptions and compares with RSVP session statistics and notifies anomalies";

--- a/juniper_official/Solutions/Mpls-blackhole-detection/rsvp-status.rule
+++ b/juniper_official/Solutions/Mpls-blackhole-detection/rsvp-status.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.jnh-exception-packets {
         description "Detects MPLS LSP blackhole";
         synopsis "MPLS blackhole detector";
@@ -87,4 +87,3 @@ iceberg {
         }
     }
 }
- 

--- a/juniper_official/Solutions/RCA-OSPF-Subsystems-ChipAgnostic/rca-chip-agnostic.playbook
+++ b/juniper_official/Solutions/RCA-OSPF-Subsystems-ChipAgnostic/rca-chip-agnostic.playbook
@@ -16,7 +16,7 @@
 * Rule linecard.statistics/check-center-chip-wan-out, detects increase in wan out packets
 * and notifies anomalies when error count increases.
 */
-iceberg {
+healthbot {
     playbook chip-agnostic-kpis {
         description "Playbook detects chip agnostic anomalies";
         synopsis "Chip agnostic kpis";

--- a/juniper_official/Solutions/RCA-OSPF-Subsystems-ChipAgnostic/rca-ospf-subsystems.playbook
+++ b/juniper_official/Solutions/RCA-OSPF-Subsystems-ChipAgnostic/rca-ospf-subsystems.playbook
@@ -66,7 +66,7 @@
 * Rule protocol.ospf/check-ospf-io-statistics-information, detects ospf io errors and notifies
 * anomalies when io errors found.
 */
-iceberg {
+healthbot {
     playbook rca-ospf-playbook {
         description "Playbook detects OSPF protocol and its subsystems anomalies";
         synopsis "OSPF RCA kpis";

--- a/juniper_official/Solutions/System-blackhole-detection/system-blackhole-detection.playbook
+++ b/juniper_official/Solutions/System-blackhole-detection/system-blackhole-detection.playbook
@@ -6,7 +6,7 @@
  *    anomalies io traffic difference exceeds dynamic and static thresholds.
 
  */
-iceberg {
+healthbot {
     playbook system-blackhole-detection-playbook {
         rules system.traffic/check-system-traffic;
         description "Playbook detects blackhole based on difference between input and output traffic and notifies anomalies";

--- a/juniper_official/Solutions/System-blackhole-detection/system-traffic.rule
+++ b/juniper_official/Solutions/System-blackhole-detection/system-traffic.rule
@@ -9,7 +9,7 @@
  *      traffic difference exceeds static threshold 'traffic-diff-threshold'.
  * 
  */
-iceberg {
+healthbot {
     topic system.traffic {   
         description "This topic is to monitor system total input and output packets usage and notify in case difference in io traffic is above static and dynamic threshold";
         synopsis "System total Input and output packets analyzer";

--- a/juniper_official/Subscriber-Service/address-pool-utilization.rule
+++ b/juniper_official/Subscriber-Service/address-pool-utilization.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic service.subscribers {
         description "Rules related to subscribers address pool utilization";
         synopsis "BNG subscribers address pool monitoring rules";
@@ -163,6 +163,26 @@ iceberg {
                 description "address pool utilization minimum threshold value";
                 type int;
             }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 2;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
         rule linked-address-pool {
             synopsis "linked address pool utilization analyzer";
@@ -286,6 +306,26 @@ iceberg {
             vector list-pool-utilization {
                 path "/topic[topic-name=service.subscribers]/rule[rule-name=chk-addr-pool-util]/field[linked-pool-head='{{filter-linked-pool-head}}']/address-usage-percent";
                 time-range 90s;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 2;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Subscriber-Service/monitor-subscriber-count.rule
+++ b/juniper_official/Subscriber-Service/monitor-subscriber-count.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic service.subscribers {
         description "Rules related to subscribers count of a JUNOS Broadband Network Gateway (BNG)";
         synopsis "BNG subscribers count monitoring rules";
@@ -103,6 +103,26 @@ iceberg {
                 value 10000;
                 description "Minimum total subscribers count count";
                 type int;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 2;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
+++ b/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic service.protocols {
         description "Rules related to PPPoE statistics monitoring of a JUNOS Broadband Network Gateway (BNG)";
         synopsis "BNG PPPoE error statistics monitoring rules";
@@ -261,6 +261,26 @@ iceberg {
                 value 10;
                 description "Minimum value of increase in 3 minutes";
                 type int;
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 2;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 18.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX240 MX480 MX960 MX2010 MX2020 ];
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/juniper_official/Subscriber-Service/subscriber-service.playbook
+++ b/juniper_official/Subscriber-Service/subscriber-service.playbook
@@ -11,7 +11,7 @@
  * 4) Rule monitor-subscriber-count, detects the system total subscribers
  *    count and notifies anomalies .
  */
-iceberg {
+healthbot {
     playbook subscriber-services {
         rules [ service.protocols/pppoe-error-statistics service.subscribers/chk-addr-pool-util service.subscribers/linked-address-pool service.subscribers/monitor-subscriber-count ];
         description "The subscriber-services playbook contains rules for monitoring the health subscriber services KPI";

--- a/juniper_official/System/fpc-memory.rule
+++ b/juniper_official/System/fpc-memory.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.fpc {
         description "Monitors FPC memory usage percentage and notifies anomalies";
         synopsis "FPC memory analyzer";
@@ -51,6 +51,59 @@ iceberg {
                             message "$name memory usage for $target is normal ($perc)!";
                         }
                     }
+                }
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                catalogue {
+                    tier 1;
+                }
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products PTX {
+                                releases 11.4R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products QFX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products EX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products ACX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                            products SRX {
+                                releases 15.2R1 {
+                                    release-support min-supported-release;
+                                    platform All;
+                                }
+                            }
+                        }
+                    }
+                }
+               helper-files other {
+                    list-of-files fpc_memory.yml;
                 }
             }
         }

--- a/juniper_official/System/pfe-traffic-statistics.rule
+++ b/juniper_official/System/pfe-traffic-statistics.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules relevant to linecards";
         synopsis "Linecard drops, discards and ospf hello analyzer";
@@ -182,7 +182,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/System/pre-classifier.rule
+++ b/juniper_official/System/pre-classifier.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic linecard.statistics {
         description "Rules pertaining to the performance of the PFE";
         synopsis "PFE performance kpi";
@@ -80,7 +80,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/System/re-cpu-utilization.rule
+++ b/juniper_official/System/re-cpu-utilization.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic system.statistics {
         description "Rules relevant to metrics and KPI of the system";
         synopsis "Routing Engine CPU utilization kpi";
@@ -123,7 +123,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/System/software-version.rule
+++ b/juniper_official/System/software-version.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic system.statistics{
         description "Rules relevant to metrics and KPI of the system";
         synopsis "System product name and software version analyzer";
@@ -90,7 +90,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/System/system-cpu-load-average.rule
+++ b/juniper_official/System/system-cpu-load-average.rule
@@ -14,7 +14,7 @@
  *      when RE CPU utilization below high threshold. Otherwise color is set
  *      to red. 
  */
-iceberg {
+healthbot {
     topic system.cpu {
         description "Monitors system statistics i.e. CPU, memory, storage, processes& queues and notifies anomalies";
         synopsis "System statistics analyzer";

--- a/juniper_official/System/system-cpu.rule
+++ b/juniper_official/System/system-cpu.rule
@@ -19,7 +19,7 @@
  *      threshold 're-cpu-low-threshold' for a period of 5 minutes.
  *      Otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic system.cpu {
         description "Monitors system statistics i.e. CPU, memory, storage, processes & queues and notifies anomalies";
         synopsis "System statistics analyzer";

--- a/juniper_official/System/system-kpis.playbook
+++ b/juniper_official/System/system-kpis.playbook
@@ -15,7 +15,7 @@
  * 6) Rule check-system-storage, detects the system storage usage of **all**
  *    mounts threshold breaches and notifies anomalies.
  */
-iceberg {
+healthbot {
     playbook system-kpis-playbook {
         rules [ system.cpu/check-system-cpu system.cpu/check-system-cpu-load-average system.memory/check-system-memory system.processes/check-process-cpu system.processes/check-process-memory system.storage/check-storage ];
         description "Playbook checks the system health i.e. system cpu, memory, storage and junos processes cpu and memory utilization";

--- a/juniper_official/System/system-memory.rule
+++ b/juniper_official/System/system-memory.rule
@@ -20,7 +20,7 @@
  *      utilization exceed high threshold'memory-buffer-re-low-threshold'
  *      for a period of 5 minutes. Otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic system.memory {
         description "Monitors system statistics i.e. CPU, memory, storage, processes& queues and notifies anomalies";
         synopsis "System statistics analyzer";

--- a/juniper_official/System/system-processes-cpu.rule
+++ b/juniper_official/System/system-processes-cpu.rule
@@ -20,7 +20,7 @@
  *      exceed low threshold 'process-cpu-low-threshold' for period of
  *      3 minutes. Otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic system.processes {
         description "Monitors system statistics i.e. CPU, memory, storage, processes & queues and notifies anomalies";
         synopsis "System statistics analyzer";

--- a/juniper_official/System/system-processes-memory.rule
+++ b/juniper_official/System/system-processes-memory.rule
@@ -20,7 +20,7 @@
  *      utilization exceed low threshold 'process-memory-low-threshold'
  *      for a period of 5 minutes. Otherwise color is set to green.
  */
-iceberg {
+healthbot {
     topic system.processes {
         description "Monitors system statistics i.e. CPU, memory, storage, processes & queues and notifies anomalies";
         synopsis "System statistics analyzer";

--- a/juniper_official/System/system-queues.rule
+++ b/juniper_official/System/system-queues.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic system.statistics {
         description "Rules relevant to metrics and KPI of the system";
         synopsis "Packet drops on the input interface analyzer";
@@ -79,7 +79,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {
@@ -205,7 +205,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/System/system-statistics-ip.rule
+++ b/juniper_official/System/system-statistics-ip.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic system.statistics {
         description "Rules relevant to metrics and KPI of the system";
         synopsis "Incoming raw ip packets analyzer";
@@ -79,7 +79,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/System/system-storage-capacity.rule
+++ b/juniper_official/System/system-storage-capacity.rule
@@ -1,4 +1,4 @@
-iceberg {
+healthbot {
     topic system.statistics {
         description "Rules relevant to metrics and KPI of the system";
         synopsis "System storage analyzer";
@@ -56,7 +56,7 @@ iceberg {
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
                 catalogue {
-                    tier 1;
+                    tier 2;
                 }
                 supported-devices {
                     juniper {

--- a/juniper_official/System/system-storage.rule
+++ b/juniper_official/System/system-storage.rule
@@ -13,7 +13,7 @@
  *      color to green when storage used below 'storage-usage-low-threshold'.
  *      otherwise color is set to yellow as used % is between 50% and 80%.
  */
-iceberg {
+healthbot {
     topic system.storage {
         description "Monitors system statistics i.e. CPU, memory, storage, processes& queues and notifies anomalies";
         synopsis "System statistics analyzer";


### PR DESCRIPTION
-Added rule-properties to all the rules committed in 2.0.0
-Added rule-properties to native-gbp rules
-Changed rule tier type of solutions (Subscriber-services and RCA-OSPF-Subsystems-ChipAgnostic playbooks) from 1 to 2