### PR TITLE
Traffic blackhole detection rules(set-2)

### DIFF
--- a/juniper_official/Linecard/aft-sandbox-stats.yml
+++ b/juniper_official/Linecard/aft-sandbox-stats.yml
@@ -1,0 +1,48 @@
+---
+SandboxStatsTable:
+  command: show sandbox stats
+  target: Null
+  view: SandboxStatsTableView
+SandboxStatsTableView:
+  fields:
+    nodes: AftNodeTable
+    entries: AftEntryTable
+    node-summary: AftNodeSummary
+    entry-summary: AftEntrySummary
+AftEntryTable:
+  key: aft-entry
+  title: 'Entry                    Add        Rate(ps)  Delete     Rate(ps)  Create Fail Add Fail     Out of Order'
+  view: AftEntryView
+AftEntryView:
+  regex:
+    aft-entry: '(\w+)\s+\d+\s+\d+\s+\d+\s+\d+\s+'
+    entry-create-fail: '(\d+)\s+'
+    entry-add-fail: '(\d+)\s+'
+    entry-out-of-order: '(\d+).*'
+AftNodeTable:
+  key: aft-node
+  title: 'Node                     Add        Rate(ps)  Update     Rate(ps)  Delete     Rate(ps)  Bind Fail   Create Fail  Out of Order  pOut Of Order'
+  view: AftNodeView
+AftNodeView:
+  regex:
+    aft-node: '(\w+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+'
+    node-bind-fail: '(\d+)\s+'
+    node-create-fail: '(\d+)\s+'
+    node-out-of-order: '(\d+)\s+'
+    node-pout-of-order: '(\d+).*'
+AftNodeSummary:
+  key: node-sum-name
+  title: 'AFT NODE OPERATIONS'
+  view: AftNodeSummaryView
+AftNodeSummaryView:
+  regex:
+    node-sum-name: '(\w+)\s+:\s'
+    node-sum-value: (\d+).*
+AftEntrySummary:
+  key: entry-sum-name
+  title: 'AFT ENTRY OPERATIONS'
+  view: AftNodeSummaryView
+AftEntrySummaryView:
+  regex:
+    entry-sum-name: '(\w+)\s+:\s'
+    entry-sum-value: (\d+).*

