### PR TITLE
Remove catalogue tier info from the rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ######################
 .DS_Store
 .DS_Store?
+.idea
 ehthumbs.db
 Icon?
 Thumbs.db

--- a/community_supplied/Interface/snmp-interface-status.rule
+++ b/community_supplied/Interface/snmp-interface-status.rule
@@ -617,9 +617,6 @@ iceberg {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/community_supplied/Solutions/EVO/evo-system-storage.rule
+++ b/community_supplied/Solutions/EVO/evo-system-storage.rule
@@ -126,9 +126,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/chassis-fan-health.rule
+++ b/juniper_official/Chassis/chassis-fan-health.rule
@@ -65,9 +65,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/chassis-temperature.rule
+++ b/juniper_official/Chassis/chassis-temperature.rule
@@ -149,9 +149,6 @@ healthbot {
                 version 2;
                     contributor juniper;
                     supported-healthbot-version 1.0.1;
-                    catalogue {
-                        tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/fpc-temperature.rule
+++ b/juniper_official/Chassis/fpc-temperature.rule
@@ -158,9 +158,6 @@ healthbot {
                 version 2;
                     contributor juniper;
                     supported-healthbot-version 1.0.1;
-                    catalogue {
-                        tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/netsvc.rule
+++ b/juniper_official/Chassis/netsvc.rule
@@ -41,9 +41,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/pem-power-usage.rule
+++ b/juniper_official/Chassis/pem-power-usage.rule
@@ -302,9 +302,6 @@ healthbot {
                 version 2;
                     contributor juniper;
                     supported-healthbot-version 1.0.1;
-                    catalogue {
-                        tier 1;
-                    }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/re-cpu-temperature.rule
+++ b/juniper_official/Chassis/re-cpu-temperature.rule
@@ -159,9 +159,6 @@ healthbot {
                 version 2;
                     contributor juniper;
                     supported-healthbot-version 1.0.1;
-                    catalogue {
-                        tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/re-temperature.rule
+++ b/juniper_official/Chassis/re-temperature.rule
@@ -158,9 +158,6 @@ healthbot {
                 version 2;
                     contributor juniper;
                     supported-healthbot-version 1.0.1;
-                    catalogue {
-                        tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/system-power-usage.rule
+++ b/juniper_official/Chassis/system-power-usage.rule
@@ -139,9 +139,6 @@ healthbot {
                 version 2;
                     contributor juniper;
                     supported-healthbot-version 1.0.1;
-                    catalogue {
-                        tier 1;
-                    }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/system-virtual-memory.rule
+++ b/juniper_official/Chassis/system-virtual-memory.rule
@@ -102,9 +102,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/zone-power-usage.rule
+++ b/juniper_official/Chassis/zone-power-usage.rule
@@ -123,9 +123,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/EVO/evo-system-storage.rule
+++ b/juniper_official/EVO/evo-system-storage.rule
@@ -126,9 +126,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/health-monitor-based-on-interface-description.rule
+++ b/juniper_official/Interfaces/health-monitor-based-on-interface-description.rule
@@ -207,9 +207,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-flaps-iagent.rule
+++ b/juniper_official/Interfaces/interface-flaps-iagent.rule
@@ -94,9 +94,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-flaps.rule
+++ b/juniper_official/Interfaces/interface-flaps.rule
@@ -160,9 +160,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-in-errors-iagent.rule
+++ b/juniper_official/Interfaces/interface-in-errors-iagent.rule
@@ -94,9 +94,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-in-errors.rule
+++ b/juniper_official/Interfaces/interface-in-errors.rule
@@ -155,9 +155,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-in-traffic-iagent.rule
+++ b/juniper_official/Interfaces/interface-in-traffic-iagent.rule
@@ -107,9 +107,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-in-traffic.rule
+++ b/juniper_official/Interfaces/interface-in-traffic.rule
@@ -177,9 +177,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-input-output-traffic-snmp.rule
+++ b/juniper_official/Interfaces/interface-input-output-traffic-snmp.rule
@@ -232,9 +232,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-neighbor-state.rule
+++ b/juniper_official/Interfaces/interface-neighbor-state.rule
@@ -137,9 +137,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-out-errors-netconf.rule
+++ b/juniper_official/Interfaces/interface-out-errors-netconf.rule
@@ -105,9 +105,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-out-errors.rule
+++ b/juniper_official/Interfaces/interface-out-errors.rule
@@ -151,9 +151,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-out-traffic-iagent.rule
+++ b/juniper_official/Interfaces/interface-out-traffic-iagent.rule
@@ -107,9 +107,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-out-traffic.rule
+++ b/juniper_official/Interfaces/interface-out-traffic.rule
@@ -176,9 +176,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-status-iagent.rule
+++ b/juniper_official/Interfaces/interface-status-iagent.rule
@@ -61,9 +61,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/interface-status.rule
+++ b/juniper_official/Interfaces/interface-status.rule
@@ -116,9 +116,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/logical-interface-in-traffic.rule
+++ b/juniper_official/Interfaces/logical-interface-in-traffic.rule
@@ -192,9 +192,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Interfaces/logical-interface-out-traffic.rule
+++ b/juniper_official/Interfaces/logical-interface-out-traffic.rule
@@ -192,9 +192,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/cm-error.rule
+++ b/juniper_official/Linecard/cm-error.rule
@@ -62,9 +62,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/cm-events.rule
+++ b/juniper_official/Linecard/cm-events.rule
@@ -163,9 +163,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/fi-error.rule
+++ b/juniper_official/Linecard/fi-error.rule
@@ -181,9 +181,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/fi-statistics.rule
+++ b/juniper_official/Linecard/fi-statistics.rule
@@ -170,9 +170,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/fpc-cpu-utilization.rule
+++ b/juniper_official/Linecard/fpc-cpu-utilization.rule
@@ -167,9 +167,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                        tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/fpc-memory-utilization.rule
+++ b/juniper_official/Linecard/fpc-memory-utilization.rule
@@ -271,9 +271,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/fpc-threads.rule
+++ b/juniper_official/Linecard/fpc-threads.rule
@@ -54,9 +54,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/fpc-utilization.rule
+++ b/juniper_official/Linecard/fpc-utilization.rule
@@ -153,9 +153,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/host-drops.rule
+++ b/juniper_official/Linecard/host-drops.rule
@@ -46,9 +46,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/host-loopback-status.rule
+++ b/juniper_official/Linecard/host-loopback-status.rule
@@ -67,9 +67,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/ithrottle-id.rule
+++ b/juniper_official/Linecard/ithrottle-id.rule
@@ -223,9 +223,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/ithrottle.rule
+++ b/juniper_official/Linecard/ithrottle.rule
@@ -126,9 +126,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/jnh-exceptions.rule
+++ b/juniper_official/Linecard/jnh-exceptions.rule
@@ -69,9 +69,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/jnh-ifd-stream.rule
+++ b/juniper_official/Linecard/jnh-ifd-stream.rule
@@ -96,9 +96,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/li-statistics.rule
+++ b/juniper_official/Linecard/li-statistics.rule
@@ -55,9 +55,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/linecard-ethernet-statistics.rule
+++ b/juniper_official/Linecard/linecard-ethernet-statistics.rule
@@ -50,9 +50,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/lo-statistics.rule
+++ b/juniper_official/Linecard/lo-statistics.rule
@@ -56,9 +56,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/online-fpc.rule
+++ b/juniper_official/Linecard/online-fpc.rule
@@ -22,9 +22,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/pci-error.rule
+++ b/juniper_official/Linecard/pci-error.rule
@@ -43,9 +43,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/pt-statistics.rule
+++ b/juniper_official/Linecard/pt-statistics.rule
@@ -85,9 +85,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/scheduler-info.rule
+++ b/juniper_official/Linecard/scheduler-info.rule
@@ -164,9 +164,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/toe-pfe.rule
+++ b/juniper_official/Linecard/toe-pfe.rule
@@ -163,9 +163,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Linecard/wo-statistics.rule
+++ b/juniper_official/Linecard/wo-statistics.rule
@@ -46,9 +46,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Bgp/bgp-advertised-routes-kpi.rule
+++ b/juniper_official/Protocols/Bgp/bgp-advertised-routes-kpi.rule
@@ -193,9 +193,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Bgp/bgp-neighbor-flap-detection.rule
+++ b/juniper_official/Protocols/Bgp/bgp-neighbor-flap-detection.rule
@@ -153,9 +153,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Bgp/bgp-neighbor-flap-iagent.rule
+++ b/juniper_official/Protocols/Bgp/bgp-neighbor-flap-iagent.rule
@@ -109,9 +109,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Bgp/bgp-neighbor-state-iagent.rule
+++ b/juniper_official/Protocols/Bgp/bgp-neighbor-state-iagent.rule
@@ -67,9 +67,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Bgp/bgp-neighbor-state.rule
+++ b/juniper_official/Protocols/Bgp/bgp-neighbor-state.rule
@@ -100,9 +100,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Bgp/bgp-received-routes-kpi.rule
+++ b/juniper_official/Protocols/Bgp/bgp-received-routes-kpi.rule
@@ -193,9 +193,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Fib/fib-summary.rule
+++ b/juniper_official/Protocols/Fib/fib-summary.rule
@@ -168,9 +168,6 @@
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Infra/task-io.rule
+++ b/juniper_official/Protocols/Infra/task-io.rule
@@ -104,9 +104,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Infra/task-memory.rule
+++ b/juniper_official/Protocols/Infra/task-memory.rule
@@ -91,9 +91,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Isis/isis-adjacency.rule
+++ b/juniper_official/Protocols/Isis/isis-adjacency.rule
@@ -134,9 +134,6 @@
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Isis/isis-statistics.rule
+++ b/juniper_official/Protocols/Isis/isis-statistics.rule
@@ -384,9 +384,6 @@
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Lldp/lldp-session-state.rule
+++ b/juniper_official/Protocols/Lldp/lldp-session-state.rule
@@ -140,9 +140,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Lldp/lldp-session-statistics.rule
+++ b/juniper_official/Protocols/Lldp/lldp-session-statistics.rule
@@ -447,9 +447,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Mpls/check-lsp-flap-count-oc.rule
+++ b/juniper_official/Protocols/Mpls/check-lsp-flap-count-oc.rule
@@ -103,9 +103,6 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Mpls/check-lsp-state-oc.rule
+++ b/juniper_official/Protocols/Mpls/check-lsp-state-oc.rule
@@ -88,9 +88,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Mpls/check-rsvp-neighbor-state-oc.rule
+++ b/juniper_official/Protocols/Mpls/check-rsvp-neighbor-state-oc.rule
@@ -99,9 +99,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Mpls/check-te-rsvp-global-errors-oc.rule
+++ b/juniper_official/Protocols/Mpls/check-te-rsvp-global-errors-oc.rule
@@ -422,9 +422,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Mpls/check-te-rsvp-interface-errors-oc.rule
+++ b/juniper_official/Protocols/Mpls/check-te-rsvp-interface-errors-oc.rule
@@ -434,9 +434,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Ospf/ddos-statistics.rule
+++ b/juniper_official/Protocols/Ospf/ddos-statistics.rule
@@ -185,9 +185,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Ospf/fpc-link-stats.rule
+++ b/juniper_official/Protocols/Ospf/fpc-link-stats.rule
@@ -49,9 +49,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Ospf/ospf-io-statistics.rule
+++ b/juniper_official/Protocols/Ospf/ospf-io-statistics.rule
@@ -69,9 +69,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Ospf/ospf-kernel-route.rule
+++ b/juniper_official/Protocols/Ospf/ospf-kernel-route.rule
@@ -67,9 +67,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Ospf/ospf-neighbor-information.rule
+++ b/juniper_official/Protocols/Ospf/ospf-neighbor-information.rule
@@ -75,9 +75,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Ospf/ospf-neighbor-state.rule
+++ b/juniper_official/Protocols/Ospf/ospf-neighbor-state.rule
@@ -73,9 +73,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Ospf/ospf-statistics.rule
+++ b/juniper_official/Protocols/Ospf/ospf-statistics.rule
@@ -102,9 +102,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Ospf/pfe-ddos-policer.rule
+++ b/juniper_official/Protocols/Ospf/pfe-ddos-policer.rule
@@ -117,9 +117,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Rib/route-table-protocol-summary.rule
+++ b/juniper_official/Protocols/Rib/route-table-protocol-summary.rule
@@ -159,9 +159,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Protocols/Rib/route-tables-summary.rule
+++ b/juniper_official/Protocols/Rib/route-tables-summary.rule
@@ -169,9 +169,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Security/check-alarm-status-netconf.rule
+++ b/juniper_official/Security/check-alarm-status-netconf.rule
@@ -94,9 +94,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.1;
-                    catalogue {
-                        tier 1;
-                    }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Security/check-appid-asc-cache-status-netconf.rule
+++ b/juniper_official/Security/check-appid-asc-cache-status-netconf.rule
@@ -84,9 +84,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.1;
-                    catalogue {
-                        tier 1;
-                    }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Security/check-cpu-memory-utilization-netconf.rule
+++ b/juniper_official/Security/check-cpu-memory-utilization-netconf.rule
@@ -234,9 +234,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.1;
-                    catalogue {
-                        tier 1;
-                    }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Security/check-idp-memory-counter-netconf.rule
+++ b/juniper_official/Security/check-idp-memory-counter-netconf.rule
@@ -470,9 +470,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.1;
-                    catalogue {
-                        tier 1;
-                    }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Security/check-idp-memory-utilization-netconf.rule
+++ b/juniper_official/Security/check-idp-memory-utilization-netconf.rule
@@ -164,9 +164,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.1;
-                    catalogue {
-                        tier 1;
-                    }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack-v4.rule
+++ b/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack-v4.rule
@@ -121,9 +121,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack-v6.rule
+++ b/juniper_official/Solutions/Bgp-route-hijack/bgp-route-hijack-v6.rule
@@ -121,9 +121,6 @@
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/bfd-session-state.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/bfd-session-state.rule
@@ -61,9 +61,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-bpdu-errors-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-bpdu-errors-netconf.rule
@@ -80,9 +80,6 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-df-correlation-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-df-correlation-netconf.rule
@@ -113,9 +113,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-flabels-count-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-flabels-count-netconf.rule
@@ -87,9 +87,6 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-irb-mac-count-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-irb-mac-count-netconf.rule
@@ -80,9 +80,6 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-lacp-state-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-lacp-state-netconf.rule
@@ -107,9 +107,6 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-mac-count-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-mac-count-netconf.rule
@@ -110,9 +110,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-multihomed-state-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-multihomed-state-netconf.rule
@@ -66,9 +66,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-remote-vtep-count-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-remote-vtep-count-netconf.rule
@@ -118,9 +118,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -196,9 +193,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-rvi-reachability-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-rvi-reachability-netconf.rule
@@ -95,9 +95,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -129,9 +126,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/check-stp-state-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/check-stp-state-netconf.rule
@@ -92,9 +92,6 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/evpn-advertised-prefix.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/evpn-advertised-prefix.rule
@@ -116,9 +116,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/evpn-db-state-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/evpn-db-state-netconf.rule
@@ -89,9 +89,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/evpn-received-prefix.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/evpn-received-prefix.rule
@@ -117,9 +117,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/evpn-route-count.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/evpn-route-count.rule
@@ -91,9 +91,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -148,9 +145,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/evpn-vxlan-monitor-count-online-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/evpn-vxlan-monitor-count-online-netconf.rule
@@ -97,9 +97,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -200,9 +197,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/irb-interface-status.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/irb-interface-status.rule
@@ -72,9 +72,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/irb-interface-traffic.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/irb-interface-traffic.rule
@@ -131,9 +131,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/irb-next-hops.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/irb-next-hops.rule
@@ -134,9 +134,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/verify-mac-ip-netconf.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/verify-mac-ip-netconf.rule
@@ -19,9 +19,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -102,9 +99,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-count.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-count.rule
@@ -48,9 +48,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -148,9 +145,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-error.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-error.rule
@@ -139,9 +139,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-flap.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-flap.rule
@@ -89,9 +89,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-status.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-status.rule
@@ -95,9 +95,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-traffic.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/vtep-interface-traffic.rule
@@ -158,9 +158,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/vtep-tunnel-statistics.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/vtep-tunnel-statistics.rule
@@ -196,9 +196,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/EVPN-VXLAN/vxlan-vport.rule
+++ b/juniper_official/Solutions/EVPN-VXLAN/vxlan-vport.rule
@@ -100,9 +100,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.1.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/Icmp-outlier/icmp.rule
+++ b/juniper_official/Solutions/Icmp-outlier/icmp.rule
@@ -216,9 +216,6 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 2.0.0;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/L3-vpn-view/l3vpn-network.rule
+++ b/juniper_official/Solutions/L3-vpn-view/l3vpn-network.rule
@@ -209,9 +209,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -325,9 +322,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -441,9 +435,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/Microburst/microburst-oc.rule
+++ b/juniper_official/Solutions/Microburst/microburst-oc.rule
@@ -115,9 +115,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 2.1.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/Microburst/microburst.rule
+++ b/juniper_official/Solutions/Microburst/microburst.rule
@@ -106,9 +106,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/Mpls-blackhole-detection/jnh-drop-packets.rule
+++ b/juniper_official/Solutions/Mpls-blackhole-detection/jnh-drop-packets.rule
@@ -69,9 +69,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/Mpls-blackhole-detection/rsvp-status.rule
+++ b/juniper_official/Solutions/Mpls-blackhole-detection/rsvp-status.rule
@@ -35,9 +35,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Solutions/System-blackhole-detection/system-traffic.rule
+++ b/juniper_official/Solutions/System-blackhole-detection/system-traffic.rule
@@ -139,9 +139,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Subscriber-Service/address-pool-utilization.rule
+++ b/juniper_official/Subscriber-Service/address-pool-utilization.rule
@@ -167,9 +167,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -313,9 +310,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Subscriber-Service/monitor-subscriber-count.rule
+++ b/juniper_official/Subscriber-Service/monitor-subscriber-count.rule
@@ -108,9 +108,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
+++ b/juniper_official/Subscriber-Service/pppoe-error-statistics.rule
@@ -266,9 +266,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 2;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/fpc-memory.rule
+++ b/juniper_official/System/fpc-memory.rule
@@ -93,9 +93,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/pfe-traffic-statistics.rule
+++ b/juniper_official/System/pfe-traffic-statistics.rule
@@ -201,9 +201,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/pre-classifier.rule
+++ b/juniper_official/System/pre-classifier.rule
@@ -117,9 +117,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/re-cpu-utilization.rule
+++ b/juniper_official/System/re-cpu-utilization.rule
@@ -157,9 +157,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/software-version.rule
+++ b/juniper_official/System/software-version.rule
@@ -89,9 +89,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-cpu-load-average.rule
+++ b/juniper_official/System/system-cpu-load-average.rule
@@ -341,9 +341,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-cpu.rule
+++ b/juniper_official/System/system-cpu.rule
@@ -193,9 +193,6 @@ healthbot {
                 version 2;
                     contributor juniper;
                     supported-healthbot-version 1.0.1;
-                    catalogue {
-                        tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-memory.rule
+++ b/juniper_official/System/system-memory.rule
@@ -171,9 +171,6 @@ healthbot {
                 version 2;
                     contributor juniper;
                     supported-healthbot-version 1.0.1;
-                    catalogue {
-                        tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-proc-ext.rule
+++ b/juniper_official/System/system-proc-ext.rule
@@ -105,9 +105,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-processes-cpu.rule
+++ b/juniper_official/System/system-processes-cpu.rule
@@ -188,9 +188,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-processes-memory.rule
+++ b/juniper_official/System/system-processes-memory.rule
@@ -224,9 +224,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-queues.rule
+++ b/juniper_official/System/system-queues.rule
@@ -117,9 +117,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {
@@ -289,9 +286,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-statistics-ip.rule
+++ b/juniper_official/System/system-statistics-ip.rule
@@ -86,9 +86,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-storage-capacity.rule
+++ b/juniper_official/System/system-storage-capacity.rule
@@ -92,9 +92,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/system-storage.rule
+++ b/juniper_official/System/system-storage.rule
@@ -162,9 +162,6 @@ healthbot {
                 version 2;
                 contributor juniper;
                 supported-healthbot-version 1.0.1;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/vmhost-cpu-iagent.rule
+++ b/juniper_official/System/vmhost-cpu-iagent.rule
@@ -217,9 +217,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/vmhost-memory-monitoring.rule
+++ b/juniper_official/System/vmhost-memory-monitoring.rule
@@ -187,9 +187,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                    catalogue {
-                        tier 1;
-                    }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/vmhost-mgmt-interface-status-iagent.rule
+++ b/juniper_official/System/vmhost-mgmt-interface-status-iagent.rule
@@ -107,9 +107,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/vmhost-resource-status-iagent.rule
+++ b/juniper_official/System/vmhost-resource-status-iagent.rule
@@ -67,9 +67,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/vmhost-status-iagent.rule
+++ b/juniper_official/System/vmhost-status-iagent.rule
@@ -90,9 +90,6 @@
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/System/vmhost-storage-iagent.rule
+++ b/juniper_official/System/vmhost-storage-iagent.rule
@@ -152,9 +152,6 @@ healthbot {
                 version 1;
                 contributor juniper;
                 supported-healthbot-version 3.0.0;
-                catalogue {
-                    tier 1;
-                }
                 supported-devices {
                     juniper {
                         operating-system junos {


### PR DESCRIPTION
Remove catalogue tier info from the rule. This is based on user feedback and also business decision. The classification of default rules for licensing which used to be based on the tiers, will now be based on the features used in the rule. So, for example, if a rule has user defined function or AI/ML formula, then it is considered as advanced rule. 