### PR TITLE
HB 3.1.0 new/modified KPIs list

### DIFF
--- a/juniper_official/Chassis/chassis-fan-health.rule
+++ b/juniper_official/Chassis/chassis-fan-health.rule
@@ -7,7 +7,7 @@ healthbot {
         synopsis "Chassis environment analyzer";
         rule check-fan-health {
             synopsis "Chassis fans health analyzer";
-            description "Collects chassis fan statistics periodically and notifies anomalies when fan status is NOK";
+            description "Collects chassis environment statistics periodically and notifies anomalies when fan status is NOK";
             /*
              * Monitors all the chassis fans. Notifies via the dashboard
              * colors when the fan status is OK to green. Otherwise the
@@ -15,18 +15,35 @@ healthbot {
              * 
              * Use fan name as key for rule.
              */
-             keys fan-name;
+             keys name;
             /*
              * sensor configuration to get data from network devices
              */
             sensor chassis-fan {
                 synopsis "iAgent sensor definition";
-                description "iAgent sensor using show-chassis-fan command to collect data from network device";
+                description "iAgent sensor using get-environment-information rpc command to collect data from network device";
                 iAgent {
                     file chassis-fan.yml;
-                    table ChassisFanTable;
+                    table ChassisEnvTable
                     frequency 60s;
                 }
+            }
+            field comment {
+                sensor chassis-env-fan-sensor {
+                    path comment;
+                }
+                type string;
+            }
+            field name {
+                sensor chassis-env-fan-sensor {
+                    path name;
+                }
+            }
+            field status {
+                sensor chassis-env-fan-sensor {
+                    path status;
+                }
+                type string;
             }
             /*
              * Anomaly detection logic.
@@ -34,18 +51,20 @@ healthbot {
             trigger fan-status {
                 synopsis "Chassis fan health KPI";
                 description "Sets health based on chassis fan status and speed";
-                frequency 60s; 
+                frequency 90s; 
                 /*
                  * Sets color to green when fan status is OK.
                  */
                 term is-fan-health-good {
                     when {
-                        matches-with "$fan-status" OK;
+                        matches-with "$status" OK {
+                            ignore-case;
+                        }
                     }
                     then {
                         status {
                             color green;
-                            message "$fan-name health-status is normal. $fan-measurement($fan-rpm rpm)";
+                            message "$name status is normal. $comment";
                         }
                     }
                 }
@@ -56,7 +75,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$fan-name health-status is $fan-status. $fan-measurement($fan-rpm rpm)";
+                            message "$name status is $status. $comment";
                         }
                     }
                 }
@@ -64,7 +83,7 @@ healthbot {
             rule-properties {
                 version 2;
                 contributor juniper;
-                supported-healthbot-version 1.0.1;
+                supported-healthbot-version 3.1.0;
                 supported-devices {
                     juniper {
                         operating-system junos {

--- a/juniper_official/Chassis/chassis-fan.yml
+++ b/juniper_official/Chassis/chassis-fan.yml
@@ -1,11 +1,11 @@
 ---
-ChassisFanTable:
-    command: show chassis fan
-    key: fan-name
-    view: ChassisFanView
-ChassisFanView:
-    columns:
-        fan-name: Item
-        fan-status: Status
-        fan-rpm: RPM
-        fan-measurement: Measurement
+ChassisEnvTable:
+    rpc: get-environment-information
+    item: environment-item[class="Fans"]
+    key: name
+    view: ChassisEnvView
+
+ChassisEnvView:
+    fields:
+        status: status
+        comment: comment

--- a/juniper_official/Interfaces/health-monitor-based-on-interface-description.rule
+++ b/juniper_official/Interfaces/health-monitor-based-on-interface-description.rule
@@ -130,7 +130,7 @@ healthbot {
                 /*
                  * Sets color to red and sends out an anomaly notification when
                  * the interface input traffic ($stats-value) is above high
-                 * threshold ($high-threshold) for all points in a 60 seconds
+                 * threshold ($high-threshold) for all points in a 180 seconds
                  * period.
                  */
                 term is-interface-stats-increasing-high-threshold {
@@ -150,7 +150,7 @@ healthbot {
                 /*
                  * Sets color to yellow and sends out an anomaly notification
                  * when the interface input traffic ($stats-value) exceed
-                 * threshold ($medium-threshold) for all points in 60 seconds
+                 * threshold ($medium-threshold) for all points in 180 seconds
                  * period.
                  */
                 term is-interface-stats-increasing-medium-threshold {

--- a/juniper_official/Interfaces/interface-flaps.rule
+++ b/juniper_official/Interfaces/interface-flaps.rule
@@ -97,7 +97,7 @@ healthbot {
                 /*
                  * Sets color to red and sends out an anomaly notification when
                  * the interface carrier-transition ($flaps) count increases for
-                 * all points in a 60 seconds period.
+                 * all points in a 180 seconds period.
                  */
                 term is-link-flapping-consistently {
                     when {


### PR DESCRIPTION
1. Modified chassis-fan-health.rule to collect the FAN status from rpc get-environment-information. The previous committed rule was not working for EX platform. Now it should work for all the platforms and products.