### PR TITLE
Patch2

### DIFF
--- a/community_supplied/Interface/oc-interface-throughput.rule
+++ b/community_supplied/Interface/oc-interface-throughput.rule
@@ -1,3 +1,32 @@
+/*
+* Detects interface throughput utilization and notifies when
+* anomalies are found.
+* Five input control detection
+*
+* 1) in-stats-name, is the interface input traffic counter name
+* whose input octets you would like to monitor. By default it
+* is 'in-octets'.
+*
+* 2) interface-name, is a regular expression that matches the
+* interfaces that you would like to monitor. By default it is '.*',
+* which matches all interfaces. Use something like 'ge.*' to
+* match only gigabit ethernet interfaces.
+*
+* 3) out-stats-name, is the interface output traffic counter name
+* whose output octets you would like to monitor. By default it
+* is 'out-octets'.
+*
+* 4) speed, is the interface speed state name that is used to
+* calculate the interface throughput utilization. By default it
+* is 'high-speed'.
+*
+* 5) threshold, is the threshold that causes the rule to report
+* an anomaly. By default it is 75.00 %. This rule will set a
+* dashboard color to red when io throughput utilization percent
+* exceeds threshold value. If dynamic threshold of io throughput
+* utilization is equal to 1, the color is set to yellow. Otherwise
+* it is set to green.
+*/
 healthbot {
     topic interface.throughput {
         description "Rules that monitor interface throughput and react to changes";
@@ -5,7 +34,317 @@ healthbot {
         rule check-interface-throughput-oc {
             synopsis "Interface throughput threshold crossing";
             description "Monitors interface throughput and generates triggers on customizable threshold crossing";    
-	    	
+            keys interface-name;
+            /*
+            * Monitors interface input and output throughput utilization. Notifies via the
+            * dashboard colors when interface io throughput utilization exceeds the high
+            * threshold {{$threshold}} it sets the color to red. The color is
+            * set to yellow if dynamic threshold {{$dt-in-bw-util}} or {{$dt-out-bw-util}}
+            * of io throughput is equal to 1. Otherwise the color is set to green.
+            *
+            * Use interface-name as key for rule
+            *
+            *
+            * Sensor configuration to get data from network devices.
+            */
+            sensor interfaces {
+                synopsis "Interface open-config sensor definition";
+                description "Interfaces open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /interfaces/interface/state;
+                    frequency 90s;
+                }
+            }
+            /*
+            * Fields defined using formulae by user-defined function
+            */
+            field in-bw-util {
+                formula {
+                    eval {
+                        expression "( $in-mbps / $speed ) * 100";
+                    }
+                }
+                type float;
+                description "Input bandwidth utilization";
+            }
+            field in-mbps {
+                formula {
+                    rate-of-change {
+                        field-name "$input-bytes";
+                        multiplication-factor 0.000001;
+                    }
+                }
+                type float;
+            }
+            field out-bw-util {
+                formula {
+                    eval {
+                        expression "( $out-mbps / $speed ) * 100";
+                    }
+                }
+                type float;
+                description "Output bandwidth utilization";
+            }
+            field out-mbps {
+                formula {
+                    rate-of-change {
+                        field-name "$output-bytes";
+                        multiplication-factor 0.000001;
+                    }
+                }
+                type float;
+            }
+            /*
+            * Field defined using machine learning algorithms
+            */
+            field dt-in-bw-util {
+                formula {
+                    anomaly-detection { 
+                        algorithm 3sigma;
+                        learning-period 7d;
+                        pattern-periodicity 1h;
+                        field-name "$in-bw-util";
+                    }
+                }
+                type integer;
+                description "ML anomaly detection Input bandwidth utilization field";
+            }
+            field dt-out-bw-util {
+                formula {
+                    anomaly-detection { 
+                        algorithm 3sigma;
+                        learning-period 7d;
+                        pattern-periodicity 1h;
+                        field-name "$out-bw-util";
+                    }
+                }
+                type integer;
+                description "ML anomaly detection output bandwidth utilization field";
+            }
+            field predicted-in-bw-util {
+                formula {
+                    predict {
+                        algorithm median-prediction;
+                        learning-period 1d;
+                        pattern-periodicity 1h;
+                        field-name "$in-bw-util";
+                        prediction-offset 1d;
+                    }
+                }
+                type float;
+                description "ML predicted input bandwidth utilization";
+            }
+            field predicted-out-bw-util {
+                formula {
+                    predict {
+                        algorithm median-prediction;
+                        learning-period 1d;
+                        pattern-periodicity 1h;
+                        field-name "$out-bw-util";
+                        prediction-offset 1d;
+                    }
+                }
+                type float;
+                description "ML predicted output bandwidth utilization";
+            }
+            /*
+            * Field defined using sensor path. Map the longer sensor names
+            * to the shorter field names used in the rules.
+            */
+            field input-bytes {
+                sensor interfaces {
+                    path "/interfaces/interface/state/counters/{{in-stats-name}}";
+                    zero-suppression;
+                }
+                type integer;
+                description "Interface statistics counter (in-octets) value";
+            }
+            field interface-name {
+                sensor interfaces {
+                    where "/interfaces/interface/@name =~ /{{interface-name-variable}}/";
+                    where "/interfaces/interface/state/{{speed}} != 0";
+                    path "/interfaces/interface/@name";
+                }
+                type string;
+                description "Interfaces to be monitored";
+            }
+            field output-bytes {
+                sensor interfaces {
+                    path "/interfaces/interface/state/counters/{{out-stats-name}}";
+                    zero-suppression;
+                }
+                type integer;
+                description "Interface statistics counter (out-octets) value";
+            }
+            field speed {
+                sensor interfaces {
+                    path "/interfaces/interface/state/{{speed}}";
+                    zero-suppression;
+                }
+                type string;
+                description "Collected interface speed";
+            }
+            /*
+            * Field defined with variable and constant value
+            */
+            field threshold {
+                constant {
+                    value "{{threshold}}";
+                }
+                type float;
+                description "Interface bandwidth utilization increase threshold";
+            }
+            /*
+            * Anomaly detection logic.
+            */
+            trigger in-bw-utilization {
+                synopsis "Interface input bandwidth utilization ";
+                description "Sets health based on the change in input bandwidth utilization";
+                frequency 90s;
+                /*
+                * Sets color to red and sends out an anomaly notification when
+                * the input bandwidth utilization ($in-bw-util %) is greater than
+                * the threshold ($threshold %).
+                */
+                term is-input-bandwidth-abnormal {
+                    when {
+                        greater-than-or-equal-to "$in-bw-util" "$threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$interface-name input bandwidth utilization ($in-bw-util %) crossed threshold value ($threshold %). Mbps:$in-mbps Input bytes:$input-bytes";
+                        }
+                    }
+                }
+                /*
+                * Sets color to yellow and sends out an anomaly notification when
+                * the dynamic threshold ($dt-in-bw-util) of input bandwidth
+                * utilization is equal to 1.
+                */
+                term is-input-bandwidth-above-dt {
+                    when {
+                        equal-to "$dt-in-bw-util" 1;
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "$interface-name input bandwidth utilization ($in-bw-util %) is above the dynamic threshold. Mbps:$in-mbps Input Bytes:$input-bytes Predicted BW utilization:$predicted-in-bw-util";
+                        }
+                    }
+                }
+                /*
+                * Defaults color to green.
+                */
+                term is-input-bandwidth-normal {
+                    then {
+                        status {
+                            color green;
+                            message "$interface-name input bandwidth utilization ($in-bw-util %) is normal. Mbps:$in-mbps Input bytes:$input-bytes";
+                        }
+                    }
+                }
+            }
+            trigger out-bw-utilization {
+                synopsis "Interface output bandwidth utilization ";
+                description "Sets health based on the change in output bandwidth utilization";
+                frequency 90s;
+                /*
+                * Sets color to red and sends out an anomaly notification when
+                * the output bandwidth utilization ($out-bw-util %) is greater than
+                * the threshold ($threshold %).
+                */
+                term is-output-bandwidth-abnormal {
+                    when {
+                        greater-than-or-equal-to "$out-bw-util" "$threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "$interface-name output bandwidth utilization($out-bw-util%) crossed threshold value ($threshold %). Mbps:$out-mbps Output bytes:$output-bytes";
+                        }
+                    }
+                }
+                /*
+                * Sets color to yellow and sends out an anomaly notification when
+                * the dynamic threshold ($dt-out-bw-util) of output bandwidth
+                * utilization is equal to 1.
+                */
+                term is-output-bandwidth-above-dt {
+                    when {
+                        equal-to "$dt-out-bw-util" 1;
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "$interface-name output bandwidth utilization ($out-bw-util %) is above dynamic threshold. Mbps:$out-mbps Output Bytes:$output-bytes Predicted BW utilization:$predicted-out-bw-util";
+                        }
+                    }
+                }
+                /*
+                * Defaults color to green.
+                */
+                term is-output-bandwidth-normal {
+                    then {
+                        status {
+                            color green;
+                            message "$interface-name output bandwidth utilization ($out-bw-util %) is normal. Mbps:$out-mbps Output bytes:$output-bytes";
+                        }
+                    }
+                }
+            }
+            /*
+            * Variables with default values. Default values can be changed
+            * while deploying playbook instance.
+            */
+            variable in-stats-name {
+                value in-octets;
+                description "Interface input traffic counter name";
+                type string;
+            }
+            variable interface-name-variable {
+                value .*;
+                description "Interfaces to be monitored";
+                type string;
+            }
+            variable out-stats-name {
+                value out-octets;
+                description "Interface output traffic counter name";
+                type string;
+            }
+            variable speed {
+                value high-speed;
+                description "Interface speed state name";
+                type string;
+            }
+            variable threshold {
+                value 75.00;
+                description "Interface bandwidth percent high threshold value in %.";
+                type float;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 3.1.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products EX {
+                                releases 17.3R1 {
+                                    release-support min-supported-release;
+                                    platform all;
+                                }
+                            }
+                            products MX {
+                                releases 15.1R1 {
+                                    release-support min-supported-release;
+                                    platform all;
+                                }
+                            }
+                        }
+                    }
+                }
+            }	    	
         }
     }
 }

