### PR TITLE
Resource Monitor Rules

### DIFF
--- a/juniper_official/Linecard/resource-monitor-cos-queue.rule
+++ b/juniper_official/Linecard/resource-monitor-cos-queue.rule
@@ -1,0 +1,76 @@
+healthbot {
+    topic linecard.pfe.resource  {
+        rule monitor-cos-queues-utilization {
+            keys [ fpc-slot pfe-num ];
+            synopsis "CoS queues analyser";
+            description "Collects periodically CoS queues utilization for each PFE instance in all FPCs and reports whether it is normal or exceeded threshold ";
+            sensor cos-queue-sensor {
+                iAgent {
+                    file resource-monitor-cos-queue.yml;
+                    table ResoureMonitorCosQueueTable;
+                    frequency 60s;
+                }
+            }
+            field cos-queue-threshold {
+                sensor cos-queue-sensor {
+                    path cos-queue-threshold;
+                }
+                type integer;
+                description "CoS queue utilization threshold value";
+            }
+            field cos-queue-used {
+                sensor cos-queue-sensor {
+                    path used-cos-queues;
+                }
+                type integer;
+                description "CoS queue utilization";
+            }
+            field cos-queue-used-percent {
+                sensor cos-queue-sensor {
+                    path used-cos-queues-percentage;
+                }
+                type integer;
+                description "Cos queue utilization in percent";
+            }
+            field fpc-slot {
+                sensor cos-queue-sensor {
+                    path ../fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field pfe-num {
+                sensor cos-queue-sensor {
+                    path pfe-num;
+                }
+                type string;
+                description "PFE instance in each FPC slot";
+            }
+            trigger report-cos-queue {
+                frequency 60s;
+                term normal {
+                    when {
+                        less-than "$cos-queue-used-percent" "$cos-queue-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] [CoS Queue] Used:$cos-queue-used($cos-queue-used-percent%) Threshold: $cos-queue-threshold";
+                        }
+                    }
+                }
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$cos-queue-used-percent" "$cos-queue-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] [CoS Queue] Used:$cos-queue-used($cos-queue-used-percent%) Threshold: $cos-queue-threshold";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-cos-queue.yml
+++ b/juniper_official/Linecard/resource-monitor-cos-queue.yml
@@ -1,0 +1,14 @@
+---
+ResoureMonitorCosQueueTable:
+    rpc: get-resource-monitor-summary-fpc-information
+    item: resource-monitor-summary-fpc-information-summary/resource-monitor-summary-cos-queue-utilization/pfe-num/parent::*
+    key:
+        - ../fpc-slot
+        - pfe-num
+    view: ResoureMonitorCosQueueMemoryView
+
+ResoureMonitorCosQueueMemoryView:
+    fields:
+        cos-queue-threshold: ../../resource-monitor-summary-fpc-information-summary-header/cos-queue-threshold
+        used-cos-queues: used-cos-queues
+        used-cos-queues-percentage: used-cos-queues-percentage

--- a/juniper_official/Linecard/resource-monitor-counter-expansion-mem.rule
+++ b/juniper_official/Linecard/resource-monitor-counter-expansion-mem.rule
@@ -1,0 +1,168 @@
+healthbot {
+    topic linecard.pfe.resource  {
+        rule monitor-counter-and-expansion-memory {
+            keys [ fpc-slot pfe-num ];
+            synopsis "Filter counter memory, IFL counter memory and expansion memory analyser";
+            description "Collects periodically Filter counter memory, IFL counter memory and Expansion memory utilisation for each PFE instance in all FPCs and reports whether it is normal or exceeded threshold ";
+            sensor asic-mem-sensor {
+                iAgent {
+                    file resource-monitor-counter-expansion-mem.yml;
+                    table ResoureMonitorSummaryPfeAsicMemTable;
+                    frequency 60s;
+                }
+            }
+            field expansion-mem-threshold {
+                sensor asic-mem-sensor {
+                    path expansion-memory-threshold;
+                }
+                type integer;
+                description "Expansion memory threshold value";
+            }
+            field expansion-mem-used {
+                sensor asic-mem-sensor {
+                    path used-expansion-memory;
+                }
+                type integer;
+                description "Expansion memory used";
+            }
+            field expansion-mem-used-percent {
+                sensor asic-mem-sensor {
+                    path used-expansion-memory-percent;
+                }
+                type integer;
+                description "Expansion memory used in percent";
+            }
+            field filter-counter-mem-threshold {
+                sensor asic-mem-sensor {
+                    path filter-counter-memory-threshold;
+                }
+                type integer;
+                description "Filter counter memory threshold value";
+            }
+            field filter-counter-mem-used {
+                sensor asic-mem-sensor {
+                    path used-filter-counter;
+                }
+                type integer;
+                description "Filter counter memory used";
+            }
+            field filter-counter-mem-used-percent {
+                sensor asic-mem-sensor {
+                    path used-filter-counter-percent;
+                }
+                type integer;
+                description "Filter counter memory used in percent";
+            }
+            field fpc-slot {
+                sensor asic-mem-sensor {
+                    path ../fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field ifl-counter-mem-threshold {
+                sensor asic-mem-sensor {
+                    path ifl-counter-memory-threshold;
+                }
+                type integer;
+                description "IFL counter memory threshold value";
+            }
+            field ifl-counter-mem-used {
+                sensor asic-mem-sensor {
+                    path used-ifl-counter;
+                }
+                type integer;
+                description "IFL counter memory used";
+            }
+            field ifl-counter-mem-used-percent {
+                sensor asic-mem-sensor {
+                    path used-ifl-counter-percent;
+                }
+                type integer;
+                description "IFL counter memory used in percent";
+            }
+            field pfe-num {
+                sensor asic-mem-sensor {
+                    path pfe-num;
+                }
+                type string;
+                description "PFE instance in each FPC slot";
+            }
+            trigger report-expansion-mem {
+                frequency 60s;
+                term normal {
+                    when {
+                        less-than "$expansion-mem-used-percent" "$expansion-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] Expansion memory used: $expansion-mem-used-percent ($expansion-mem-used) threshold: $expansion-mem-threshold";
+                        }
+                    }
+                }
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$expansion-mem-used-percent" "$expansion-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] Expansion memory used: $expansion-mem-used-percent ($expansion-mem-used) threshold: $expansion-mem-threshold";
+                        }
+                    }
+                }
+            }
+            trigger report-filter-ctr-mem {
+                frequency 60s;
+                term normal {
+                    when {
+                        less-than "$filter-counter-mem-used-percent" "$filter-counter-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] Filter counter memory used: $filter-counter-mem-used-percent ($filter-counter-mem-used) threshold: $filter-counter-mem-threshold";
+                        }
+                    }
+                }
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$filter-counter-mem-used-percent" "$filter-counter-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] Filter counter memory used: $filter-counter-mem-used-percent ($filter-counter-mem-used) threshold: $filter-counter-mem-threshold";
+                        }
+                    }
+                }
+            }
+            trigger report-ifl-ctr-mem {
+                frequency 60s;
+                term normal {
+                    when {
+                        less-than "$ifl-counter-mem-used-percent" "$ifl-counter-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] IFL counter memory used: $ifl-counter-mem-used-percent ($ifl-counter-mem-used) threshold: $ifl-counter-mem-threshold";
+                        }
+                    }
+                }
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$ifl-counter-mem-used-percent" "$ifl-counter-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] IFL counter memory used: $ifl-counter-mem-used-percent ($ifl-counter-mem-used) threshold: $ifl-counter-mem-threshold";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-counter-expansion-mem.yml
+++ b/juniper_official/Linecard/resource-monitor-counter-expansion-mem.yml
@@ -1,0 +1,20 @@
+---
+ResoureMonitorSummaryPfeAsicMemTable:
+    rpc: get-resource-monitor-summary-fpc-information
+    item: resource-monitor-summary-fpc-information-summary/resource-monitor-summary-pfe-information-summary/pfe-num/parent::*
+    key:
+        - ../fpc-slot
+        - pfe-num
+    view: ResoureMonitorSummaryPfeAsicMemView
+
+ResoureMonitorSummaryPfeAsicMemView:
+    fields:
+        filter-counter-memory-threshold: ../../resource-monitor-summary-fpc-information-summary-header/filter-counter-memory-threshold
+        ifl-counter-memory-threshold: ../../resource-monitor-summary-fpc-information-summary-header/ifl-counter-memory-threshold
+        expansion-memory-threshold: ../../resource-monitor-summary-fpc-information-summary-header/expansion-memory-threshold
+        used-filter-counter: used-filter-counter
+        used-filter-counter-percent: used-filter-counter-percent
+        used-ifl-counter: used-ifl-counter
+        used-ifl-counter-percent: used-ifl-counter-percent
+        used-expansion-memory: used-expansion-memory
+        used-expansion-memory-percent: used-expansion-memory-percent

