### PR TITLE
Changed field 'index' path

### DIFF
--- a/juniper_official/Interfaces/interface-input-output-traffic-snmp.rule
+++ b/juniper_official/Interfaces/interface-input-output-traffic-snmp.rule
@@ -60,7 +60,7 @@ healthbot {
             }
             field index {
                 sensor input-output-bytes {
-                    path ifIndex;
+                    path index;
                 }
                 type string;
                 description "This field contains interface index value";


### PR DESCRIPTION
Changed field 'index' path from "IfIndex" to "index". 
In earlier release there was a bug where if the key was missing also we were accepting the data which was resulting in unexpected behaviors.