### PR TITLE
Cleanup of yamllint warnings

### DIFF
--- a/community_supplied/Solutions/Krt-async-statistics/krtcorrtable.yml
+++ b/community_supplied/Solutions/Krt-async-statistics/krtcorrtable.yml
@@ -1,3 +1,4 @@
+---
 krtcorrtable:
   rpc: get-async-cor-stats
   item: krt-tree-statistics

--- a/community_supplied/Solutions/Krt-async-statistics/krtiotable.yml
+++ b/community_supplied/Solutions/Krt-async-statistics/krtiotable.yml
@@ -1,3 +1,4 @@
+---
 krtiotable:
   rpc: get-async-io-stats
   item: krt-io-statistics-entry

--- a/community_supplied/Solutions/Krt-async-statistics/krtstate.yml
+++ b/community_supplied/Solutions/Krt-async-statistics/krtstate.yml
@@ -1,3 +1,4 @@
+---
 krtstate:
   rpc: get-krt-state
   key: krtq-time-until-next-run

--- a/juniper_official/Chassis/chassis-fan.yml
+++ b/juniper_official/Chassis/chassis-fan.yml
@@ -1,3 +1,4 @@
+---
 ChassisFanTable:
     command: show chassis fan
     key: fan-name

--- a/juniper_official/Linecard/fpc-utilization.yml
+++ b/juniper_official/Linecard/fpc-utilization.yml
@@ -2,7 +2,7 @@
 FPCCPUHEAPutilizationTable:
   rpc: get-fpc-information
   args:
-    extensive: False
+    extensive: !!bool False
   item: fpc
   key:
     - slot

--- a/juniper_official/Protocols/Fib/fib.yml
+++ b/juniper_official/Protocols/Fib/fib.yml
@@ -2,7 +2,7 @@
 FibSummaryTable:
   rpc: get-forwarding-table-information
   args:
-    summary: True
+    summary: !!bool True
   item: route-table
   key:
     - table-name

--- a/juniper_official/Protocols/Infra/task-memory.yml
+++ b/juniper_official/Protocols/Infra/task-memory.yml
@@ -2,7 +2,7 @@
 taskMemory:
   rpc: get-task-memory-information
   args:
-    detail: True
+    detail: !!bool True
   item: .
   key: task-memory-overall-report
   view: taskMemoryDetailView

--- a/juniper_official/Solutions/Krt-async-stuck/krtcorrtable.yml
+++ b/juniper_official/Solutions/Krt-async-stuck/krtcorrtable.yml
@@ -1,3 +1,4 @@
+---
 krtcorrtable:
   rpc: get-async-cor-stats
   item: krt-tree-statistics

--- a/juniper_official/Solutions/Krt-async-stuck/krtiotable.yml
+++ b/juniper_official/Solutions/Krt-async-stuck/krtiotable.yml
@@ -1,3 +1,4 @@
+---
 krtiotable:
   rpc: get-async-io-stats
   item: krt-io-statistics-entry

--- a/juniper_official/Solutions/Krt-async-stuck/krtstate.yml
+++ b/juniper_official/Solutions/Krt-async-stuck/krtstate.yml
@@ -1,3 +1,4 @@
+---
 krtstate:
   rpc: get-krt-state
   key: krtq-time-until-next-run

--- a/juniper_official/Solutions/Mpls-blackhole-detection/rsvpsession.yml
+++ b/juniper_official/Solutions/Mpls-blackhole-detection/rsvpsession.yml
@@ -2,7 +2,7 @@
 RsvpSessionTable:
   rpc: get-rsvp-session-information
   args:
-    extensive: False
+    extensive: !!bool False
   item: rsvp-session-data/rsvp-session
   key:
     - name


### PR DESCRIPTION
Fixing warnings only. 
No functional change.
Tested e.g. `/Protocols/Infra/task-memory.rule` end-to-end on Healthbot server.
After this change, 3 yamllint warnings still remain related to line-length > 80.

