### PR TITLE
Added new xmchip pattern and example for cisco syslog header

### DIFF
--- a/community_supplied/VendorSpecific/Cisco/IOS_XR/Syslog/MATCH-ALL-SYSLOG-PATTERN.ingest
+++ b/community_supplied/VendorSpecific/Cisco/IOS_XR/Syslog/MATCH-ALL-SYSLOG-PATTERN.ingest
@@ -1,0 +1,10 @@
+healthbot {
+    ingest {
+        syslog {
+            pattern ALLDATA {
+                event-id ALL-DATA;
+                filter "%{GREEDYDATA:syslog_message}";
+            }
+        }
+    }
+}

--- a/community_supplied/VendorSpecific/Cisco/IOS_XR/Syslog/MATCH-ALL-SYSLOG-PATTERNSET.ingest
+++ b/community_supplied/VendorSpecific/Cisco/IOS_XR/Syslog/MATCH-ALL-SYSLOG-PATTERNSET.ingest
@@ -1,0 +1,10 @@
+healthbot {
+    ingest {
+        syslog {
+            pattern-set ALL-DATA-PS {
+                pattern-names ALLDATA;
+            }
+        }
+    }
+}
+

--- a/community_supplied/VendorSpecific/Cisco/IOS_XR/Syslog/MATCH-ALL-SYSLOG.rule
+++ b/community_supplied/VendorSpecific/Cisco/IOS_XR/Syslog/MATCH-ALL-SYSLOG.rule
@@ -1,0 +1,46 @@
+healthbot {
+    /* Collects all the syslogs received from the device and notifies when anomalies are found */
+    topic syslog {
+        description "Collects all the syslogs received from the device and notifies when a syslog matches the user defined value ";
+        rule get-all-data {
+            sensor syslog-sensor {
+                syslog {
+                    pattern-set ALL-DATA-PS;
+                }
+            }
+            field syslog-message {
+                sensor syslog-sensor {
+                    path syslog_message;
+                }
+            }
+            field syslog-to-match-field {
+                constant {
+                    value "{{syslog-to-match}}";
+                }
+                type string;
+            }
+            trigger match-syslog {
+                term syslog-received {
+                    when {
+                        matches-with "$syslog-message" "$syslog-to-match-field" {
+                            time-range 1h;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "Received syslog message $syslog-message";
+                        }
+                    }
+                }
+            }
+            variable syslog-to-match {
+                value .*;
+                type string;
+            }
+        }
+    }
+    playbook get-syslogs {
+        rules syslog/get-all-data;
+    }                                   
+}

--- a/community_supplied/VendorSpecific/Cisco/IOS_XR/Syslog/cisco-header.ingest
+++ b/community_supplied/VendorSpecific/Cisco/IOS_XR/Syslog/cisco-header.ingest
@@ -1,0 +1,30 @@
+healthbot {
+    ingest {
+        syslog {
+            /* Header for parsing syslog packets from cisco devices */
+            header-pattern cisco-header {
+                filter "^(.*):([A-Z][a-z]{2} \\d{1,2} \\d{1,2}:\\d{1,2}:\\d{1,2}\\.\\d*)\\s:\\s([a-z]*)\\[(\\d*)\\]:\\s*(.*)\\s*";
+                description "Header for parsing syslog packets from cisco devices";
+                /* Position of host name */
+                field __log_host__ {
+                    description "Position of host name";
+                    from "$1";
+                }
+                /* Position of payload */
+                field __log_message_payload__ {
+                    description "Position of payload";
+                    from "$5";
+                }
+                /* Position of time stamp */
+                field __log_timestamp__ {
+                    description "Position of time stamp";
+                    from "$2";
+                }
+                field pid {
+                    from "$4";
+                }
+                key-fields [ __log_timestamp__ pid ];
+            }
+        }
+    }
+}

--- a/juniper_official/Solutions/Pfe-wedge-detection/xmchip-pattern-set-syslog.ingest
+++ b/juniper_official/Solutions/Pfe-wedge-detection/xmchip-pattern-set-syslog.ingest
@@ -967,8 +967,31 @@ healthbot {
                 }
                 key-fields fpc_number;
             }