--- a/juniper_official/Linecard/resource-monitor-denied-count.rule
+++ b/juniper_official/Linecard/resource-monitor-denied-count.rule
@@ -1,0 +1,233 @@
+healthbot {
+    topic linecard.fpc.resoure  {
+        rule monitor-denied-count {
+            keys fpc-slot;
+            synopsis "Denied count analyser";
+            description "Check client session, service session and IFL denied count for each PFC and reports if denied count is zero, non-zero or increasing.";
+            sensor denied-count-sensor {
+                iAgent {
+                    file resource-monitor-denied-count.yml;
+                    table ResoureMonitorDeniedCountTable;
+                    frequency 30s;
+                }
+            }
+            field client-denied-count {
+                sensor denied-count-sensor {
+                    path fpc-client-session-denied-count;
+                }
+                type integer;
+                description "Client session denied count";
+            }
+            field fpc-slot {
+                sensor denied-count-sensor {
+                    path fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field ifl-denied-count {
+                sensor denied-count-sensor {
+                    path fpc-ifl-denied-count;
+                }
+                type integer;
+                description "IFL denied count";
+            }
+            field lb-client-denied-count {
+                sensor denied-count-sensor {
+                    path load-based-client-session-denied-count;
+                }
+                type integer;
+                description "Load based client session denied count";
+            }
+            field lb-service-denied-count {
+                sensor denied-count-sensor {
+                    path load-based-service-session-denied-count;
+                }
+                type integer;
+                description "Load based service session denied count";
+            }
+            field service-denied-count {
+                sensor denied-count-sensor {
+                    path fpc-service-session-denied-count;
+                }
+                type integer;
+                description "Service session denied count";
+            }
+            trigger report-client-denied {
+                frequency 30s;
+                term increasing {
+                    when {
+                        increasing-at-least-by-value "$client-denied-count" {
+                            value 1;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot] Client session denied count increasing ($client-denied-count).";
+                        }
+                    }
+                }
+                term zero {
+                    when {
+                        equal-to "$client-denied-count" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot] Client session denied count is 0";
+                        }
+                    }
+                }
+                term non-zero {
+                    then {
+                        status {
+                            color yellow;
+                            message "[FPC:$fpc-slot] Client session denied count is $client-denied-count";
+                        }
+                    }
+                }
+            }
+            trigger report-ifl-denied {
+                frequency 30s;
+                term increasing {
+                    when {
+                        increasing-at-least-by-value "$ifl-denied-count" {
+                            value 1;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot] IFL denied count is increasing ($ifl-denied-count).";
+                        }
+                    }
+                }
+                term zero {
+                    when {
+                        equal-to "$ifl-denied-count" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot] IFL denied count is 0.";
+                        }
+                    }
+                }
+                term non-zero {
+                    then {
+                        status {
+                            color yellow;
+                            message "[FPC:$fpc-slot] IFL denied count is $ifl-denied-count.";
+                        }
+                    }
+                }
+            }
+            trigger report-lb-client-denied {
+                frequency 30s;
+                term increasing {
+                    when {
+                        increasing-at-least-by-value "$lb-client-denied-count" {
+                            value 1;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot] Load based client session denied count is increasing ($lb-client-denied-count).";
+                        }
+                    }
+                }
+                term zero {
+                    when {
+                        equal-to "$lb-client-denied-count" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot] Load based client session denied count is 0";
+                        }
+                    }
+                }
+                term non-zero {
+                    then {
+                        status {
+                            color yellow;
+                            message "[FPC:$fpc-slot] Load based client session denied count is $lb-client-denied-count";
+                        }
+                    }
+                }
+            }
+            trigger report-lb-service-denied {
+                frequency 30s;
+                term increasing {
+                    when {
+                        increasing-at-least-by-value "$lb-service-denied-count" {
+                            value 1;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot] Load based service session denied count increasing ($lb-service-denied-count).";
+                        }
+                    }
+                }
+                term zero {
+                    when {
+                        equal-to "$lb-service-denied-count" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot] Load based service session denied count is 0";
+                        }
+                    }
+                }
+                term non-zero {
+                    then {
+                        status {
+                            color yellow;
+                            message "[FPC:$fpc-slot] Load based service session denied count is $lb-service-denied-count.";
+                        }
+                    }
+                }
+            }
+            trigger report-service-denied {
+                frequency 30s;
+                term increasing {
+                    when {
+                        increasing-at-least-by-value "$service-denied-count" {
+                            value 1;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot] Service session denied count is increasing ($service-denied-count)";
+                        }
+                    }
+                }
+                term zero {
+                    when {
+                        equal-to "$service-denied-count" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot] Service denied count is 0";
+                        }
+                    }
+                }
+                term non-zero {
+                    then {
+                        status {
+                            color yellow;
+                            message "[FPC:$fpc-slot] Service denied count is $service-denied-count";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-denied-count.yml
+++ b/juniper_official/Linecard/resource-monitor-denied-count.yml
@@ -1,0 +1,14 @@
+---
+ResoureMonitorDeniedCountTable:
+    rpc: get-resource-monitor-summary-fpc-information
+    item: resource-monitor-summary-fpc-information-summary/fpc-slot/parent::*
+    key: fpc-slot
+    view: ResoureMonitorDeniedCountView
+ 
+ResoureMonitorDeniedCountView:
+    fields:
+        fpc-client-session-denied-count: fpc-client-session-denied-count
+        fpc-service-session-denied-count: fpc-service-session-denied-count
+        load-based-client-session-denied-count: load-based-client-session-denied-count
+        load-based-service-session-denied-count: load-based-service-session-denied-count
+        fpc-ifl-denied-count: fpc-ifl-denied-count

--- a/juniper_official/Linecard/resource-monitor-expansion-mem.rule
+++ b/juniper_official/Linecard/resource-monitor-expansion-mem.rule
@@ -1,0 +1,76 @@
+healthbot {
+    topic linecard.pfe.resource  {
+        rule monitor-expansion-memory {
+            keys [ fpc-slot pfe-num ];
+            synopsis "Expansion memory analyser";
+            description "Collects periodically Expansion memory utilisation for each PFE instance in all FPCs and reports whether it is normal or exceeded threshold ";
+            sensor expansion-mem-sensor {
+                iAgent {
+                    file resource-monitor-expansion-mem.yml;
+                    table ResoureMonitorExpansionMemoryTable;
+                    frequency 60s;
+                }
+            }
+            field expansion-mem-threshold {
+                sensor expansion-mem-sensor {
+                    path expansion-memory-threshold;
+                }
+                type integer;
+                description "Expansion memory threshold value";
+            }
+            field expansion-mem-used {
+                sensor expansion-mem-sensor {
+                    path used-expansion-memory;
+                }
+                type integer;
+                description "Expansion memory used";
+            }
+            field expansion-mem-used-percent {
+                sensor expansion-mem-sensor {
+                    path used-expansion-memory-percent;
+                }
+                type integer;
+                description "Expansion memory used in percent";
+            }
+            field fpc-slot {
+                sensor expansion-mem-sensor {
+                    path ../fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field pfe-num {
+                sensor expansion-mem-sensor {
+                    path pfe-num;
+                }
+                type string;
+                description "PFE instance in each FPC slot";
+            }
+            trigger report-expansion-mem {
+                frequency 60s;
+                term normal {
+                    when {
+                        less-than "$expansion-mem-used-percent" "$expansion-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] [Expansion memory] Used:$expansion-mem-used($expansion-mem-used-percent%) Threshold: $expansion-mem-threshold";
+                        }
+                    }
+                }
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$expansion-mem-used-percent" "$expansion-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] [Expansion memory] Used:$expansion-mem-used($expansion-mem-used-percent%) Threshold: $expansion-mem-threshold";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-expansion-mem.yml
+++ b/juniper_official/Linecard/resource-monitor-expansion-mem.yml
@@ -1,0 +1,14 @@
+---
+ResoureMonitorExpansionMemoryTable:
+    rpc: get-resource-monitor-summary-fpc-information
+    item: resource-monitor-summary-fpc-information-summary/resource-monitor-summary-pfe-information-summary/pfe-num/parent::*
+    key:
+        - ../fpc-slot
+        - pfe-num
+    view: ResoureMonitorExpansionMemoryView
+
+ResoureMonitorExpansionMemoryView:
+    fields:
+        expansion-memory-threshold: ../../resource-monitor-summary-fpc-information-summary-header/expansion-memory-threshold
+        used-expansion-memory: used-expansion-memory
+        used-expansion-memory-percent: used-expansion-memory-percent

--- a/juniper_official/Linecard/resource-monitor-filter-counter-mem.rule
+++ b/juniper_official/Linecard/resource-monitor-filter-counter-mem.rule
@@ -1,0 +1,76 @@
+healthbot {
+    topic linecard.pfe.resource  {
+        rule monitor-filter-counter-memory {
+            keys [ fpc-slot pfe-num ];
+            synopsis "Filter counter memory analyser";
+            description "Collects periodically Filter counter memory utilisation for each PFE instance in all FPCs and reports whether it is normal or exceeded threshold ";
+            sensor filter-counter-mem-sensor {
+                iAgent {
+                    file resource-monitor-filter-counter-mem.yml;
+                    table ResoureMonitorFilterCounterMemoryTable;
+                    frequency 60s;
+                }
+            }
+            field filter-counter-mem-threshold {
+                sensor filter-counter-mem-sensor {
+                    path filter-counter-memory-threshold;
+                }
+                type integer;
+                description "IFL counter memory threshold value";
+            }
+            field filter-counter-mem-used {
+                sensor filter-counter-mem-sensor {
+                    path used-filter-counter;
+                }
+                type integer;
+                description "IFL counter memory used";
+            }
+            field filter-counter-mem-used-percent {
+                sensor filter-counter-mem-sensor {
+                    path used-filter-counter-percent;
+                }
+                type integer;
+                description "IFL counter memory used in percent";
+            }
+            field fpc-slot {
+                sensor filter-counter-mem-sensor {
+                    path ../fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field pfe-num {
+                sensor filter-counter-mem-sensor {
+                    path pfe-num;
+                }
+                type string;
+                description "PFE instance in each FPC slot";
+            }
+            trigger report-filter-counter-mem {
+                frequency 60s;
+                term normal {
+                    when {
+                        less-than "$filter-counter-mem-used-percent" "$filter-counter-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] [Filter counter memory] Used: $filter-counter-mem-used($filter-counter-mem-used-percent%) Threshold: $filter-counter-mem-threshold";
+                        }
+                    }
+                }
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$filter-counter-mem-used-percent" "$filter-counter-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] [Filter counter memory] Used: $filter-counter-mem-used($filter-counter-mem-used-percent%) Threshold: $filter-counter-mem-threshold";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-filter-counter-mem.yml
+++ b/juniper_official/Linecard/resource-monitor-filter-counter-mem.yml
@@ -1,0 +1,14 @@
+---
+ResoureMonitorFilterCounterMemoryTable:
+    rpc: get-resource-monitor-summary-fpc-information
+    item: resource-monitor-summary-fpc-information-summary/resource-monitor-summary-pfe-information-summary/pfe-num/parent::*
+    key:
+        - ../fpc-slot
+        - pfe-num
+    view: ResoureMonitorFilterCounterMemoryView
+
+ResoureMonitorFilterCounterMemoryView:
+    fields:
+        filter-counter-memory-threshold: ../../resource-monitor-summary-fpc-information-summary-header/filter-counter-memory-threshold
+        used-filter-counter: used-filter-counter
+        used-filter-counter-percent: used-filter-counter-percent

--- a/juniper_official/Linecard/resource-monitor-heap-mem.yml
+++ b/juniper_official/Linecard/resource-monitor-heap-mem.yml
@@ -1,0 +1,12 @@
+---
+ResoureMonitorHeapMemoryTable:
+    rpc: get-resource-monitor-summary-fpc-information
+    item: resource-monitor-summary-fpc-information-summary/fpc-slot/parent::*
+    key: fpc-slot
+    view: ResoureMonitorHeapMemoryView
+ 
+ResoureMonitorHeapMemoryView:
+    fields:
+        heap-memory-threshold: ../resource-monitor-summary-fpc-information-summary-header/heap-memory-threshold
+        used-heap-mem: used-heap-mem
+        used-heap-mem-percent: used-heap-mem-percent

--- a/juniper_official/Linecard/resource-monitor-heap-memory.rule
+++ b/juniper_official/Linecard/resource-monitor-heap-memory.rule
@@ -1,0 +1,69 @@
+healthbot {
+    topic linecard.fpc.resoure  {
+        rule monitor-heap-memory {
+            keys fpc-slot;
+            synopsis "Heap memory analyser";
+            description "Check heap memory utilization periodically for each FPC";
+            sensor heap-mem-sensor {
+                iAgent {
+                    file resource-monitor-heap-mem.yml;
+                    table ResoureMonitorHeapMemoryTable;
+                    frequency 30s;
+                }
+            }
+            field fpc-slot {
+                sensor heap-mem-sensor {
+                    path fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field heap-mem-threshold {
+                sensor heap-mem-sensor {
+                    path heap-memory-threshold;
+                }
+                type integer;
+                description "Heap memory threshold value";
+            }
+            field heap-mem-used {
+                sensor heap-mem-sensor {
+                    path used-heap-mem;
+                }
+                type integer;
+                description "Heap memory used";
+            }
+            field heap-mem-used-percent {
+                sensor heap-mem-sensor {
+                    path used-heap-mem-percent;
+                }
+                type integer;
+                description "Heap memory used in percent";
+            }
+            trigger report-heap-mem {
+                frequency 30s;
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$heap-mem-used-percent" "$heap-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot] Heap memory used: $heap-mem-used ($heap-mem-used-percent%) threshold:$heap-mem-threshold";
+                        }
+                    }
+                }
+                term normal {
+                    when {
+                        less-than "$heap-mem-used-percent" "$heap-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot] Heap memory used: $heap-mem-used ($heap-mem-used-percent%) threshold:$heap-mem-threshold";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-ifl-counter-mem.rule
+++ b/juniper_official/Linecard/resource-monitor-ifl-counter-mem.rule
@@ -1,0 +1,76 @@
+healthbot {
+    topic linecard.pfe.resource  {
+        rule monitor-ifl-counter-memory {
+            keys [ fpc-slot pfe-num ];
+            synopsis "IFL counter memory analyser";
+            description "Collects periodically IFL counter memory utilisation for each PFE instance in all FPCs and reports whether it is normal or exceeded threshold ";
+            sensor ifl-counter-mem-sensor {
+                iAgent {
+                    file resource-monitor-ifl-counter-mem.yml;
+                    table ResoureMonitorIflCounterMemoryTable;
+                    frequency 60s;
+                }
+            }
+            field fpc-slot {
+                sensor ifl-counter-mem-sensor {
+                    path ../fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field ifl-counter-mem-threshold {
+                sensor ifl-counter-mem-sensor {
+                    path ifl-counter-memory-threshold;
+                }
+                type integer;
+                description "IFL counter memory threshold value";
+            }
+            field ifl-counter-mem-used {
+                sensor ifl-counter-mem-sensor {
+                    path used-ifl-counter;
+                }
+                type integer;
+                description "IFL counter memory used";
+            }
+            field ifl-counter-mem-used-percent {
+                sensor ifl-counter-mem-sensor {
+                    path used-ifl-counter-percent;
+                }
+                type integer;
+                description "IFL counter memory used in percent";
+            }
+            field pfe-num {
+                sensor ifl-counter-mem-sensor {
+                    path pfe-num;
+                }
+                type string;
+                description "PFE instance in each FPC slot";
+            }
+            trigger report-ifl-counter-mem {
+                frequency 60s;
+                term normal {
+                    when {
+                        less-than "$ifl-counter-mem-used-percent" "$ifl-counter-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] [IFL counter memory] Used: $ifl-counter-mem-used($ifl-counter-mem-used-percent%) Threshold: $ifl-counter-mem-threshold";
+                        }
+                    }
+                }
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$ifl-counter-mem-used-percent" "$ifl-counter-mem-threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] [IFL counter memory] Used: $ifl-counter-mem-used($ifl-counter-mem-used-percent%) Threshold: $ifl-counter-mem-threshold";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-ifl-counter-mem.yml
+++ b/juniper_official/Linecard/resource-monitor-ifl-counter-mem.yml
@@ -1,0 +1,14 @@
+---
+ResoureMonitorIflCounterMemoryTable:
+    rpc: get-resource-monitor-summary-fpc-information
+    item: resource-monitor-summary-fpc-information-summary/resource-monitor-summary-pfe-information-summary/pfe-num/parent::*
+    key:
+        - ../fpc-slot
+        - pfe-num
+    view: ResoureMonitorIflCounterMemoryView
+
+ResoureMonitorIflCounterMemoryView:
+    fields:
+        ifl-counter-memory-threshold: ../../resource-monitor-summary-fpc-information-summary-header/ifl-counter-memory-threshold
+        used-ifl-counter: used-ifl-counter
+        used-ifl-counter-percent: used-ifl-counter-percent

--- a/juniper_official/Linecard/resource-monitor-nh-fw-encap-mem.rule
+++ b/juniper_official/Linecard/resource-monitor-nh-fw-encap-mem.rule
@@ -1,0 +1,144 @@
+healthbot {
+    topic linecard.pfe.resource  {
+        rule monitor-firewall-nh-encap-memory {
+            keys [ fpc-slot pfe-num ];
+            synopsis " Firewall memory, NH memory and Encap memory analyser";
+            description "Collects periodically Firewall memory, NH memory and Encap memory availability for each PFE instance in all FPCs and reports whether it is normal or below watermark";
+            sensor asic-mem-sensor {
+                iAgent {
+                    file resource-monitor-nh-fw-encap-mem.yml;
+                    table ResoureMonitorSummaryPfeAsicMemTable;
+                    frequency 60s;
+                }
+            }
+            field encap-mem-free-percent {
+                sensor asic-mem-sensor {
+                    path free-encap-memory-rsmon-percent;
+                }
+                type integer;
+                description "Free encap memory in percent";
+            }
+            field encap-mem-watermark {
+                sensor asic-mem-sensor {
+                    path free-encap-memory-watermark;
+                }
+                type integer;
+                description "Free encap memory watermark";
+            }
+            field firewall-mem-free-percent {
+                sensor asic-mem-sensor {
+                    path free-filter-memory-rsmon-percent;
+                }
+                type string;
+                description "Free firewall memory in percent";
+            }
+            field firewall-mem-watermark {
+                sensor asic-mem-sensor {
+                    path free-filter-memory-watermark;
+                }
+                type integer;
+                description "Free firewall memory watermark";
+            }
+            field fpc-slot {
+                sensor asic-mem-sensor {
+                    path ../fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field nh-mem-free-percent {
+                sensor asic-mem-sensor {
+                    path free-nh-memory-rsmon-percent;
+                }
+                type integer;
+                description "Free NH memory in percent";
+            }
+            field nh-mem-watermark {
+                sensor asic-mem-sensor {
+                    path free-nh-memory-watermark;
+                }
+                type integer;
+                description "Free NH memory watermark";
+            }
+            field pfe-num {
+                sensor asic-mem-sensor {
+                    path pfe-num;
+                }
+                type string;
+                description "PFE instance in each FPC slot";
+            }
+            trigger report-encap-mem {
+                frequency 60s;
+                term normal {
+                    when {
+                        equal-to "$encap-mem-free-percent" NA;
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] Encap memory free:$encap-mem-free-percent watermark:$encap-mem-watermark";
+                        }
+                    }
+                }
+                term Term_2 {
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] Encap memory free:$encap-mem-free-percent watermark:$encap-mem-watermark";
+                        }
+                    }
+                }
+            }
+            trigger report-fw-mem {
+                frequency 60s;
+                term below-watermark {
+                    when {
+                        less-than-or-equal-to "$firewall-mem-free-percent" "$firewall-mem-watermark";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] Firewall memory free:$firewall-mem-free-percent watermark:$firewall-mem-watermark";
+                        }
+                    }
+                }
+                term normal {
+                    when {
+                        greater-than "$firewall-mem-free-percent" "$firewall-mem-watermark";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] Firewall memory free:$firewall-mem-free-percent watermark:$firewall-mem-watermark";
+                        }
+                    }
+                }
+            }
+            trigger report-nh-mem {
+                frequency 60s;
+                term below-watermark {
+                    when {
+                        less-than-or-equal-to "$nh-mem-free-percent" "$nh-mem-watermark";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] NH memory free:$nh-mem-free-percent watermark:$nh-mem-watermark";
+                        }
+                    }
+                }
+                term normal {
+                    when {
+                        greater-than "$nh-mem-free-percent" "$nh-mem-watermark";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot PFE:$pfe-num] NH memory free:$nh-mem-free-percent watermark:$nh-mem-watermark";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-nh-fw-encap-mem.yml
+++ b/juniper_official/Linecard/resource-monitor-nh-fw-encap-mem.yml
@@ -1,0 +1,17 @@
+---
+ResoureMonitorSummaryPfeAsicMemTable:
+    rpc: get-resource-monitor-fpc-information
+    item: resource-monitor-fpc-information-summary/resource-monitor-fpc-pfe-information-summary/pfe-num/parent::*
+    key:
+        - ../fpc-slot
+        - pfe-num
+    view: ResoureMonitorSummaryPfeAsicMemView
+
+ResoureMonitorSummaryPfeAsicMemView:
+    fields:
+        free-nh-memory-watermark: ../../resource-monitor-fpc-information-header/free-nh-memory-watermark
+        free-filter-memory-watermark: ../../resource-monitor-fpc-information-header/free-filter-memory-watermark
+        free-encap-memory-watermark: ../../resource-monitor-fpc-information-header/free-encap-memory-watermark
+        free-nh-memory-rsmon-percent: free-nh-memory-rsmon-percent
+        free-filter-memory-rsmon-percent: free-filter-memory-rsmon-percent
+        free-encap-memory-rsmon-percent: free-encap-memory-rsmon-percent

--- a/juniper_official/Linecard/resource-monitor-rtt.rule
+++ b/juniper_official/Linecard/resource-monitor-rtt.rule
@@ -1,0 +1,85 @@
+healthbot {
+    topic linecard.fpc.resoure  {
+        rule monitor-round-trip-time {
+            keys fpc-slot;
+            synopsis "RTT analyser";
+            description "Check Round Trip Time periodically for each FPC";
+            sensor rtt-sensor {
+                iAgent {
+                    file resource-monitor-rtt.yml;
+                    table ResoureMonitorRttTable;
+                    frequency 30s;
+                }
+            }
+            field average-rtt-delay {
+                sensor rtt-sensor {
+                    path avg-rtt;
+                }
+                type integer;
+                description "Average round trip time in milli seconds";
+            }
+            field average-rtt-sample {
+                sensor rtt-sensor {
+                    path avg-rtt-sample;
+                }
+                type integer;
+                description "Average sample time in seconds";
+            }
+            field fpc-slot {
+                sensor rtt-sensor {
+                    path fpc-slot;
+                }
+                type string;
+                description "FPC slot number";
+            }
+            field invalid-rtt {
+                constant {
+                    value 2147483647;
+                }
+                type integer;
+                description "Invalid average rtt value 0x7FFFFFFF";
+            }
+            field rtt-delay {
+                sensor rtt-sensor {
+                    path rtt;
+                }
+                type integer;
+                description "Round trip time in milli seconds";
+            }
+            field rtt-threshold {
+                sensor rtt-sensor {
+                    path rtt-threshold;
+                }
+                type integer;
+                description "Round trip time threshold value in milliseconds";
+            }
+            trigger report-rtt {
+                frequency 30s;
+                term above-threshold {
+                    when {
+                        greater-than-or-equal-to "$average-rtt-delay" "$rtt-threshold";
+                        not-equal-to "$average-rtt-delay" "$invalid-rtt";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "[FPC:$fpc-slot] RTT delay: $rtt-delay avg-delay:$average-rtt-delay ($average-rtt-sample) threshold:$rtt-threshold";
+                        }
+                    }
+                }
+                term normal {
+                    when {
+                        less-than "$average-rtt-delay" "$rtt-threshold";
+                        not-equal-to "$average-rtt-delay" "$invalid-rtt";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "[FPC:$fpc-slot] RTT delay: $rtt-delay avg-delay:$average-rtt-delay ($average-rtt-sample) threshold:$rtt-threshold";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/resource-monitor-rtt.yml
+++ b/juniper_official/Linecard/resource-monitor-rtt.yml
@@ -1,0 +1,13 @@
+---
+ResoureMonitorRttTable:
+    rpc: get-resource-monitor-summary-fpc-information
+    item: resource-monitor-summary-fpc-information-summary/fpc-slot/parent::*
+    key: fpc-slot
+    view: ResoureMonitorRttView
+ 
+ResoureMonitorRttView:
+    fields:
+        rtt-threshold: ../resource-monitor-summary-fpc-information-summary-header/rtt-threshold
+        avg-rtt: avg-rtt
+        avg-rtt-sample: avg-rtt-sample
+        rtt: rtt


### PR DESCRIPTION
Rules to fetch and display various FPC and PFE resources.
CLI command "show system resource-monitor summary" and
"show system resource-monitor fpc" provide information about resources
Heap memory, counter memory, CoS utilization, RTT, etc. Added rules to fetch
information about these resources and trigger normal or threshold exceeded.