### PR TITLE
Changes to make Foghorn BGP, OSPF and ICMP rules to have uniform naming of variables

### DIFF
--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-ospf.playbook
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-ospf.playbook
@@ -5,7 +5,7 @@
  *
  * Rule protocol.l3vpn/get-interface-details, collects interface state.
  * Rule protocol.ospf/get-l3vpn-ospf-neighbor-information, collects
- * BGP session details under routing instance
+ * OSPF session details under routing instance
  *
  * Network rule check-l3vpn-ospf-state, Analyzes the routing instance, PE
  * interface status and notifies anomalies when any of the state is down.

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-ospf.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-ospf.rule
@@ -34,7 +34,7 @@ healthbot {
             }
             field neighbor-session {
                 constant {
-                    value "{{neighbor-address}}";
+                    value "{{customer-neighbor-address}}";
                 }
                 type string;
                 description "Protocol neighbor address";
@@ -55,7 +55,7 @@ healthbot {
             }
             field vpn-state {
                 reference {
-                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='protocol.ospf']/rule[rule-name=get-l3vpn-ospf-neighbor-information]/field[neighbor-address='{{neighbor-address}}']/ospf-neighbor-state";
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='protocol.ospf']/rule[rule-name=get-l3vpn-ospf-neighbor-information]/field[neighbor-address='{{customer-neighbor-address}}']/ospf-neighbor-state";
                     data-if-missing {
                         value DOWN;
                     }
@@ -110,12 +110,12 @@ healthbot {
                     }
                 }
             }
-            variable customer-vpn-name {
-                description "VRF name to monitor, regular expression, e.g. 'customer*'";
+            variable customer-neighbor-address {
+                description "OSPF neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
                 type string;
             }
-            variable neighbor-address {
-                description "BGP neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
+            variable customer-vpn-name {
+                description "VRF name to monitor, regular expression, e.g. 'customer*'";
                 type string;
             }
             variable pe-device-group {

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-static.playbook
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-static.playbook
@@ -14,7 +14,7 @@ healthbot {
     playbook get-l3vpn-static-info {
         rules [ protocol.l3vpn/get-interface-details protocol.icmp/check-icmp-statistics-with-source ];
         description "Playbook collects interface and routing instance details periodically";
-        synopsis "Interface and routing instance BGP session info collector";
+        synopsis "Interface and routing instance ICMP probe info collector";
     }
     playbook get-l3vpn-static-view {
         rules protocol.l3vpn/check-l3vpn-static-state;

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-static.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-static.rule
@@ -8,7 +8,7 @@ healthbot {
         synopsis "L3VPN session state analyzer";
         rule check-l3vpn-static-state {
             synopsis "L3VPN session state detector";
-            description "Refer L3VPN peer state through ICMP probe and PE interface states from rule protocol.icmp/check-icmp-statistics-with-source & protocol.bgp/get-interface-details and notify anomalies when flap count increases";
+            description "Refer L3VPN peer state through ICMP probe and PE interface states from rule protocol.icmp/check-icmp-statistics-with-source & protocol.l3vpn/get-interface-details and notify anomalies when flap count increases";
             rule-frequency 75s;
             network-rule;
             field instance-ifl-no {

--- a/juniper_official/Paragon/Foghorn/l3vpn-proto-static.rule
+++ b/juniper_official/Paragon/Foghorn/l3vpn-proto-static.rule
@@ -126,7 +126,7 @@ healthbot {
                 }
             }
             variable customer-neighbor-address {
-                description "BGP neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
+                description "neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
                 type string;
             }
             /*


### PR DESCRIPTION
Changes include
1. Change neighbor-address variable to customer-neighbor-address in OSPF rule to make it uniform across BGP, OSPF and ICMP rules. This will help in development of templates in Foghorn project
2. Remove BGP name from OSPF and ICMP rules, playbooks