--- a/juniper_official/Linecard/cda-api-stats.rule
+++ b/juniper_official/Linecard/cda-api-stats.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get CDA Server RPC failure stats
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-cda-api-stats {
+            keys [ fpc-name cda-api ];
+            synopsis "Cda Server API Stats";
+            description "Rule to fetch Cda Server API Stats from PFE";
+            sensor cda-api-stats {
+                iAgent {
+                    file cda-api-stats.yml;
+                    table CdaServerStatsTable;
+                    frequency 180s;
+                }
+		synopsis "Definition of Cda Server API Stats";
+                description "Netconf igent command show cda statistics server api to collect telemetry data from network device";
+            }
+            field cda-api {
+                sensor cda-api-stats {
+                    path cda-api;
+                }
+                type string;
+                description "CDA API Name";
+            }
+            field fail {
+                sensor cda-api-stats {
+                    path fail;
+                }
+                type integer;
+                description "CDA API failure count";
+            }
+            field fpc-name {
+                sensor cda-api-stats {
+                    path target;
+                }
+                type string;
+                description "FPC Number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX1008 {
+                                    sensors cda-api-stats;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/cda-api-stats.yml
+++ b/juniper_official/Linecard/cda-api-stats.yml
@@ -1,0 +1,27 @@
+---
+CdaServerStatsTable:
+  command: show cda statistics server api
+  target: Null
+  view: cdaServerStatsTableView
+cdaServerStatsTableView:
+  fields:
+    apis: CdaApis
+    summary-apis: SummaryCdaApis
+CdaApis:
+  key: cda-api
+  title: '|                API NAME                 |       CALLS      |   RATE   |       FAIL       |   RATE   |      ASYNC       |   RATE   |'
+  view: CdaApiView
+CdaApiView:
+  regex:
+    cda-api: '\|\s+(\w+)\s+\|\s+'
+    calls: '(\d+)\s+\|\s+\d+\s+\|\s+'
+    fail: '(\d+)\s+\|\s+\d+\s+\|\s+'
+    async: '(\d+).*'
+SummaryCdaApis:
+  key: summary-name
+  title: 'Aggreagte Server Statistics'
+  view: SummaryCdaApisView
+SummaryCdaApisView:
+  regex:
+    summary-name: '(\w+)\s+:\s'
+    summary-value: (\d+).*

--- a/juniper_official/Linecard/npu-resources.rule
+++ b/juniper_official/Linecard/npu-resources.rule
@@ -1,0 +1,62 @@
+/*
+ * Rule to get NPU(ASIC) resource usage stats.
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule npu-resource {
+            keys fpc-name;
+            synopsis "PFE Hardware Resource";
+            description "Rule to fetch PFE Hardware Resource";
+            sensor sensor-npu-resources {
+                synopsis "PFE Hardware Resource definition";
+                description "GNMI based telemetry which collects ASIC resource usage";
+                open-config {
+                    sensor-name /junos/system/linecard/npu/memory/;
+                    frequency 180s;
+                }
+            }
+            field fpc-name {
+                sensor sensor-npu-resources {
+                    path "/components/component/@name";
+                }
+                type string;
+                description "FPC name";
+            }
+            field property-name {
+                sensor sensor-npu-resources {
+                    path "/components/component/properties/property/@name";
+                }
+                type string;
+                description "Resource name";
+            }
+            field property-value {
+                sensor sensor-npu-resources {
+                    path /components/component/properties/property/state/value;
+                }
+                type integer;
+                description "Resource usage";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX1008 {
+                                    sensors aft-sb-entry-stats;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/online-fpc.yml
+++ b/juniper_official/Linecard/online-fpc.yml
@@ -3,3 +3,7 @@ UpdateTable:
     udf: online_fpc
     tables:
         - SandboxStatsTable
+        - NhFailureStatsTable
+        - RouteFailureStatsTable
+        - PfeRerouteStatsTable
+        - CdaServerStatsTable

--- a/juniper_official/Linecard/pfe-bq-nh-failures.rule
+++ b/juniper_official/Linecard/pfe-bq-nh-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe nexthop failures from BQ layer
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-bq-nh-failures {
+            keys [ fpc-name bq-nh-type-name ];
+            synopsis "PFE Nexthop failures from BQ layer";
+            description "Rule to fetch BQ nexthop failures from PFE";
+            sensor bq-nh-failures {
+		synopsis "Definition of PFE Nexthop failures from BQ layer sensor";
+                description "Netconf igent command show nh management to collect telemetry data from network device";
+                iAgent {
+                    file pfe-nh-failures.yml;
+                    table NhFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field bq-nh-type-name {
+                sensor bq-nh-failures {
+                    path bq-nh-type-name;
+                }
+                type string;
+                description "Nexthop name";
+            }
+            field bq-nh-type-fail {
+                sensor bq-nh-failures {
+                    path bq-nh-type-fail;
+                }
+                type integer;
+                description "Nexthop failure count";
+            }
+            field fpc-name {
+                sensor bq-nh-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX1008 {
+                                    sensors bq-nh-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/pfe-ipv4-route-failures.rule
+++ b/juniper_official/Linecard/pfe-ipv4-route-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe IPv4 route failures in evo-aftman
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-ipv4-route-failure {
+            keys [ fpc-name ipv4-name ];
+            synopsis "PFE route failures in evo-aftman";
+            description "Rule to fetch PFE IPv4 route failures in evo-aftman";
+            sensor ipv4-route-failures {
+		synopsis "Definition to get PFE route failures in evo-aftman";
+                description "Netconf igent command show route management statistics to collect telemetry data from network device";
+                iAgent {
+                    file pfe-route-failures.yml;
+                    table RouteFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field ipv4-name {
+                sensor ipv4-route-failures {
+                    path ipv4-name;
+                }
+                type string;
+                description "IPv4 operation name";
+            }
+            field ipv4-fail {
+                sensor ipv4-route-failures {
+                    path ipv4-fail;
+                }
+                type integer;
+                description "IPv4 fail operation count";
+            }
+            field fpc-name {
+                sensor ipv4-route-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX1008 {
+                                    sensors ipv4-route-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/pfe-ipv6-route-failures.rule
+++ b/juniper_official/Linecard/pfe-ipv6-route-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe IPv6 route failures in evo-aftman
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-ipv6-route-failure {
+            keys [ fpc-name ipv6-name ];
+            synopsis "PFE route failures in evo-aftman";
+            description "Rule to fetch PFE IPv6 route failures in evo-aftman";
+            sensor ipv6-route-failures {
+		synopsis "Definition to get PFE route failures in evo-aftman";
+                description "Netconf igent command show route management statistics to collect telemetry data from network device";
+                iAgent {
+                    file pfe-route-failures.yml;
+                    table RouteFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field ipv6-name {
+                sensor ipv6-route-failures {
+                    path ipv6-name;
+                }
+                type string;
+                description "IPv6 opearation name";
+            }
+            field ipv6-fail {
+                sensor ipv6-route-failures {
+                    path ipv6-fail;
+                }
+                type integer;
+                description "IPv6 fail opearation count";
+            }
+            field fpc-name {
+                sensor ipv6-route-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX1008 {
+                                    sensors ipv6-route-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/pfe-mpls-route-failures.rule
+++ b/juniper_official/Linecard/pfe-mpls-route-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe mpls route failures in evo-aftman
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-mpls-route-failure {
+            keys [ fpc-name mpls-name ];
+            synopsis "PFE mpls route failures in evo-aftman";
+            description "Rule to fetch PFE mpls route failures in evo-aftman";
+            sensor mpls-route-failures {
+		synopsis "Definition to get PFE mpls route failures in evo-aftman";
+                description "Netconf igent command show route management statistics to collect telemetry data from network device";
+                iAgent {
+                    file pfe-route-failures.yml;
+                    table RouteFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field mpls-name {
+                sensor mpls-route-failures {
+                    path mpls-name;
+                }
+                type string;
+                description "mpls operation name";
+            }
+            field mpls-fail {
+                sensor mpls-route-failures {
+                    path mpls-fail;
+                }
+                type integer;
+                description "mpls fail operation count";
+            }
+            field fpc-name {
+                sensor mpls-route-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX1008 {
+                                    sensors mpls-route-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/pfe-nh-failures.rule
+++ b/juniper_official/Linecard/pfe-nh-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe nexthop failures from evo-aftman
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-nh-failures {
+            keys [ fpc-name pfe-nh-type-name ];
+            synopsis "PFE Nexthop failures from evo-aftman";
+            description "Rule to fetch nexthop failures from PFE evo-aftman";
+            sensor nh-failures {
+		synopsis "Definition to get PFE Nexthop failures from evo-aftman";
+                description "Netconf igent command show nh management to collect telemetry data from network device";
+                iAgent {
+                    file pfe-nh-failures.yml;
+                    table NhFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field pfe-nh-type-name {
+                sensor nh-failures {
+                    path pfe-nh-type-name;
+                }
+                type string;
+                description "Nexthop name";
+            }
+            field pfe-nh-type-fail {
+                sensor nh-failures {
+                    path pfe-nh-type-fail;
+                }
+                type integer;
+                description "Nexthop failure count";
+            }
+            field fpc-name {
+                sensor nh-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX1008 {
+                                    sensors nh-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/pfe-nh-failures.yml
+++ b/juniper_official/Linecard/pfe-nh-failures.yml
@@ -1,0 +1,25 @@
+---
+NhFailureStatsTable:
+  command: show nh management
+  target: Null
+  view: NhStatsTableView
+NhStatsTableView:
+  fields:
+    bqstats: BqTable
+    pfestats: PfeTable
+BqTable:
+  key: bq-nh-type-name
+  title: 'Next Hop BQ calling Statistic'
+  view: BqTableView
+BqTableView:
+  regex:
+    bq-nh-type-name: '(\w+)\s+\d+\s+\d+\s+\d+\s+'
+    bq-nh-type-fail: '(\d+).*'
+PfeTable:
+  key: pfe-nh-type-name
+  title: 'Next Hop PFE completion Statistics'
+  view: PfeTableView
+PfeTableView:
+  regex:
+    pfe-nh-type-name: '(\w+)\s+\d+\s+\d+\s+\d+\s+'
+    pfe-nh-type-fail: '(\d+).*'

--- a/juniper_official/Linecard/pfe-reroute.rule
+++ b/juniper_official/Linecard/pfe-reroute.rule
@@ -1,0 +1,77 @@
+/*
+ * Rule to get pfe reroute events
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-reroute-events {
+            keys [ fpc-name id ];
+            synopsis "PFE Reroute events";
+            description "Rule to fetch PFE Reroute events";
+            sensor reroute-events {
+                iAgent {
+                    file pfe-reroute.yml;
+                    table PfeRerouteStatsTable;
+                    frequency 180s;
+                }
+		synopsis "Definition of PFE reroute events";
+                description "Netconf igent command show pfe statistics reroute to collect telemetry data from network device";
+            }
+            field event {
+                sensor reroute-events {
+                    path event;
+                }
+                type string;
+                description "Event name";
+            }
+            field id {
+                sensor reroute-events {
+                    path id;
+                }
+                type integer;
+                description "Event id";
+            }
+            field status {
+                sensor reroute-events {
+                    path status;
+                }
+                type string;
+                description "Event status(Up/Down)";
+            }
+            field timestamp {
+                sensor reroute-events {
+                    path timestamp;
+                }
+                type string;
+                description "Event timestamp";
+            }
+            field fpc-name {
+                sensor reroute-events {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX1008 {
+                                    sensors reroute-events;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/Linecard/pfe-reroute.yml
+++ b/juniper_official/Linecard/pfe-reroute.yml
@@ -1,0 +1,13 @@
+---
+PfeRerouteStatsTable:
+  command: show pfe statistics reroute
+  target: Null
+  key: id
+  title: 'Sequence Number          Reroute Event            Start Timestamp               End Timestamp                 Delta (msecs)                 Selectors Repaire'
+  view: PfeRerouteTableView
+PfeRerouteTableView:
+  regex:
+    id: '(\d+)\s+'
+    event: '((session\s+\d+)|(\S+))\s:\s'
+    status: '(\w+)\s+'
+    timestamp: '(\S+\s\S+).*'

--- a/juniper_official/Linecard/pfe-route-failures.yml
+++ b/juniper_official/Linecard/pfe-route-failures.yml
@@ -1,0 +1,52 @@
+---
+RouteFailureStatsTable:
+  command: show route management statistics
+  target: Null
+  view: RouteStatsTableView
+RouteStatsTableView:
+  fields:
+    v4stats: V4Table
+    v6stats: V6Table
+    mplsstats: MplsTable
+    clnpstats: ClnpTable
+    vplsstats: VplsTable
+V4Table:
+  key: ipv4-name
+  title: 'Protocol: ipv4'
+  view: V4TableView
+V4TableView:
+  regex:
+    ipv4-fail: '(\d+)\s+:\s+'
+    ipv4-name: '(\w+\s+\w+\s+fails).*'
+V6Table:
+  key: ipv6-name
+  title: 'Protocol: ipv6'
+  view: V6TableView
+V6TableView:
+  regex:
+    ipv6-fail: '(\d+)\s+:\s+'
+    ipv6-name: '(\w+\s+\w+\s+fails).*'
+MplsTable:
+  key: mpls-name
+  title: 'Protocol: mpls'
+  view: MplsTableView
+MplsTableView:
+  regex:
+    mpls-fail: '(\d+)\s+:\s+'
+    mpls-name: '(\w+\s+\w+\s+fails).*'
+ClnpTable:
+  key: clnp-name
+  title: 'Protocol: clnp'
+  view: ClnpTableView
+ClnpTableView:
+  regex:
+    clnp-fail: '(\d+)\s+:\s+'
+    clnp-name: '(\w+\s+\w+\s+fails).*'
+VplsTable:
+  key: vpls-name
+  title: 'Protocol: vpls'
+  view: VplsTableView
+VplsTableView:
+  regex:
+    vpls-fail: '(\d+)\s+:\s+'
+    vpls-name: '(\w+\s+\w+\s+fails).*'

--- a/juniper_official/Linecard/pipe-stats.rule
+++ b/juniper_official/Linecard/pipe-stats.rule
@@ -13,7 +13,7 @@ healthbot {
 		description "GNMI based telemetry which collects ASIC drops from interface, fabric, lookup, host and Queuing blocks";
                 open-config {
                     sensor-name /components/component/integrated-circuit/pipeline-counters;
-                    frequency 60s;
+                    frequency 180s;
                 }
             }
             field fabric-block-fabric-aggregate {

--- a/juniper_official/Linecard/trafficblackhole.playbook
+++ b/juniper_official/Linecard/trafficblackhole.playbook
@@ -1,0 +1,6 @@
+healthbot {
+    playbook trafficblackhole {
+        rules [ linecard.blackhole/aft-sandbox-entry-stats linecard.blackhole/aft-sandbox-node-stats linecard.blackhole/pfe-bq-nh-failures linecard.blackhole/pfe-cda-api-stats linecard.blackhole/pfe-ipv4-route-failure linecard.blackhole/pfe-ipv6-route-failure linecard.blackhole/pfe-mpls-route-failure linecard.blackhole/pfe-nh-failures linecard.blackhole/pfe-pipe-stats linecard.blackhole/pfe-reroute-events linecard.cm-events/check-cm-events linecard.statistics/update-online-fpc ];
+    }
+}
+


### PR DESCRIPTION
 - Blackhole detection rules for Route failures, nexthop failures, cda failures, reroute events and npu resources
 - Committing the missing file aft-sandbox-stats.yml from last commit
 - Traffic blackhole playbook which includes all the rules
 - Updated the online-fpc to include more tables