### PR TITLE
 Foghorn playbooks: L3VPN with BGP, OSPF and Static protocol configs 

### DIFF
--- a/juniper_official/Paragon/Foghorn/icmp-statistics-with-source.yml
+++ b/juniper_official/Paragon/Foghorn/icmp-statistics-with-source.yml
@@ -1,0 +1,22 @@
+---
+pingWithSourceTable:
+    rpc: ping
+    args:
+        count: Null
+        host: Null
+        source: Null
+        routing-instance: Null
+
+    key: ../target-host
+    item: probe-results-summary
+    view: pingView
+pingView:
+    fields:
+        host-ip: ../target-host
+        probes-sent: probes-sent
+        responses-received: responses-received
+        packet-loss: packet-loss
+        rtt-minimum: rtt-minimum
+        rtt-maximum: rtt-maximum
+        rtt-average: rtt-average
+        rtt-stddev: rtt-stddev

--- a/juniper_official/Paragon/Foghorn/l3vpn-bgp-session.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-bgp-session.rule
@@ -1,0 +1,72 @@
+/*
+ * Collects L3VPN BGP protocol status between PE and CE;
+ */
+healthbot {
+    topic protocol.bgp {
+        description "Collect routing instance BGP session state";
+        synopsis "L3VPN BGP session state analyzer";
+        rule get-l3vpn-bgp-routing-instance-details {
+            keys [ instance-name neighbor-address ];
+            synopsis "Routing details collector.";
+            description "Collects routing instance bgp peer status periodically";
+            sensor vpn-sensor {
+                synopsis "Routing instance sensor definition";
+                description "Open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /network-instances/network-instance;
+                    frequency 60s;
+                }
+            }
+            field instance-name {
+                sensor vpn-sensor {
+                    where "/network-instances/network-instance/@name =~ /{{instance}}/";
+                    path "/network-instances/network-instance/@name";
+                }
+                type string;
+                description "Routing Instance to be monitored";
+            }
+            field neighbor-address {
+                sensor vpn-sensor {
+                    where "/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/@neighbor-address =~ /{{neighbors}}/";
+                    path "/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/@neighbor-address";
+                }
+                type string;
+                description "Routing instance neighbor to be monitored";
+            }
+            field session-state {
+                sensor vpn-sensor {
+                    path /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/session-state;
+                }
+                type string;
+                description "Routing instance neighbor state";
+            }
+            variable instance {
+                value .*;
+                description "Routing instance to be monitored, regular expression, eg 'VPN*'";
+                type string;
+            }
+            variable neighbors {
+                value .*;
+                description "BGP neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/l3vpn-icmp.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-icmp.rule
@@ -55,11 +55,11 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "Host $host not reachable";
+                            message "Host $host reachable and  $packet-loss-percent % packet loss";
                         }
                     }
                 }
