### PR TITLE
Update bgp-neighbor-flap-detection.rule

### DIFF
--- a/juniper_official/Protocols/Bgp/bgp-neighbor-flap-detection.rule
+++ b/juniper_official/Protocols/Bgp/bgp-neighbor-flap-detection.rule
@@ -94,8 +94,8 @@ healthbot {
                  */
                 term is-session-flapping {
                     when {
-                        min-rate-of-increase "$established-transitions" {
-                            rate $flap-count-threshold;
+                        increasing-at-least-by-value "$established-transitions" {
+                            value $flap-count-threshold;
                             time-range 180s;
                         }
                     }
@@ -112,8 +112,8 @@ healthbot {
                  */
                 term is-session-inconsistent {
                     when {
-                        min-rate-of-increase "$established-transitions" {
-                            rate $flap-count-threshold;
+                        increasing-at-least-by-value "$established-transitions" {
+                            value $flap-count-threshold;
                         }
                     }
                     then {


### PR DESCRIPTION
changed min-rate-of-increase to increasing-at-least-by-value