### PR TITLE
Foghorn L2VPN (EVPN) rules and playbook

### DIFF
--- a/juniper_official/Paragon/Foghorn/evpn-check-mac-count-netconf.rule
+++ b/juniper_official/Paragon/Foghorn/evpn-check-mac-count-netconf.rule
@@ -1,0 +1,116 @@
+/*
+ *   This rule checks health of MAC count in evpn mac table and notify in case any of the health monitored field crosses threshold
+ */
+healthbot {
+    topic foghorn.evpn {
+        description "This rule checks health of MAC count in evpn mac table and notify in case any of the health monitored field crosses threshold";
+        synopsis "MAC count check in evpn";
+        rule evpn-check-mac-count-netconf {
+            keys learn-vlan;
+            synopsis "MAC count in evpn mac table analyzer";
+            description "This rule checks health of MAC count in ethernet switching table and notify in case any of the health monitored field crosses threshold";
+            sensor evpn-mac-count {
+                synopsis "mac count netconf based iAgent sensor definition";
+                description "iAgent sensor defined in yml file using netconf rpc/cli command and defined fields using pyez tables&views to collect data from network device";
+                iAgent {
+                    file evpn-mac-count.yml;
+                    table MacCountTable;
+                    frequency 180s;
+                }
+            }
+            /*
+             * Fields defined using sensor path. Map the longer sensor names
+             * to the shorter field names used in the rules.
+             */
+            field mac-count {
+                sensor evpn-mac-count {
+                    path mac-count;
+                }
+                type integer;
+                description "This filed is for mac count";
+            }
+            field threshold {
+                constant {
+                    value "{{static-threshold}}";
+                }
+                type integer;
+            }
+            field learn-vlan {
+                sensor evpn-mac-count {
+                    where "learn-vlan =~ /{{vlan-id}}/";
+                    path learn-vlan;
+                }
+                type string;
+                description "VLAN ID";
+            }
+            /*
+             * Anomaly detection logic.
+             */
+            trigger mac-count {
+                synopsis "MAC count kpi";
+                description "Sets health based on MAC count in ethernet switching table.";
+                frequency 1.5offset;
+                term ignore-default-vlan {
+                    when {
+                        matches-with "$learn-vlan" default {
+                            ignore-case;
+                        }
+                    }
+                }
+                term is-mac-count-above-static-threshold {
+                    when {
+                        greater-than-or-equal-to "$mac-count" "$threshold";
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Observed significant amount of changes in MAC count ($mac-count) of VLAN($learn-vlan)";
+                        }
+                    }
+                }
+                term mac-count-normal {
+                    then {
+                        status {
+                            color green;
+                            message "MAC count ($mac-count) of VLAN($learn-vlan) is normal";
+                        }
+                    }
+                }
+            }
+           /*
+            * Variables with default values. Default values can be changed
+            * while deploying playbook instance.
+            */
+            variable static-threshold {
+                value 800;
+                description "Enter MAC limit threshold per VLAN";
+                type int;
+            }
+            variable vlan-id {
+                value .*;
+                description "Enter VLAN IDs to be monitored.";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+                helper-files other {
+                    list-of-files evpn-mac-count.yml;
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/evpn-interface-status.rule
+++ b/juniper_official/Paragon/Foghorn/evpn-interface-status.rule
@@ -1,0 +1,100 @@
+/*
+ * Indicates whether an interface is UP or DOWN;
+ */
+healthbot {
+    topic foghorn.evpn {
+        rule get-interface-details {
+            keys [ interface-name sub-interface-index ];
+            /*
+             * Collects all interface and sub-interface(IFL) details periodically
+             *
+             * Use interface-name and  sub-interface-index as keys for rule.
+             */
+            synopsis "Interface details collector.";
+            description "Collects interface and IFL status periodically";
+            /*
+             * Sensor configuration to get data from network devices
+             */
+            sensor interfaces {
+                synopsis "Interface open-config sensor definition";
+                description "Interfaces open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /interfaces/;
+                    frequency 60s;
+                }
+            }
+            field interface-name {
+                sensor interfaces {
+                    where "/interfaces/interface/@name =~ /{{ifd-name}}/";
+                    path "/interfaces/interface/@name";
+                }
+                type string;
+                description "Interfaces to be monitored";
+            }
+            field link-state {
+                sensor interfaces {
+                    path /interfaces/interface/subinterfaces/subinterface/state/oper-status;
+                }
+                type string;
+                description "Sub Interface oper status.";
+            }
+            field sub-interface-index {
+                sensor interfaces {
+                    where "/interfaces/interface/subinterfaces/subinterface/@index =~ /{{ifl-no}}/";
+                    path "/interfaces/interface/subinterfaces/subinterface/@index";
+                }
+                type string;
+                description "IFL to be monitored";
+            }
+            trigger l2vpn-pe-interface-state {
+                frequency 1.5offset;
+                term is-pe-interface-up {
+                    when {
+                        matches-with "$link-state" UP;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "PE interface $interface-name.$sub-interface-index is $link-state";
+                        }
+                    }
+                }
+                term is-pe-interface-down {
+                    then {
+                        status {
+                            color red;
+                            message "PE interface $interface-name.$sub-interface-index is $link-state";
+                        }
+                    }
+                }
+            }
+            variable ifd-name {
+                value .*;
+                description "Interfaces to be monitored, regular expression, eg 'ge-.*';";
+                type string;
+            }
+            variable ifl-no {
+                value .*;
+                description "Sub interfaces index to be monitored, regular expression, eg '0-10'";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/evpn-lfm.rule
+++ b/juniper_official/Paragon/Foghorn/evpn-lfm.rule
@@ -1,0 +1,93 @@
+/*
+ * Collects LFM state for a PE interface that connects to a CE
+ */
+healthbot {
+    topic foghorn.evpn {
+        description "Collect LFM interface state";
+        synopsis "EVPN LFM discovery state analyzer";
+        rule get-lfm-information {
+            keys  [ lfm-interface-name ];
+            synopsis "LFM discovery state analyzer";
+            description "Monitors the discovery state for a PE interface which is connected to CE";
+            sensor link-fault-management-information {
+                synopsis "EVPN LFM iAgent sensor definition";
+                description "Netconfig rpc get-evpn-lfm-information iAgent sensor to collect telemetry data from network device";
+                iAgent {
+                    file evpn-lfm.yml;
+                    table EvpnLFMTable;
+                    frequency 60s;
+                }
+            }
+            field lfm-discovery-state {
+                sensor link-fault-management-information {
+                    path lfmd-discovery-state;
+                }
+                type string;
+                description "Discovery state for a given interface";
+            }
+            field lfm-interface-name {
+                sensor link-fault-management-information {
+                    path lfmd-interface-name;
+                }
+                type string;
+                description "interface for which LFM info is collected";
+            }
+            field pe-interface-name {
+                constant {
+                    value "{{interface-name}}"
+                }
+                type string;
+                description "PE Interface to monitor";
+            }
+            trigger lfm-interface-discovery-state {
+                synopsis "LFM discovery status KPI";
+                description "Sets health based on LFM discovery state between PE and CE";
+                frequency 1.5offset;
+                term is-lfm-remote-discovery-status {
+                    when {
+                        matches-with "$lfm-discovery-state" "Send Any";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "Remote side $lfm-interface-name is $lfm-discovery-state";
+                        }
+                    }
+                }
+                term lfm-discovery-state-remote-unstable {
+                    then {
+                        status {
+                            color red;
+                            message "LFM on $lfm-interface-name is in Discovery State $lfm-discovery-state";
+                        }
+                    }
+                }
+            }
+            variable interface-name {
+                value .*
+                description "PE interface to monitor, regular expression, e.g. 'ge-.*'";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+                helper-files other {
+                    list-of-files evpn-lfm.yml;
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/evpn-lfm.yml
+++ b/juniper_official/Paragon/Foghorn/evpn-lfm.yml
@@ -1,10 +1,10 @@
 ---
 EvpnLFMTable:
     rpc: get-lfmd-information
-    item: lfmd-interface-information 
-    key: lfmd-interface-name 
+    item: lfmd-interface-information
+    key: lfmd-interface-name
     view: EvpnLFMTableView
 
 EvpnLFMTableView:
     fields:
-        lfmd-discovery-state : lfmd-discovery-state
+        lfmd-discovery-state: lfmd-discovery-state

--- a/juniper_official/Paragon/Foghorn/evpn-lfm.yml
+++ b/juniper_official/Paragon/Foghorn/evpn-lfm.yml
@@ -1,0 +1,10 @@
+---
+EvpnLFMTable:
+    rpc: get-lfmd-information
+    item: lfmd-interface-information 
+    key: lfmd-interface-name 
+    view: EvpnLFMTableView
+
+EvpnLFMTableView:
+    fields:
+        lfmd-discovery-state : lfmd-discovery-state

--- a/juniper_official/Paragon/Foghorn/evpn-lldp-session-state.rule
+++ b/juniper_official/Paragon/Foghorn/evpn-lldp-session-state.rule
@@ -1,0 +1,158 @@
+/*
+ * Detects LLDP (session) state changes and notifies when anomalies are found.
+ * One input control detection
+ * 
+ *   1) if-name, is a regular expression that matches the
+ *      interfaces that you would like to monitor.  By default it's
+ *      '.*', which matches all interfaces. Use something like 'ge.*' to
+ *      match only gigabit ethernet interfaces.
+ */
+healthbot {
+    topic foghorn.evpn {
+        description "Monitors lldp information i.e. neighbor state and notify anomalies";
+        synopsis "LLDP session statistics analyzer";
+        rule check-lldp-session {
+            description "Collects lldp session state periodically and notify anomaly when state is down";
+            synopsis "LLDP session state analyzer";
+            /*
+             * Monitors the LLDP session state. Notifies via the dashboard
+             * colors when the session state is false and color is set to red.
+             * Otherwise the color is set to green.
+             * 
+             * Use interface name as key for rule.
+             */
+            keys interface-name;
+            /*
+             * Sensor configuration to get data from network devices
+             */
+            sensor lldp-sensor {
+                synopsis "LLDP open-config sensor definition";
+                description "/lldp open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /lldp/;
+                    frequency 60s;
+                }
+            }
+            /*
+             * Fields defined using sensor path. Map the longer sensor names
+             * to the shorter field names used in the rules.
+             */
+            field if-lldp-state {
+                sensor lldp-sensor {
+                    path /lldp/interfaces/interface/state/enabled;
+                }
+                type string;
+                description "Local interface LLDP state";
+            }
+            field interface-name {
+                sensor lldp-sensor {
+                    where "/lldp/interfaces/interface/@name =~ /{{if-name}}/";
+                    path "/lldp/interfaces/interface/@name";
+                }
+                type string;
+                description "Interfaces to be monitored";
+            }
+            field neighbor-state {
+                reference {
+                    path "/topic[topic-name='foghorn.evpn']/rule[rule-name='get-lldp-state']/field[interface-name='$interface-name']/neighbor-capability-state";
+                    time-range 60s;
+                }
+                type string;
+                description "LLDP neighbor state";
+            }
+            /*
+             * Anomaly detection logic.
+             */
+            trigger lldp-session-state {
+                synopsis "LLDP state KPI";
+                description "Sets health based on lldp session state changes and notify anomaly.";
+                frequency 1offset;
+                /*
+                 * Sets color to green when LLDP neighbor state is true.
+                 */
+                term is-lldp-session-up {
+                    when {
+                        matches-with "$neighbor-state" true;
+                        matches-with "$if-lldp-state" true;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "Interface $interface-name lldp session is up";
+                        }
+                    }
+                }
+                /*
+                 * Defaults color to red and notify anomaly.
+                 */
+                term lldp-session-down {
+                    then {
+                        status {
+                            color red;
+                            message "Interface-$interface-name lldp session down";
+                        }
+                    }
+                }
+            }
+            /*
+             * Variables with default values. Default values can be changed
+             * while deploying playbook instance.
+             */
+            variable if-name {
+                value ".*";
+                type string;
+                description "Interface names to monitor, regular expression, eg 'ge-.*'";
+           }
+        }
+        rule get-lldp-state {
+            keys interface-name;
+            synopsis "LLDP neighbor state collector";
+            description "Collects lldp session state periodically";
+            sensor lldp-sensor {
+                synopsis "LLDP open-config sensor definition";
+                description "/lldp open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /lldp/;
+                    frequency 55s;
+                }
+            }
+            field interface-name {
+                sensor lldp-sensor {
+                    where "/lldp/interfaces/interface/@name =~ /{{if-name}}/";
+                    path "/lldp/interfaces/interface/@name";
+                }
+                type string;
+                description "Interfaces to be monitored";
+            }
+            field neighbor-capability-state {
+                sensor lldp-sensor {
+                    path /lldp/interfaces/interface/neighbors/neighbor/capabilities/capability/state/enabled;
+                }
+                type string;
+                description "Remote LLDP neighbor state";
+            }
+            variable if-name {
+                value .*;
+                description "Interface names to monitor, regular expression, eg 'ge-.*'";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                supported-healthbot-version 4.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products MX {
+                                releases 20.1R1 {
+                                    release-support min-supported-release;
+                                    platform [ MX2010 MX2020 MX240 MX480 MX960 ];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Paragon/Foghorn/evpn-mac-count.yml
+++ b/juniper_official/Paragon/Foghorn/evpn-mac-count.yml
@@ -4,7 +4,7 @@ MacCountTable:
     args:
         count: True
     item: l2ald-rtb-mac-count-entry/l2ald-rtb-learn-vlan-mac-count/l2ald-rtb-learn-vlan-mac-count-entry
-    key: learn-vlan 
+    key: learn-vlan
     view: MacCountView
 
 MacCountView:

--- a/juniper_official/Paragon/Foghorn/evpn-mac-count.yml
+++ b/juniper_official/Paragon/Foghorn/evpn-mac-count.yml
@@ -1,0 +1,12 @@
+---
+MacCountTable:
+    rpc: get-evpn-mac-table
+    args:
+        count: True
+    item: l2ald-rtb-mac-count-entry/l2ald-rtb-learn-vlan-mac-count/l2ald-rtb-learn-vlan-mac-count-entry
+    key: learn-vlan 
+    view: MacCountView
+
+MacCountView:
+    fields:
+        mac-count: mac-count

--- a/juniper_official/Paragon/Foghorn/fh-evpn-monitoring.playbook
+++ b/juniper_official/Paragon/Foghorn/fh-evpn-monitoring.playbook
@@ -15,6 +15,7 @@
  * - Checks LLDP status on an interface and notifies anamolies when
  * neighbor is not UP
  */
+
 healthbot {
     playbook fh-evpn-view {
         rules [ foghorn.evpn/check-lldp-session  foghorn.evpn/evpn-check-mac-count-netconf  foghorn.evpn/get-interface-details foghorn.evpn/get-lfm-information foghorn.evpn/get-lldp-state ];

--- a/juniper_official/Paragon/Foghorn/fh-evpn-monitoring.playbook
+++ b/juniper_official/Paragon/Foghorn/fh-evpn-monitoring.playbook
@@ -1,0 +1,25 @@
+/*
+ * Playbook contains multiple rules which monitors different conditions
+ * in EVPN deployment and notifies when anamolies are found
+ * 
+ * Rule foghorn.evpn/get-interface-details - collects interface state 
+ * and notifies anomoly when interface is not UP
+ *
+ * Rule foghorn.evpn/evpn-check-mac-count-netconf - monitors MAC count
+ * in evpn mac table and notifies anamolies when threshold exceeds
+ *
+ * Rule foghorn.evpn/get-lfm-information - Checks status of LFM (802.3AH)
+ * on given interface and notifies anamolies based on Discovery State
+ *
+ * Rules foghorn.evpn/check-lldp-session and foghorn.evpn/get-lldp-state
+ * - Checks LLDP status on an interface and notifies anamolies when
+ * neighbor is not UP
+ */
+healthbot {
+    playbook fh-evpn-view {
+        rules [ foghorn.evpn/check-lldp-session  foghorn.evpn/evpn-check-mac-count-netconf  foghorn.evpn/get-interface-details foghorn.evpn/get-lfm-information foghorn.evpn/get-lldp-state ];
+        description "Playbook collects interface and protocol details periodically and notifies anamolies";
+        synopsis "EVPN network health analyzer in scenarios supported in Foghorn";
+    }
+}
+


### PR DESCRIPTION
Files are consisting of rules that are used in EVPN scenarios of Foghorn project and playbook consisting of all these rules. Objective is to represent all rules per PE under a single tile i.e., foghorn.evpn