-                term is-device-up {
+                term is-packet-loss {
                     when {
                         greater-than "$packet-loss-percent" 0 {
                             time-range 2offset;

--- a/juniper_official/Paragon/Foghorn/l3vpn-icmp.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-icmp.rule
@@ -1,0 +1,123 @@
+/*
+ * Collects ICMP probe status between PE and CE for a given routing-instance;
+ */
+healthbot {
+    topic protocol.icmp {
+        description "Collect routing instance and interfaces stats and notify anomalies";
+        synopsis "L3VPN session state analyzer";
+        rule check-icmp-statistics-with-source {
+            keys host;
+            sensor icmp {
+                synopsis "iAgent sensor definition";
+                description "Ping rpc to collect data from network device";
+                iAgent {
+                    file icmp-statistics-with-source.yml;
+                    table pingWithSourceTable;
+                    frequency 60s;
+                    args count {
+                        arg-value "{{count-var}}";
+                    }
+                    args host {
+                        arg-value "{{host-var}}";
+                    }
+                    args routing-instance {
+                        arg-value "{{rt-instance}}";
+                    }
+                    args source {
+                        arg-value "{{source-var}}";
+                    }
+                }
+            }
+            field host {
+                sensor icmp {
+                    path host;
+                }
+                type string;
+                description "Destination address/Host address in ICMP probe";
+            }
+            field packet-loss-percent {
+                sensor icmp {
+                    path packet-loss;
+                }
+                type integer;
+                description "ICMP probe packet loss percentage"
+            }
+            trigger packet-loss {
+                synopsis "ICMP packet loss KPI";
+                description "Sets health based on the packet loss";
+                frequency 1offset;
+                term is-device-not-reachable {
+                    when {
+                        equal-to "$packet-loss-percent" 100 {
+                            time-range 2offset;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Host $host not reachable";
+                        }
+                    }
+                }
+                term is-device-up {
+                    when {
+                        greater-than "$packet-loss-percent" 0 {
+                            time-range 2offset;
+                        }
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "Host $host reachable and  $packet-loss-percent % packet loss";
+                        }
+                    }
+                }
+                term no-packet-loss {
+                    then {
+                        status {
+                            color green;
+                            message "Host $host reachable and  $packet-loss-percent % packet loss";
+                        }
+                    }
+                }
+            }
+            variable count-var {
+                value 1;
+                description "Input ICMP probe count";
+                type sensor-argument;
+            }
+            variable host-var {
+                description "Input Destination host";
+                type sensor-argument;
+            }
+            variable rt-instance {
+                description "Routing instance on which ICMP probe is sent";
+                type sensor-argument;
+            }
+            variable source-var {
+                description "Source address to use in ICMP probe";
+                type sensor-argument;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+                helper-files other {
+                    list-of-files icmp-statistics-with-source.yml;
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/l3vpn-ospf-neighbor-vrf.yml
+++ b/juniper_official/Paragon/Foghorn/l3vpn-ospf-neighbor-vrf.yml
@@ -1,0 +1,22 @@
+L3vpnOspfNeighborTable:
+  rpc: get-ospf-neighbor-information
+  args:
+    instance: "all"
+  item: ospf-instance-neighbor
+  key:
+    - ospf-instance-name
+  view: view1
+
+view1:
+  fields:
+    ospf-instance-name: _NestedNeighborTable
+
+_NestedNeighborTable:
+  item: ospf-neighbor
+  key: neighbor-address
+  view: OspfNeighborView
+
+OspfNeighborView:
+  fields:
+    interface-name: interface-name
+    ospf-neighbor-state: ospf-neighbor-state

--- a/juniper_official/Paragon/Foghorn/l3vpn-ospf-session.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-ospf-session.rule
@@ -1,0 +1,57 @@
+/*
+ * Collects L3VPN OSPF protocol status between PE and CE
+ */
+healthbot {
+    topic protocol.ospf {
+        description "Collect routing instance OSPF session state";
+        synopsis "L3VPN OSPF session state analyzer";
+        rule get-l3vpn-ospf-neighbor-information {
+            keys [ interface-name neighbor-address ospf-instance-name ];
+            synopsis "OSPF session state analyzer";
+            description "Monitors the OPSF neighbor states for all routing instances";
+            sensor protocol-ospf-neighbor-information {
+                synopsis "OSPF iAgent sensor definition";
+                description "Netconfig rpc get-ospf-neighbor-information iAgent sensor to collect telemetry data from network device";
+                iAgent {
+                    file l3vpn-ospf-neighbor-vrf.yml;
+                    table L3vpnOspfNeighborTable;
+                    frequency 60s;
+                }
+            }
+            field neighbor-address {
+                sensor protocol-ospf-neighbor-information {
+                    path neighbor-address;
+                }
+                type string;
+                description "Neighbor address to monitor";
+            }
+            field ospf-neighbor-state {
+                sensor protocol-ospf-neighbor-information {
+                    path ospf-neighbor-state;
+                }
+                type string;
+                description "OSPF session state for a given neighbor";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+                helper-files other {
+                    list-of-files l3vpn-ospf-neighbor-vrf.yml;
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-bgp.playbook
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-bgp.playbook
@@ -1,0 +1,24 @@
+/*
+ * Collects BGP protocol status in L3VPN network and PE interface state
+ * and notifies anomalies when BGP session b/w PE and CE or PE interface
+ * is down.
+ *
+ * Rule protocol.l3vpn/get-interface-details, collects interface state.
+ * Rule protocol.bgp/get-l3vpn-bgp-routing-instance-details, collects
+ * BGP session details under routing instance
+ *
+ * Network rule check-l3vpn-bgp-state, Analyzes the routing instance, PE
+ * interface status and notifies anomalies when any of the state is down.
+ */
+healthbot {
+    playbook get-l3vpn-bgp-stats {
+        rules [ protocol.l3vpn/get-interface-details protocol.bgp/get-l3vpn-bgp-routing-instance-details ];
+        description "Playbook collects interface and routing instance details periodically";
+        synopsis "Interface and routing instance BGP session info collector";
+    }
+    playbook get-l3vpn-bgp-view {
+        rules protocol.l3vpn/check-l3vpn-bgp-state;
+        description "Playbook checks health of L3VPN session, PE interface status and notify anomaly when either BGP session state or PE interface state is down";
+        synopsis "L3VPN network health analyzer";
+    }
+}

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-bgp.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-bgp.rule
@@ -1,0 +1,160 @@
+/*
+ * Refers L3VPN BGP protocol status between PE and CE, PE interface details
+ * and notifies anomalies when either BGP session or PE interface is down.
+ */
+healthbot {
+    topic protocol.l3vpn {
+        description "Refer routing instance BGP session state and PE interfaces state and notify anomalies";
+        synopsis "L3VPN BGP session state analyzer";
+        rule check-l3vpn-bgp-state {
+            synopsis "L3VPN session state detector";
+            description "Refer L3VPN peer state and PE interface state from rule protocol.bgp/get-l3vpn-bgp-routing-instance-details & protocol.l3vpn/get-interface-details and notify anomalies when flap count increases";
+            rule-frequency 75s;
+            network-rule;
+            field instance-ifl-no {
+                constant {
+                    value "{{pe-ifl-number}}";
+                }
+                type integer;
+                description "Routing instance IFL number";
+            }
+            field instance-interface-name {
+                constant {
+                    value "{{pe-interface-name}}";
+                }
+                type string;
+                description "Routing instance interface name";
+            }
+            field instance-interface-status {
+                reference {
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='protocol.l3vpn']/rule[rule-name=get-interface-details]/field[sub-interface-index='{{pe-ifl-number}}' and interface-name='{{pe-interface-name}}']/link-state";
+                }
+                type string;
+                description "Routing instance interface status";
+            }
+            field neighbor-session {
+                constant {
+                    value "{{customer-neighbor-address}}";
+                }
+                type string;
+                description "Protocol neighbor address";
+            }
+            /*
+             * Fields defined by collecting values from other rule. Maps the
+             * longer references to the shorter field names used in this rule.
+             */
+            field pe-router-name {
+                constant {
+                    value "{{pe-device-name}}";
+                }
+                type string;
+                description "PE router name to monitor";
+            }
+            field vpn-name {
+                constant {
+                    value "{{customer-vpn-name}}";
+                }
+                type string;
+                description "VRF name";
+            }
+            field vpn-state {
+                reference {
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='protocol.bgp']/rule[rule-name=get-l3vpn-bgp-routing-instance-details]/field[neighbor-address='{{customer-neighbor-address}}']/session-state";
+                }
+                type string;
+                description "VRF peer state";
+            }
+            trigger l3vpn-pe-interface-state {
+                frequency 1offset;
+                term is-pe-interface-up {
+                    when {
+                        matches-with "$instance-interface-status" UP;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is UP";
+                        }
+                    }
+                }
+                term is-pe-interface-down {
+                    then {
+                        status {
+                            color red;
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is $instance-interface-status";
+                        }
+                    }
+                }
+            }
+            trigger l3vpn-state {
+                synopsis "L3VPN session status KPI";
+                description "Sets health based on state change in L3VPN peer, CE interface and PE interface state.";
+                frequency 1offset;
+                term is-vpn-session-up {
+                    when {
+                        matches-with "$vpn-state" ESTABLISHED;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is UP";
+                        }
+                    }
+                }
+                term is-vpn-session-down {
+                    then {
+                        status {
+                            color red;
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is $vpn-state";
+                        }
+                    }
+                }
+            }
+            variable customer-neighbor-address {
+                description "BGP neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
+                type string;
+            }
+            /*
+             * Variables with default values. Default values can be changed
+             * while deploying playbook instance.
+             */
+            variable customer-vpn-name {
+                description "VRF name to monitor, regular expression, e.g. 'customer*'";
+                type string;
+            }
+            variable pe-device-group {
+                description "Router group to monitor, regular expression, e.g. 'edge.*'";
+                type device-group;
+            }
+            variable pe-device-name {
+                description "Router name to monitor, regular expression, e.g. 'edge-router.*'";
+                type device;
+            }
+            variable pe-ifl-number {
+                description "PE IFL to monitor, regular expression, e.g. '1-10'";
+                type int;
+            }
+            variable pe-interface-name {
+                description "PE interface to monitor, regular expression, e.g. 'ge-.*'";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-bgp.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-bgp.rule
@@ -115,8 +115,8 @@ healthbot {
                 type string;
             }
             /*
-             * Variables with default values. Default values can be changed
-             * while deploying playbook instance.
+             * Variables with default values. Default values can be
+             * changed while deploying playbook instance.
              */
             variable customer-vpn-name {
                 description "VRF name to monitor, regular expression, e.g. 'customer*'";

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-ospf.playbook
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-ospf.playbook
@@ -1,0 +1,24 @@
+/*
+ * Collects OSPF session status in L3VPN network and PE interface state
+ * and notifies anomalies when OSPF session b/w PE and CE or PE interface
+ * is down.
+ *
+ * Rule protocol.l3vpn/get-interface-details, collects interface state.
+ * Rule protocol.ospf/get-l3vpn-ospf-neighbor-information, collects
+ * BGP session details under routing instance
+ *
+ * Network rule check-l3vpn-ospf-state, Analyzes the routing instance, PE
+ * interface status and notifies anomalies when any of the state is down.
+ */
+healthbot {
+    playbook get-l3vpn-ospf-stats {
+        rules [ protocol.l3vpn/get-interface-details protocol.ospf/get-l3vpn-ospf-neighbor-information ];
+        description "Playbook collects interface and routing instance details periodically";
+        synopsis "Interface and routing instance OSPF neighborship info collector";
+    }
+    playbook get-l3vpn-ospf-view {
+        rules protocol.l3vpn/check-l3vpn-ospf-state;
+        description "Playbook checks health of L3VPN session, PE interface status and notify anomaly when either OSPF session state or PE interface state is down";
+        synopsis "L3VPN network health analyzer";
+    }
+}

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-ospf.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-ospf.rule
@@ -1,0 +1,156 @@
+/*
+ * Refers L3VPN OSPF protocol status between PE and CE, PE interface details
+ * and notifies anomalies when either OSPF session or PE interface is down.
+ */
+healthbot {
+    topic protocol.l3vpn {
+        description "Refer routing instance OSPF session state and PE interfaces state and notify anomalies";
+        synopsis "L3VPN OSPF session state analyzer";
+        rule check-l3vpn-ospf-state {
+            synopsis "L3VPN session state detector";
+            description "Refer L3VPN peer state, PE interface states from rule protocol.ospf/get-l3vpn-ospf-neighbor-information & protocol.l3vpn/get-interface-details and notify anomalies when flap count increases";
+            rule-frequency 75s;
+            network-rule;
+            field instance-ifl-no {
+                constant {
+                    value "{{pe-ifl-number}}";
+                }
+                type integer;
+                description "Routing instance IFL number";
+            }
+            field instance-interface-name {
+                constant {
+                    value "{{pe-interface-name}}";
+                }
+                type string;
+                description "Routing instance interface name";
+            }
+            field instance-interface-status {
+                reference {
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='protocol.l3vpn']/rule[rule-name=get-interface-details]/field[sub-interface-index='{{pe-ifl-number}}' and interface-name='{{pe-interface-name}}']/link-state";
+                }
+                type string;
+                description "Routing instance interface status";
+            }
+            field neighbor-session {
+                constant {
+                    value "{{neighbor-address}}";
+                }
+                type string;
+                description "Protocol neighbor address";
+            }
+            field pe-router-name {
+                constant {
+                    value "{{pe-device-name}}";
+                }
+                type string;
+                description "PE router name to monitor";
+            }
+            field vpn-name {
+                constant {
+                    value "{{customer-vpn-name}}";
+                }
+                type string;
+                description "VRF name";
+            }
+            field vpn-state {
+                reference {
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='protocol.ospf']/rule[rule-name=get-l3vpn-ospf-neighbor-information]/field[neighbor-address='{{neighbor-address}}']/ospf-neighbor-state";
+                    data-if-missing {
+                        value DOWN;
+                    }
+                    time-range 120s;
+                }
+                type string;
+                description "VRF peer state";
+            }
+            trigger l3vpn-pe-interface-state {
+                frequency 1offset;
+                term is-pe-interface-up {
+                    when {
+                        matches-with "$instance-interface-status" UP;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is UP";
+                        }
+                    }
+                }
+                term is-pe-interface-down {
+                    then {
+                        status {
+                            color red;
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is $instance-interface-status";
+                        }
+                    }
+                }
+            }
+            trigger l3vpn-state {
+                synopsis "L3VPN session status KPI";
+                description "Sets health based on state change in L3VPN peer, CE interface and PE interface state.";
+                frequency 1offset;
+                term is-vpn-session-up {
+                    when {
+                        matches-with "$vpn-state" Full;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is UP";
+                        }
+                    }
+                }
+                term is-vpn-session-down {
+                    then {
+                        status {
+                            color red;
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is $vpn-state";
+                        }
+                    }
+                }
+            }
+            variable customer-vpn-name {
+                description "VRF name to monitor, regular expression, e.g. 'customer*'";
+                type string;
+            }
+            variable neighbor-address {
+                description "BGP neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
+                type string;
+            }
+            variable pe-device-group {
+                description "Router group to monitor, regular expression, e.g. 'edge.*'";
+                type device-group;
+            }
+            variable pe-device-name {
+                description "Router name to monitor, regular expression, e.g. 'edge-router.*'";
+                type device;
+            }
+            variable pe-ifl-number {
+                description "PE IFL to monitor, regular expression, e.g. '1-10'";
+                type int;
+            }
+            variable pe-interface-name {
+                description "PE interface to monitor, regular expression, e.g. 'ge-.*'";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-static.playbook
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-static.playbook
@@ -1,0 +1,24 @@
+/*
+ * Collects ICMP probe statistics in L3VPN network and PE interface state
+ * and notifies anomalies when ICMP probe b/w PE and CE results in packet
+ * loss or PE interface is down.
+ *
+ * Rule protocol.l3vpn/get-interface-details, collects interface state.
+ * Rule protocol.icmp/check-icmp-statistics-with-source, collects ICMP probe 
+ * packet loss details for a given routing instance and source address
+ *
+ * Network rule check-l3vpn-static-state, Analyzes the routing instance, PE
+ * interface status and notifies anomalies when any of the state is down.
+ */
+healthbot {
+    playbook get-l3vpn-static-info {
+        rules [ protocol.l3vpn/get-interface-details protocol.icmp/check-icmp-statistics-with-source ];
+        description "Playbook collects interface and routing instance details periodically";
+        synopsis "Interface and routing instance BGP session info collector";
+    }
+    playbook get-l3vpn-static-view {
+        rules protocol.l3vpn/check-l3vpn-static-state;
+        description "Playbook checks health of L3VPN session, PE interface status and notify anomaly when either ICMP probe packet loss or PE interface state is down";
+        synopsis "L3VPN network health analyzer";
+    }
+}

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-static.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-static.rule
@@ -1,0 +1,175 @@
+/*
+ * Refers L3VPN ICMP probe status between PE and CE, PE interface details
+ * and notifies anomalies when either there is packet loss or PE interface is down.
+ */
+healthbot {
+    topic protocol.l3vpn {
+        description "Refers ICMP probe result and PE interfaces state and notify anomalies";
+        synopsis "L3VPN session state analyzer";
+        rule check-l3vpn-static-state {
+            synopsis "L3VPN session state detector";
+            description "Refer L3VPN peer state through ICMP probe and PE interface states from rule protocol.icmp/check-icmp-statistics-with-source & protocol.bgp/get-interface-details and notify anomalies when flap count increases";
+            rule-frequency 75s;
+            network-rule;
+            field instance-ifl-no {
+                constant {
+                    value "{{pe-ifl-number}}";
+                }
+                type integer;
+                description "Routing instance IFL number";
+            }
+            field instance-interface-name {
+                constant {
+                    value "{{pe-interface-name}}";
+                }
+                type string;
+                description "Routing instance interface name";
+            }
+            field instance-interface-status {
+                reference {
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='protocol.l3vpn']/rule[rule-name=get-interface-details]/field[sub-interface-index='{{pe-ifl-number}}' and interface-name='{{pe-interface-name}}']/link-state";
+                }
+                type string;
+                description "Routing instance interface status";
+            }
+            field neighbor-address {
+                constant {
+                    value "{{customer-neighbor-address}}";
+                }
+                type string;
+                description "Protocol neighbor address";
+            }
+            /*
+             * Fields defined by collecting values from other rule. Maps the
+             * longer references to the shorter field names used in this rule.
+             */
+            field pe-router-name {
+                constant {
+                    value "{{pe-device-name}}";
+                }
+                type string;
+                description "PE router name to monitor";
+            }
+            field vpn-name {
+                constant {
+                    value "{{customer-vpn-name}}";
+                }
+                type string;
+                description "VRF name";
+            }
+            field vpn-state {
+                reference {
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='protocol.icmp']/rule[rule-name=check-icmp-statistics-with-source]/field[host='{{customer-neighbor-address}}']/packet-loss-percent";
+                }
+                type integer;
+                description "VRF peer state";
+            }
+            trigger l3vpn-pe-interface-state {
+                frequency 1offset;
+                term is-pe-interface-up {
+                    when {
+                        matches-with "$instance-interface-status" UP;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is UP";
+                        }
+                    }
+                }
+                term is-pe-interface-down {
+                    then {
+                        status {
+                            color red;
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is $instance-interface-status";
+                        }
+                    }
+                }
+            }
+            trigger l3vpn-state {
+                synopsis "L3VPN session status KPI";
+                description "Sets health based on state change in L3VPN peer, CE interface and PE interface state.";
+                frequency 1offset;
+                term is-device-not-reachable {
+                    when {
+                        equal-to "$vpn-state" 100 {
+                            time-range 2offset;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Host $neighbor-address not reachable";
+                        }
+                    }
+                }
+                term is-device-up {
+                    when {
+                        greater-than "$vpn-state" 0 {
+                            time-range 2offset;
+                        }
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "Host $neighbor-address reachable and  $vpn-state % packet loss";
+                        }
+                    }
+                }
+                term no-packet-loss {
+                    then {
+                        status {
+                            color green;
+                            message "Host $neighbor-address reachable and  $vpn-state % packet loss";
+                        }
+                    }
+                }
+            }
+            variable customer-neighbor-address {
+                description "BGP neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
+                type string;
+            }
+            /*
+             * Variables with default values. Default values can be changed
+             * while deploying playbook instance.
+             */
+            variable customer-vpn-name {
+                description "VRF name to monitor, regular expression, e.g. 'customer*'";
+                type string;
+            }
+            variable pe-device-group {
+                description "Router group to monitor, regular expression, e.g. 'edge.*'";
+                type device-group;
+            }
+            variable pe-device-name {
+                description "Router name to monitor, regular expression, e.g. 'edge-router.*'";
+                type device;
+            }
+            variable pe-ifl-number {
+                description "PE IFL to monitor, regular expression, e.g. '1-10'";
+                type int;
+            }
+            variable pe-interface-name {
+                description "PE interface to monitor, regular expression, e.g. 'ge-.*'";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The files consists of playbooks and rules to support 3 different topologies that will be used in Foghorn project.
In L3VPN scenario, configuration may have one of BGP/OSPF/static protocol configured between PE and CE. Also, CE details except for the interface address that is reachable via PE is not available. Hence, new playbooks have been written.
 Playbook for L3VPN with BGP : l3vpn-proto-bgp.playbook, network rule file -  l3vpn-proto-bgp.rule, Rule to check BGP session -  l3vpn-bgp-session.rule
Playbook for L3VPN with OSPF: l3vpn-proto-ospf.playbook, network rule file -  l3vpn-proto-ospf.rule, Rule to check OSPF neighborship - l3vpn-ospf-session.rule, helper file -  l3vpn-ospf-neighbor-vrf.yml
Playbook for L3VPN with static protocol:  l3vpn-proto-static.playbook, network rule file -  l3vpn-proto-static.rule, Rule to check ICMP probe - icmp-statistics-with-source.yml, helper file -  l3vpn-icmp.rule

