### PR TITLE
Added initial files for two rules

### DIFF
--- a/juniper_official/Security/get-dev-key-state.py
+++ b/juniper_official/Security/get-dev-key-state.py
@@ -1,0 +1,55 @@
+import re
+import jnpr.junos
+
+"""
+This function will run /usr/sbin/check-secureboot-status.sh
+on the host and check if the development keys have been revoked.
+This is achieved by calling efi-updatevar on the host.
+
+This function will return the following values and a msg
+0 : Green, "Juniper Dev keys are not revoked. Doing nothing"
+           "Dev key revocation status: Success"
+1 : Yellow, "State of Development keys unknown" (Fallthrough case)
+2 : Red, "Dev key revocation status: Failure"
+
+Note: "Dev key revocation status: ?" would appear very rarely. Success would
+only appear once when command is issues. "Failure" could appear continuously,
+so the user would likely want to know if the revocation command was issued but
+there are still keys that need to be revoked.
+"""
+
+def run():
+    dev_key_color_result = 1
+    dev = __proxy__['junos.conn']()
+
+    """ This rule needs to be run as root """
+    root = False
+    try:
+        op_cli = dev.rpc.request_shell_execute(command="/usr/bin/whoami")
+    except jnpr.junos.exception.RpcError:
+        dev_key_msg = "feature unsupported"
+        return ({'fields':{"sb_color_result": sb_color_result, "dev_key_msg": dev_key_msg}})
+
+    if hasattr(op_cli, 'xpath'):
+        user = op_cli.xpath('.')
+        root = bool(user[0].text.strip('\n') == 'root')
+
+    if not root:
+        dev_key_msg = "Rule must be run as root."
+        return ({'fields':{"sb_color_result": sb_color_result, "dev_key_msg": dev_key_msg}})
+
+    op1 = dev.rpc.request_shell_execute(command="/bin/sh /usr/sbin/check-secureboot-status.sh | grep \"Dev Key Revocation Status:\"")
+    obj1 = re.search('(?<=: ).*',op1.text)
+    dev_key_msg = obj1.group(0)
+
+    if (obj1.group(0) == "Juniper Dev keys are not revoked. Doing nothing"): #Green
+        dev_key_color_result = 0
+    elif (obj1.group(0) == "Dev key revocation status: Success"): #Green
+        dev_key_color_result = 0
+    elif (obj1.group(0) == "Dev key revocation status: Failure"): #Red
+        dev_key_color_result = 2
+    else: #Yellow, fallthrough case
+        dev_key_color_result = 1
+        dev_key_msg = "State of Development keys unknown"
+
+    return ({'fields':{"dev_key_color_result": dev_key_color_result, "dev_key_msg": dev_key_msg}})

--- a/juniper_official/Security/get-dev-key-state.rule
+++ b/juniper_official/Security/get-dev-key-state.rule
@@ -1,0 +1,89 @@
+/*
+ * This rule checks if development keys have been left on the system.
+ * 
+ * If development keys were present, this rule will report the results
+ * of the attempted revocation as Successful or a Failure.
+ * This rule relies on a file present in 19.3R1 and further.
+ */
+healthbot {
+    topic security {
+        rule get-dev-key-status {
+            sensor dev-key-sensor {
+                iAgent {
+                    file get-dev-key-state.yml;
+                    table devkeyTable;
+                    frequency 4w;
+                }
+            }
+            trigger get-dev-key-status-trigger {
+                frequency 4w;
+                term dev-key-ok {
+                    when {
+                        equal-to "$dev_key_color_result" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$dev_key_msg";
+                        }
+                    }
+                }
+                term dev-key-not-ok {
+                    when {
+                        equal-to "$dev_key_color_result" 2;
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$dev_key_msg";
+                        }
+                    }
+                }
+                term dev-key-unknown {
+                    then {
+                        status {
+                            color yellow;
+                            message "$dev_key_msg";
+                        }
+                    }
+                }
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                }
+                            }
+                            products NFX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                }
+                            }
+                            products PTX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                }
+                            }
+                            products QFX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                }
+                            }
+                            products SRX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Security/get-dev-key-state.yml
+++ b/juniper_official/Security/get-dev-key-state.yml
@@ -1,0 +1,3 @@
+---
+devkeyTable:
+    udf: get-dev-key-state

--- a/juniper_official/Security/readme.md
+++ b/juniper_official/Security/readme.md
@@ -1,0 +1,23 @@
+# Security management healthbot rules
+#
+** Synopsis **
+
+This folder contains healthbot rules to check security based metrics and notify
+when they are anomalous.
+
+** Rule Index **
+
+Rule1 - get-dev-key-state.rule - This rule checks the state of development keys
+on the host and will notify if the state is unknown or they were unable to be
+revoked. This rule only applies to specific platforms. Rule must be run as root.
+Sensor type : iAgent
+Input variables : N/A
+Dependency file(s) : get-dev-key-state.yml get-dev-key-state.py
+
+Rule2 - test-secure-boot-status.rule - This rule checks checks if secureboot is
+enabled and enforced and will return with an error state otherwise. This rule
+only applies to platforms where secureboot is available. Rule must be run as
+root.
+Sensor type: iAgent
+Input variables : N/A
+Dependency file(s): test-secure-boot-status.yml test-secure-boot-status.py