+            pattern XMCHIP_EVENT034 {
+                event-id XMCHIP_EVENT034;
+                filter "fpc%{NUMBER:fpc_number}.*XMCHIP.*HOSTIF.*Protect*Parity error for SRAM in bank";
+                description "This syslog occurs due to SRAM memory parity error";
+                constant syslog-trigger-color {
+                    value red;
+                }
+                constant syslog-trigger-message {
+                    value "Restart the MPC and monitor the errors.";
+                }
+                constant reoccur {
+                    value TRUE;
+                }
+                constant high-threshold {
+                    value 1;
+                    type integer;
+                }
+                constant low-threshold {
+                    value 0;
+                    type integer;
+                }
+                key-fields fpc_number;
+            }
             pattern-set XMCHIP {
-                pattern-names [ XMCHIP_EVENT001 XMCHIP_EVENT002 XMCHIP_EVENT003 XMCHIP_EVENT004a XMCHIP_EVENT004b XMCHIP_EVENT005 XMCHIP_EVENT006 XMCHIP_EVENT007a XMCHIP_EVENT007b XMCHIP_EVENT007c XMCHIP_EVENT008 XMCHIP_EVENT009 XMCHIP_EVENT010a XMCHIP_EVENT010b XMCHIP_EVENT011 XMCHIP_EVENT012 XMCHIP_EVENT013 XMCHIP_EVENT014 XMCHIP_EVENT015 XMCHIP_EVENT016 XMCHIP_EVENT017 XMCHIP_EVENT018 XMCHIP_EVENT019 XMCHIP_EVENT020 XMCHIP_EVENT021 XMCHIP_EVENT022a XMCHIP_EVENT022b XMCHIP_EVENT023 XMCHIP_EVENT024a XMCHIP_EVENT024b XMCHIP_EVENT024c XMCHIP_EVENT025 XMCHIP_EVENT026a XMCHIP_EVENT026b XMCHIP_EVENT027a XMCHIP_EVENT027b XMCHIP_EVENT028 XMCHIP_EVENT029 XMCHIP_EVENT030 XMCHIP_EVENT031 XMCHIP_EVENT032 XMCHIP_EVENT033 ];
+                pattern-names [ XMCHIP_EVENT001 XMCHIP_EVENT002 XMCHIP_EVENT003 XMCHIP_EVENT004a XMCHIP_EVENT004b XMCHIP_EVENT005 XMCHIP_EVENT006 XMCHIP_EVENT007a XMCHIP_EVENT007b XMCHIP_EVENT007c XMCHIP_EVENT008 XMCHIP_EVENT009 XMCHIP_EVENT010a XMCHIP_EVENT010b XMCHIP_EVENT011 XMCHIP_EVENT012 XMCHIP_EVENT013 XMCHIP_EVENT014 XMCHIP_EVENT015 XMCHIP_EVENT016 XMCHIP_EVENT017 XMCHIP_EVENT018 XMCHIP_EVENT019 XMCHIP_EVENT020 XMCHIP_EVENT021 XMCHIP_EVENT022a XMCHIP_EVENT022b XMCHIP_EVENT023 XMCHIP_EVENT024a XMCHIP_EVENT024b XMCHIP_EVENT024c XMCHIP_EVENT025 XMCHIP_EVENT026a XMCHIP_EVENT026b XMCHIP_EVENT027a XMCHIP_EVENT027b XMCHIP_EVENT028 XMCHIP_EVENT029 XMCHIP_EVENT030 XMCHIP_EVENT031 XMCHIP_EVENT032 XMCHIP_EVENT033 XMCHIP_EVENT034];
             }
         }
     }                                   

--- a/juniper_official/Solutions/Pfe-wedge-detection/xmchip-pattern-set-syslog.ingest
+++ b/juniper_official/Solutions/Pfe-wedge-detection/xmchip-pattern-set-syslog.ingest
@@ -4,7 +4,7 @@ healthbot {
             pattern XMCHIP_EVENT001 {
                 event-id XMCHIP_EVENT001;
                 filter "fpc%{NUMBER:fpc_number}.*XMCHIP.*Scheduler: Protect: Parity error for tick table single port SRAM ";
-                description "The \"Scheduler: Protect: Parity error for tick table single port SRAM\" message reports a transient hardware memory error.";
+                description "The  \"Scheduler: Protect: Parity error for tick table single port SRAM\" message reports a transient hardware memory error.";
                 constant syslog-trigger-color {
                     value red;
                 }


### PR DESCRIPTION
Changes
1) Example for adding syslog headers to parse syslogs from cisco devices 
2) Added new xmchip pattern to the list of existing Pfe Wedge cases.