### PR TITLE
updated check-krt-io-table rule

### DIFF
--- a/juniper_official/Kernel/krtasync.rule
+++ b/juniper_official/Kernel/krtasync.rule
@@ -197,6 +197,7 @@ healthbot {
             }
         }
         rule check-krt-io-table {
+            keys krt-io-task-name;
             sensor krtiotable {
                 iAgent {
                     file krtiotable.yml;
@@ -213,6 +214,7 @@ healthbot {
             }
             field krt-io-task-name {
                 sensor krtiotable {
+                    where "krt-io-task-name == 'KRT IO task'";
                     path krt-io-task-name;
                 }
                 type string;


### PR DESCRIPTION
Following issue is fixed in this update
issue no. #47 : In check-krt-io-table rule the field krt-io-task-name should be added to Rule Key