--- a/juniper_official/Security/test-secure-boot-status.py
+++ b/juniper_official/Security/test-secure-boot-status.py
@@ -1,0 +1,50 @@
+import re
+import jnpr.junos
+
+"""
+This function will run /usr/sbin/check-secureboot-status.sh
+on the host and pull the relevant secure boot information.
+
+This function will return the following values and a msg
+0 : Green, Secure boot status is good, or SB is not available
+    on this platform and the rule should be removed.
+1 : Yellow, Secure boot status is unknown
+2 : Red, Secure boot status is not enabled or not enforced
+"""
+
+def run():
+    sb_color_result = 1
+    dev = __proxy__['junos.conn']()
+
+    """ This rule needs to be run as root """
+    root = False
+    try:
+        op_cli = dev.rpc.request_shell_execute(command="/usr/bin/whoami")
+    except jnpr.junos.exception.RpcError:
+        sb_msg = "feature unsupported"
+        return ({'fields':{"sb_color_result": sb_color_result, "sb_msg": sb_msg}})
+
+    if hasattr(op_cli, 'xpath'):
+        user = op_cli.xpath('.')
+        root = bool(user[0].text.strip('\n') == 'root')
+    
+    if not root:
+        sb_msg = "Rule must be run as root."
+        return ({'fields':{"sb_color_result": sb_color_result, "sb_msg": sb_msg}})
+
+    op1 = dev.rpc.request_shell_execute(command="/bin/sh /usr/sbin/check-secureboot-status.sh | grep \"Secure Boot Status:\"")
+
+    obj1 = re.search('(?<=: ).*',op1.text)
+    sb_msg = obj1.group(0)
+
+    if (obj1.group(0) == "Secure Boot is enforced."): #Green
+        sb_color_result = 0
+    elif (obj1.group(0) == "Secure Boot is either not enabled or not enforced."): #Red
+        sb_color_result = 2
+    elif (obj1.group(0) == "Secure Boot status is unknown"): #Yellow
+        sb_color_result = 1
+    else: #Green, fallthrough case
+        sb_color_result = 0
+        sb_msg = "Secure Boot is not availble on this platform"
+
+    return ({'fields':{"sb_color_result": sb_color_result, "sb_msg": sb_msg}})

--- a/juniper_official/Security/test-secure-boot-status.rule
+++ b/juniper_official/Security/test-secure-boot-status.rule
@@ -1,0 +1,103 @@
+/*
+ * This rule checks if secureboot is running and enforced and returns
+ * an error if it is not.
+ *
+ * This rule relies on a file present in 19.3R1 and beyond.
+ * This rule is only applicible to devices where secureboot is capable.
+ * If this rule is run on a device that is incapable of secureboot,
+ * the result will be "secureboot status is unknonw" and the rule should be
+ * removed.
+ */
+healthbot {
+    topic security {
+        rule check-secureboot-status {
+            sensor secureboot-sensor {
+                iAgent {
+                    file test-secure-boot-status.yml;
+                    table securebootTable;
+                    frequency 4w;
+                }
+            }
+            trigger check-secureboot-status-trigger {
+                frequency 4w;
+                term secure-boot-enforced {
+                    when {
+                        equal-to "$sb_color_result" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$sb_msg";
+                        }
+                    }
+                }
+                term secure-boot-not-enabled {
+                    when {
+                        equal-to "$sb_color_result" 2;
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$sb_msg";
+                        }
+                    }
+                }
+                term secure-boot-unknown {
+                    then {
+                        status {
+                            color yellow;
+                            message "$sb_msg";
+                        }
+                    }
+                }
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 1.0.1;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products EX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                    platform [ EX4650-48Y EX9251 EX9253 ];
+                                }
+                            }
+                            products MX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX10003 MX10008 MX2008 MX2010 MX2020 MX204 MX240 MX480 MX960 ];
+                                }
+                            }
+                            products NFX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                    platform NFX250;
+                                }
+                            }
+                            products PTX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                    platform [ PTX10008 PTX10016 PTX3000 PTX5000 ];
+                                }
+                            }
+                            products QFX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                    platform [ QFX10002-60C QFX10008 QFX10016 QFX5110 QFX5120-48Y ];
+                                }
+                            }
+                            products SRX {
+                                releases 19.3R1 {
+                                    release-support min-supported-release;
+                                    platform [ SRX1500 SRX4600 ];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Security/test-secure-boot-status.yml
+++ b/juniper_official/Security/test-secure-boot-status.yml
@@ -1,0 +1,3 @@
+---
+securebootTable:
+    udf: test-secure-boot-status


### PR DESCRIPTION
Hello, I'm a Juniper employee in the Cybersecurity R&D team, we have written two "security" rules to be implemented.

We are unfamiliar with the process, I believe I have followed the steps listed in the Read.me. I have requested access to healthbot-rules-official in jam, still waiting on acceptance.

Please let me know how to proceed from here, and what changes need to be made to these rules and files.

Thank you,
William Bellingrath

---- Original commit message ----
Two initial Rules for Healthbot.
Rule 1 "get-dev-key-state" to check for the status of developer keys.
Rule 2 "test-secure-boot-status" to check if secureboot is running.