### PR TITLE
Traffic blackhole detection rules

### DIFF
--- a/community_supplied/Solutions/Traffic-Blackhole/aft-sandbox-entry-stats.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/aft-sandbox-entry-stats.rule
@@ -1,15 +1,15 @@
 /*
- * Rule to get all the node error stats from aft sandbox
+ * Rule to get all the entry error stats from aft sandbox
  * Upstream application will use these stats to find anomaly
  */
 healthbot {
     topic linecard.blackhole {
-        rule aft-sandbox-node-stats {
-            keys [ fpc-name aft-node ];
-            synopsis "Aft sandbox node error stats";
-            description "Rule to fetch aft server sandbox node error stats";
-            sensor aft-sb-node-stats {
-                synopsis "Aft sandbox node stats definition";
+        rule aft-sandbox-entry-stats {
+            keys [ fpc-name aft-entry ];
+            synopsis "Aft sandbox entry error stats";
+            description "Rule to fetch aft server sandbox entry error stats";
+            sensor aft-sb-entry-stats {
+                synopsis "Aft sandbox stats entry definition";
                 description "Netconf igent command show sandbox stats to collect telemetry data from network device";
                 iAgent {
                     file aft-sandbox-stats.yml;
@@ -17,36 +17,36 @@ healthbot {
                     frequency 180s;
                 }
             }
-            field aft-node {
-                sensor aft-sb-node-stats {
-                    path aft-node;
+            field aft-entry {
+                sensor aft-sb-entry-stats {
+                    path aft-entry;
                 }
                 type string;
-                description "Aft node name";
+                description "Aft entry name";
             }
-            field node-bind-fail {
-                sensor aft-sb-node-stats {
-                    path node-bind-fail;
+            field entry-add-fail {
+                sensor aft-sb-entry-stats {
+                    path entry-add-fail;
                 }
                 type integer;
-                description "Node add failure count";
+                description "Entry add failure count";
             }
-            field node-create-fail {
-                sensor aft-sb-node-stats {
-                    path node-create-fail;
+            field entry-create-fail {
+                sensor aft-sb-entry-stats {
+                    path entry-create-fail;
                 }
                 type integer;
-                description "Node create failure count";
+                description "Entry create failure count";
             }
-            field node-out-of-order {
-                sensor aft-sb-node-stats {
-                    path node-out-of-order;
+            field entry-out-of-order {
+                sensor aft-sb-entry-stats {
+                    path entry-out-of-order;
                 }
                 type integer;
-                description "Node out of order count";
+                description "Entry out of order count";
             }
             field fpc-name {
-                sensor aft-sb-node-stats {
+                sensor aft-sb-entry-stats {
                     path target;
                 }
                 type string;
@@ -61,8 +61,8 @@ healthbot {
                     juniper {
                         operating-system junos {
                             products PTX {
-			        sensors aft-sb-node-stats;
-                                platforms PTX1008 {
+                                platforms PTX10008 {
+                                    sensors aft-sb-entry-stats;
                                     releases 22.2R1 {
                                         release-support min-supported-release;
                                     }

--- a/community_supplied/Solutions/Traffic-Blackhole/aft-sandbox-node-stats.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/aft-sandbox-node-stats.rule
@@ -1,15 +1,15 @@
 /*
- * Rule to get all the entry error stats from aft sandbox
- * Upstream application will use these stats to find anomaly
+ * Rule to get all the node error stats from aft sandbox
+ * Upstream application will use these stats to find anomaly.
  */
 healthbot {
     topic linecard.blackhole {
-        rule aft-sandbox-entry-stats {
-            keys [ fpc-name aft-entry ];
-            synopsis "Aft sandbox entry error stats";
-            description "Rule to fetch aft server sandbox entry error stats";
-            sensor aft-sb-entry-stats {
-                synopsis "Aft sandbox stats entry definition";
+        rule aft-sandbox-node-stats {
+            keys [ fpc-name aft-node ];
+            synopsis "Aft sandbox node error stats";
+            description "Rule to fetch aft server sandbox node error stats";
+            sensor aft-sb-node-stats {
+                synopsis "Aft sandbox node stats definition";
                 description "Netconf igent command show sandbox stats to collect telemetry data from network device";
                 iAgent {
                     file aft-sandbox-stats.yml;
@@ -17,36 +17,36 @@ healthbot {
                     frequency 180s;
                 }
             }
-            field aft-entry {
-                sensor aft-sb-entry-stats {
-                    path aft-entry;
+            field aft-node {
+                sensor aft-sb-node-stats {
+                    path aft-node;
                 }
                 type string;
-                description "Aft entry name";
+                description "Aft node name";
             }
-            field entry-add-fail {
-                sensor aft-sb-entry-stats {
-                    path entry-add-fail;
+            field node-bind-fail {
+                sensor aft-sb-node-stats {
+                    path node-bind-fail;
                 }
                 type integer;
-                description "Entry add failure count";
+                description "Node add failure count";
             }
-            field entry-create-fail {
-                sensor aft-sb-entry-stats {
-                    path entry-create-fail;
+            field node-create-fail {
+                sensor aft-sb-node-stats {
+                    path node-create-fail;
                 }
                 type integer;
-                description "Entry create failure count";
+                description "Node create failure count";
             }
-            field entry-out-of-order {
-                sensor aft-sb-entry-stats {
-                    path entry-out-of-order;
+            field node-out-of-order {
+                sensor aft-sb-node-stats {
+                    path node-out-of-order;
                 }
                 type integer;
-                description "Entry out of order count";
+                description "Node out of order count";
             }
             field fpc-name {
-                sensor aft-sb-entry-stats {
+                sensor aft-sb-node-stats {
                     path target;
                 }
                 type string;
@@ -61,8 +61,8 @@ healthbot {
                     juniper {
                         operating-system junos {
                             products PTX {
-                                platforms PTX1008 {
-                                    sensors aft-sb-entry-stats;
+			        sensors aft-sb-node-stats;
+                                platforms PTX10008 {
                                     releases 22.2R1 {
                                         release-support min-supported-release;
                                     }

--- a/community_supplied/Solutions/Traffic-Blackhole/aft-sandbox-stats.yml
+++ b/community_supplied/Solutions/Traffic-Blackhole/aft-sandbox-stats.yml
@@ -1,0 +1,48 @@
+---
+SandboxStatsTable:
+  command: show sandbox stats
+  target: Null
+  view: SandboxStatsTableView
+SandboxStatsTableView:
+  fields:
+    nodes: AftNodeTable
+    entries: AftEntryTable
+    node-summary: AftNodeSummary
+    entry-summary: AftEntrySummary
+AftEntryTable:
+  key: aft-entry
+  title: 'Entry                    Add        Rate(ps)  Delete     Rate(ps)  Create Fail Add Fail     Out of Order'
+  view: AftEntryView
+AftEntryView:
+  regex:
+    aft-entry: '(\w+)\s+\d+\s+\d+\s+\d+\s+\d+\s+'
+    entry-create-fail: '(\d+)\s+'
+    entry-add-fail: '(\d+)\s+'
+    entry-out-of-order: '(\d+).*'
+AftNodeTable:
+  key: aft-node
+  title: 'Node                     Add        Rate(ps)  Update     Rate(ps)  Delete     Rate(ps)  Bind Fail   Create Fail  Out of Order  pOut Of Order'
+  view: AftNodeView
+AftNodeView:
+  regex:
+    aft-node: '(\w+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+'
+    node-bind-fail: '(\d+)\s+'
+    node-create-fail: '(\d+)\s+'
+    node-out-of-order: '(\d+)\s+'
+    node-pout-of-order: '(\d+).*'
+AftNodeSummary:
+  key: node-sum-name
+  title: 'AFT NODE OPERATIONS'
+  view: AftNodeSummaryView
+AftNodeSummaryView:
+  regex:
+    node-sum-name: '(\w+)\s+:\s'
+    node-sum-value: (\d+).*
+AftEntrySummary:
+  key: entry-sum-name
+  title: 'AFT ENTRY OPERATIONS'
+  view: AftNodeSummaryView
+AftEntrySummaryView:
+  regex:
+    entry-sum-name: '(\w+)\s+:\s'
+    entry-sum-value: (\d+).*

--- a/community_supplied/Solutions/Traffic-Blackhole/cda-api-stats.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/cda-api-stats.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get CDA Server RPC failure stats
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-cda-api-stats {
+            keys [ fpc-name cda-api ];
+            synopsis "Cda Server API Stats";
+            description "Rule to fetch Cda Server API Stats from PFE";
+            sensor cda-api-stats {
+                iAgent {
+                    file cda-api-stats.yml;
+                    table CdaServerStatsTable;
+                    frequency 180s;
+                }
+		synopsis "Definition of Cda Server API Stats";
+                description "Netconf igent command show cda statistics server api to collect telemetry data from network device";
+            }
+            field cda-api {
+                sensor cda-api-stats {
+                    path cda-api;
+                }
+                type string;
+                description "CDA API Name";
+            }
+            field fail {
+                sensor cda-api-stats {
+                    path fail;
+                }
+                type integer;
+                description "CDA API failure count";
+            }
+            field fpc-name {
+                sensor cda-api-stats {
+                    path target;
+                }
+                type string;
+                description "FPC Number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX10008 {
+                                    sensors cda-api-stats;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/Solutions/Traffic-Blackhole/cda-api-stats.yml
+++ b/community_supplied/Solutions/Traffic-Blackhole/cda-api-stats.yml
@@ -1,0 +1,27 @@
+---
+CdaServerStatsTable:
+  command: show cda statistics server api
+  target: Null
+  view: cdaServerStatsTableView
+cdaServerStatsTableView:
+  fields:
+    apis: CdaApis
+    summary-apis: SummaryCdaApis
+CdaApis:
+  key: cda-api
+  title: '|                API NAME                 |       CALLS      |   RATE   |       FAIL       |   RATE   |      ASYNC       |   RATE   |'
+  view: CdaApiView
+CdaApiView:
+  regex:
+    cda-api: '\|\s+(\w+)\s+\|\s+'
+    calls: '(\d+)\s+\|\s+\d+\s+\|\s+'
+    fail: '(\d+)\s+\|\s+\d+\s+\|\s+'
+    async: '(\d+).*'
+SummaryCdaApis:
+  key: summary-name
+  title: 'Aggreagte Server Statistics'
+  view: SummaryCdaApisView
+SummaryCdaApisView:
+  regex:
+    summary-name: '(\w+)\s+:\s'
+    summary-value: (\d+).*

--- a/community_supplied/Solutions/Traffic-Blackhole/npu-resources.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/npu-resources.rule
@@ -1,0 +1,62 @@
+/*
+ * Rule to get NPU(ASIC) resource usage stats.
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule npu-resource {
+            keys fpc-name;
+            synopsis "PFE Hardware Resource";
+            description "Rule to fetch PFE Hardware Resource";
+            sensor sensor-npu-resources {
+                synopsis "PFE Hardware Resource definition";
+                description "GNMI based telemetry which collects ASIC resource usage";
+                open-config {
+                    sensor-name /junos/system/linecard/npu/memory/;
+                    frequency 180s;
+                }
+            }
+            field fpc-name {
+                sensor sensor-npu-resources {
+                    path "/components/component/@name";
+                }
+                type string;
+                description "FPC name";
+            }
+            field property-name {
+                sensor sensor-npu-resources {
+                    path "/components/component/properties/property/@name";
+                }
+                type string;
+                description "Resource name";
+            }
+            field property-value {
+                sensor sensor-npu-resources {
+                    path /components/component/properties/property/state/value;
+                }
+                type integer;
+                description "Resource usage";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX10008 {
+                                    sensors aft-sb-entry-stats;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/Solutions/Traffic-Blackhole/online-fpc.yml
+++ b/community_supplied/Solutions/Traffic-Blackhole/online-fpc.yml
@@ -1,0 +1,9 @@
+---
+UpdateTable:
+    udf: online_fpc
+    tables:
+        - SandboxStatsTable
+        - NhFailureStatsTable
+        - RouteFailureStatsTable
+        - PfeRerouteStatsTable
+        - CdaServerStatsTable

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-bq-nh-failures.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-bq-nh-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe nexthop failures from BQ layer
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-bq-nh-failures {
+            keys [ fpc-name bq-nh-type-name ];
+            synopsis "PFE Nexthop failures from BQ layer";
+            description "Rule to fetch BQ nexthop failures from PFE";
+            sensor bq-nh-failures {
+		synopsis "Definition of PFE Nexthop failures from BQ layer sensor";
+                description "Netconf igent command show nh management to collect telemetry data from network device";
+                iAgent {
+                    file pfe-nh-failures.yml;
+                    table NhFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field bq-nh-type-name {
+                sensor bq-nh-failures {
+                    path bq-nh-type-name;
+                }
+                type string;
+                description "Nexthop name";
+            }
+            field bq-nh-type-fail {
+                sensor bq-nh-failures {
+                    path bq-nh-type-fail;
+                }
+                type integer;
+                description "Nexthop failure count";
+            }
+            field fpc-name {
+                sensor bq-nh-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX10008 {
+                                    sensors bq-nh-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-ipv4-route-failures.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-ipv4-route-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe IPv4 route failures in evo-aftman
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-ipv4-route-failure {
+            keys [ fpc-name ipv4-name ];
+            synopsis "PFE route failures in evo-aftman";
+            description "Rule to fetch PFE IPv4 route failures in evo-aftman";
+            sensor ipv4-route-failures {
+		synopsis "Definition to get PFE route failures in evo-aftman";
+                description "Netconf igent command show route management statistics to collect telemetry data from network device";
+                iAgent {
+                    file pfe-route-failures.yml;
+                    table RouteFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field ipv4-name {
+                sensor ipv4-route-failures {
+                    path ipv4-name;
+                }
+                type string;
+                description "IPv4 operation name";
+            }
+            field ipv4-fail {
+                sensor ipv4-route-failures {
+                    path ipv4-fail;
+                }
+                type integer;
+                description "IPv4 fail operation count";
+            }
+            field fpc-name {
+                sensor ipv4-route-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX10008 {
+                                    sensors ipv4-route-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-ipv6-route-failures.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-ipv6-route-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe IPv6 route failures in evo-aftman
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-ipv6-route-failure {
+            keys [ fpc-name ipv6-name ];
+            synopsis "PFE route failures in evo-aftman";
+            description "Rule to fetch PFE IPv6 route failures in evo-aftman";
+            sensor ipv6-route-failures {
+		synopsis "Definition to get PFE route failures in evo-aftman";
+                description "Netconf igent command show route management statistics to collect telemetry data from network device";
+                iAgent {
+                    file pfe-route-failures.yml;
+                    table RouteFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field ipv6-name {
+                sensor ipv6-route-failures {
+                    path ipv6-name;
+                }
+                type string;
+                description "IPv6 opearation name";
+            }
+            field ipv6-fail {
+                sensor ipv6-route-failures {
+                    path ipv6-fail;
+                }
+                type integer;
+                description "IPv6 fail opearation count";
+            }
+            field fpc-name {
+                sensor ipv6-route-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX10008 {
+                                    sensors ipv6-route-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-mpls-route-failures.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-mpls-route-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe mpls route failures in evo-aftman
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-mpls-route-failure {
+            keys [ fpc-name mpls-name ];
+            synopsis "PFE mpls route failures in evo-aftman";
+            description "Rule to fetch PFE mpls route failures in evo-aftman";
+            sensor mpls-route-failures {
+		synopsis "Definition to get PFE mpls route failures in evo-aftman";
+                description "Netconf igent command show route management statistics to collect telemetry data from network device";
+                iAgent {
+                    file pfe-route-failures.yml;
+                    table RouteFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field mpls-name {
+                sensor mpls-route-failures {
+                    path mpls-name;
+                }
+                type string;
+                description "mpls operation name";
+            }
+            field mpls-fail {
+                sensor mpls-route-failures {
+                    path mpls-fail;
+                }
+                type integer;
+                description "mpls fail operation count";
+            }
+            field fpc-name {
+                sensor mpls-route-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX10008 {
+                                    sensors mpls-route-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-nh-failures.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-nh-failures.rule
@@ -1,0 +1,63 @@
+/*
+ * Rule to get pfe nexthop failures from evo-aftman
+ * Upstream application will use these stats to find anomaly
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-nh-failures {
+            keys [ fpc-name pfe-nh-type-name ];
+            synopsis "PFE Nexthop failures from evo-aftman";
+            description "Rule to fetch nexthop failures from PFE evo-aftman";
+            sensor nh-failures {
+		synopsis "Definition to get PFE Nexthop failures from evo-aftman";
+                description "Netconf igent command show nh management to collect telemetry data from network device";
+                iAgent {
+                    file pfe-nh-failures.yml;
+                    table NhFailureStatsTable;
+                    frequency 180s;
+                }
+            }
+            field pfe-nh-type-name {
+                sensor nh-failures {
+                    path pfe-nh-type-name;
+                }
+                type string;
+                description "Nexthop name";
+            }
+            field pfe-nh-type-fail {
+                sensor nh-failures {
+                    path pfe-nh-type-fail;
+                }
+                type integer;
+                description "Nexthop failure count";
+            }
+            field fpc-name {
+                sensor nh-failures {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX10008 {
+                                    sensors nh-failures;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-nh-failures.yml
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-nh-failures.yml
@@ -1,0 +1,25 @@
+---
+NhFailureStatsTable:
+  command: show nh management
+  target: Null
+  view: NhStatsTableView
+NhStatsTableView:
+  fields:
+    bqstats: BqTable
+    pfestats: PfeTable
+BqTable:
+  key: bq-nh-type-name
+  title: 'Next Hop BQ calling Statistic'
+  view: BqTableView
+BqTableView:
+  regex:
+    bq-nh-type-name: '(\w+)\s+\d+\s+\d+\s+\d+\s+'
+    bq-nh-type-fail: '(\d+).*'
+PfeTable:
+  key: pfe-nh-type-name
+  title: 'Next Hop PFE completion Statistics'
+  view: PfeTableView
+PfeTableView:
+  regex:
+    pfe-nh-type-name: '(\w+)\s+\d+\s+\d+\s+\d+\s+'
+    pfe-nh-type-fail: '(\d+).*'

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-reroute.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-reroute.rule
@@ -1,0 +1,77 @@
+/*
+ * Rule to get pfe reroute events.
+ * Upstream application will use these stats to find anomaly.
+ */
+healthbot {
+    topic linecard.blackhole {
+        rule pfe-reroute-events {
+            keys fpc-name;
+            synopsis "PFE Reroute events";
+            description "Rule to fetch PFE Reroute events";
+            sensor reroute-events {
+                iAgent {
+                    file pfe-reroute.yml;
+                    table PfeRerouteStatsTable;
+                    frequency 180s;
+                }
+		synopsis "Definition of PFE reroute events";
+                description "Netconf igent command show pfe statistics reroute to collect telemetry data from network device";
+            }
+            field event {
+                sensor reroute-events {
+                    path event;
+                }
+                type string;
+                description "Event name";
+            }
+            field id {
+                sensor reroute-events {
+                    path id;
+                }
+                type integer;
+                description "Event id";
+            }
+            field status {
+                sensor reroute-events {
+                    path status;
+                }
+                type string;
+                description "Event status(Up/Down)";
+            }
+            field timestamp {
+                sensor reroute-events {
+                    path timestamp;
+                }
+                type string;
+                description "Event timestamp";
+            }
+            field fpc-name {
+                sensor reroute-events {
+                    path target;
+                }
+                type string;
+                description "FPC number";
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                supported-healthbot-version 1.0.0;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products PTX {
+                                platforms PTX10008 {
+                                    sensors reroute-events;
+                                    releases 22.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-reroute.yml
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-reroute.yml
@@ -1,0 +1,13 @@
+---
+PfeRerouteStatsTable:
+  command: show pfe statistics reroute
+  target: Null
+  key: id
+  title: 'Sequence Number          Reroute Event            Start Timestamp               End Timestamp                 Delta (msecs)                 Selectors Repaire'
+  view: PfeRerouteTableView
+PfeRerouteTableView:
+  regex:
+    id: '(\d+)\s+'
+    event: '((session\s+\d+)|(\S+))\s:\s'
+    status: '(\w+)\s+'
+    timestamp: '(\S+\s\S+).*'

--- a/community_supplied/Solutions/Traffic-Blackhole/pfe-route-failures.yml
+++ b/community_supplied/Solutions/Traffic-Blackhole/pfe-route-failures.yml
@@ -1,0 +1,52 @@
+---
+RouteFailureStatsTable:
+  command: show route management statistics
+  target: Null
+  view: RouteStatsTableView
+RouteStatsTableView:
+  fields:
+    v4stats: V4Table
+    v6stats: V6Table
+    mplsstats: MplsTable
+    clnpstats: ClnpTable
+    vplsstats: VplsTable
+V4Table:
+  key: ipv4-name
+  title: 'Protocol: ipv4'
+  view: V4TableView
+V4TableView:
+  regex:
+    ipv4-fail: '(\d+)\s+:\s+'
+    ipv4-name: '(\w+\s+\w+\s+fails).*'
+V6Table:
+  key: ipv6-name
+  title: 'Protocol: ipv6'
+  view: V6TableView
+V6TableView:
+  regex:
+    ipv6-fail: '(\d+)\s+:\s+'
+    ipv6-name: '(\w+\s+\w+\s+fails).*'
+MplsTable:
+  key: mpls-name
+  title: 'Protocol: mpls'
+  view: MplsTableView
+MplsTableView:
+  regex:
+    mpls-fail: '(\d+)\s+:\s+'
+    mpls-name: '(\w+\s+\w+\s+fails).*'
+ClnpTable:
+  key: clnp-name
+  title: 'Protocol: clnp'
+  view: ClnpTableView
+ClnpTableView:
+  regex:
+    clnp-fail: '(\d+)\s+:\s+'
+    clnp-name: '(\w+\s+\w+\s+fails).*'
+VplsTable:
+  key: vpls-name
+  title: 'Protocol: vpls'
+  view: VplsTableView
+VplsTableView:
+  regex:
+    vpls-fail: '(\d+)\s+:\s+'
+    vpls-name: '(\w+\s+\w+\s+fails).*'

--- a/community_supplied/Solutions/Traffic-Blackhole/pipe-stats.rule
+++ b/community_supplied/Solutions/Traffic-Blackhole/pipe-stats.rule
@@ -13,7 +13,7 @@ healthbot {
 		description "GNMI based telemetry which collects ASIC drops from interface, fabric, lookup, host and Queuing blocks";
                 open-config {
                     sensor-name /components/component/integrated-circuit/pipeline-counters;
-                    frequency 60s;
+                    frequency 180s;
                 }
             }
             field fabric-block-fabric-aggregate {
@@ -271,7 +271,7 @@ healthbot {
                         operating-system junos {
 			    sensors pfe-pipe-stats;
                             products PTX {
-                                platforms PTX1008 {
+                                platforms PTX10008 {
                                     releases 22.2R1 {
                                         release-support min-supported-release;
                                     }

--- a/juniper_official/Linecard/online-fpc.yml
+++ b/juniper_official/Linecard/online-fpc.yml
@@ -1,5 +1,0 @@
----
-UpdateTable:
-    udf: online_fpc
-    tables:
-        - SandboxStatsTable


### PR DESCRIPTION
 - Blackhole detection rules for Route failures, nexthop failures, cda failures, reroute events aft-sandbox, and npu resources
 - Removed the partial committed rules from juniper-official dir