--- a/juniper_official/Interfaces/check-interface-bandwidth-netconf.rule
+++ b/juniper_official/Interfaces/check-interface-bandwidth-netconf.rule
@@ -57,27 +57,21 @@ healthbot {
              */
             field in-mbps {
                 formula {
-                    eval {
-                        expression "$in-bps / 1000000";
+                    rate-of-change {
+                        field-name "$input-bytes";
+                        multiplication-factor 0.000001;
                     }
                 }
                 type float;
                 description "Input MBPS";
             }
-            field in-bps {
+            field input-bytes {
                 sensor interface {
-                    path input-bps;
+                    path input-bytes;
                 }
                 type integer;
-                description "Input BPS";
-            }            
-            field in-pps {
-                sensor interface {
-                    path input-pps;
-                }
-                type integer;
-                description "Input PPS";
-            }
+                description "Interface input-bytes value";
+            }       
             field name {
                 sensor interface {
                     where "admin-status =~ /up/";
@@ -87,28 +81,22 @@ healthbot {
                 type string;
                 description "Interfaces to be monitored";
             }
-            field out-bps {
+            field output-bytes {
                 sensor interface {
-                    path output-bps;
+                    path output-bytes;
                 }
                 type integer;
-                description "Output BPS";
+                description "Interface Output-bytes value";
             }
             field out-mbps {
                 formula {
-                    eval {
-                        expression "$out-bps / 1000000";
+                    rate-of-change {
+                        field-name "$output-bytes";
+                        multiplication-factor 0.000001;
                     }
                 }
                 type float;
                 description "Output MBPS";
-            }
-            field out-pps {
-                sensor interface {
-                    path output-pps;
-                }
-                type integer;
-                description "Output PPS";
             }
             field admin-status {
                 sensor interface {
@@ -140,7 +128,7 @@ healthbot {
             field in-bw-util {
                 formula {
                     eval {
-                        expression "($in-mbps / $if-speed ) * 100";
+                        expression "( $in-mbps / $if-speed ) * 100";
                     }
                 }
                 type float;
@@ -149,15 +137,15 @@ healthbot {
             field out-bw-util {
                 formula {
                     eval {
-                        expression "($out-mbps / $if-speed ) * 100";
+                        expression "( $out-mbps / $if-speed ) * 100";
                     }
                 }
                 type float;
                 description "Output bandwidth utilization";
             }            
             /*
-             * Field defined using machine learning algorithms
-             */
+            * Field defined using machine learning algorithms
+            */
             field dt-in-bw-util {
                 formula {
                     anomaly-detection {
@@ -218,31 +206,8 @@ healthbot {
                 type float;
                 description "Interface bandwidth utilization increase threshold";
             }
-
-            field dt-in-bw-util {
-                formula {
-                    anomaly-detection {
-                        algorithm 3sigma;
-                        learning-period 7d;
-                        pattern-periodicity 1h;
-                        field-name "$in-pps";
-                    }
-                }
-                type integer;
-            }
-            field dt-out-bw-util {
-                formula {
-                    anomaly-detection {
-                        algorithm 3sigma;
-                        learning-period 7d;
-                        pattern-periodicity 1h;
-                        field-name "$out-pps";
-                    }
-                }
-                type integer;
-            }
             /*
-             * Anomaly detection logic.
+            * Anomaly detection logic.
             */
             trigger in-bw-utilization {
                 synopsis "Interface input bandwidth utilization ";
@@ -260,7 +225,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$name input bandwidth utilization ($in-bw-util %) crossed threshold value ($threshold %). Mbps:$in-mbps Bps:$in-bps bps Pps:$in-pps";
+                            message "$name input bandwidth utilization ($in-bw-util %) crossed threshold value ($threshold %). Mbps:$in-mbps Input Bytes:$input-bytes bytes";
                         }
                     }
                 }
@@ -276,7 +241,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$name input bandwidth utilization ($in-bw-util %) is above the dynamic threshold. Mbps:$in-mbps Bps:$in-bps bps Pps:$in-pps Predicted BW utilization:$predicted-in-bw-util";
+                            message "$name input bandwidth utilization ($in-bw-util %) is above the dynamic threshold. Mbps:$in-mbps Input Bytes:$input-bytes bytes Predicted BW utilization:$predicted-in-bw-util";
                         }
                     }
                 }
@@ -287,7 +252,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$name input bandwidth utilization ($in-bw-util %) is normal. Mbps:$in-mbps Bps:$in-bps bps Pps:$in-pps";
+                            message "$name input bandwidth utilization ($in-bw-util %) is normal. Mbps:$in-mbps Input Bytes:$input-bytes bytes";
                         }
                     }
                 }
@@ -308,7 +273,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$name output bandwidth utilization($out-bw-util%) crossed threshold value ($threshold %). Mbps:$out-mbps Bps:$out-bps bps Pps:$out-pps";
+                            message "$name output bandwidth utilization($out-bw-util%) crossed threshold value ($threshold %). Mbps:$out-mbps Output Bytes:$output-bytes bytes";
                         }
                     }
                 }
@@ -324,7 +289,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$name output bandwidth utilization ($out-bw-util %) is above dynamic threshold. Mbps:$out-mbps Bps:$out-bps bps Pps:$out-pps Predicted BW utilization:$predicted-out-bw-util";
+                            message "$name output bandwidth utilization ($out-bw-util %) is above dynamic threshold. Mbps:$out-mbps Output Bytes:$output-bytes bytes Predicted BW utilization:$predicted-out-bw-util";
                         }
                     }
                 }
@@ -335,7 +300,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$name output bandwidth utilization ($out-bw-util %) is normal. Mbps:$out-mbps Bps:$out-bps bps Pps:$out-pps";
+                            message "$name output bandwidth utilization ($out-bw-util %) is normal. Mbps:$out-mbps Output Bytes:$output-bytes bytes";
                         }
                     }
                 }


### PR DESCRIPTION
Using input and output bytes instead of input and output bps, for input and output mbps using rate of change formula instead of eval.
Removed input and output pps.
Changed the message accordingly.