### PR TITLE
Added new rule to get port data

### DIFF
--- a/juniper_official/interface/interface-get-port-data.rule
+++ b/juniper_official/interface/interface-get-port-data.rule
@@ -1,0 +1,144 @@
+/*
+ * Get the port information like port name, description and the part number
+ *
+ */
+healthbot {
+    topic interfaces {
+        rule get-port-data {
+            keys port-name;
+            synopsis "Port Data Collector";
+            description "Collects port information from the device";
+            sensor components {
+                synopsis "system components open-config sensor definition";
+                description "/components open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /components/;
+                    frequency 60s;
+                }
+            }
+            field description {
+                sensor components {
+                    path /components/component/state/description;
+                }
+                type string;
+            }
+            field part-number {
+                sensor components {
+                    path /components/component/state/part-no;
+                    data-if-missing {
+                        value UNCONNECTED;
+                    }
+                }
+                type string;
+                description "part number of port";
+            }
+            field port-name {
+                sensor components {
+                    where "/components/component/@name =~ /^FPC\d+:PIC\d+:PORT\d+$/";
+                    path "/components/component/@name";
+                }
+                description "port name";
+            }
+            rule-properties {
+                version 2;
+                contributor juniper;
+                category advanced;
+                supported-healthbot-version 1.0.1;
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            products EX {
+                                platforms EX4600 {
+                                    releases 18.4R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms EX4650 {
+                                    releases 18.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms EX9200 {
+                                    releases 17.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products MX {
+                                platforms MX150 {
+                                    releases 17.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2010 {
+                                    releases 16.1R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2020 {
+                                    releases 16.1R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX240 {
+                                    releases 16.1R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX480 {
+                                    releases 16.1R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX960 {
+                                    releases 16.1R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products PTX {
+                                platforms PTX1000 {
+                                    releases 17.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10000 {
+                                    releases 17.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX5000 {
+                                    releases 17.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products QFX {
+                                platforms QFX10000 {
+                                    releases 17.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms QFX5100 {
+                                    releases 18.1R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms QFX5120-48Y {
+                                    releases 18.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms QFX5200 {
+                                    releases 17.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/interface/interface-get-port-data.rule
+++ b/juniper_official/interface/interface-get-port-data.rule
@@ -2,7 +2,7 @@
  * Get the port information like port name, description and the part number
  */
 healthbot {
-    topic interface {
+    topic interfaces {
         rule get-port-data {
             keys port-name;
             synopsis "Port Data Collector";

--- a/juniper_official/interface/interface-get-port-data.rule
+++ b/juniper_official/interface/interface-get-port-data.rule
@@ -2,7 +2,7 @@
  * Get the port information like port name, description and the part number
  */
 healthbot {
-    topic interfaces {
+    topic interface {
         rule get-port-data {
             keys port-name;
             synopsis "Port Data Collector";
@@ -45,91 +45,17 @@ healthbot {
                 supported-healthbot-version 1.0.1;
                 supported-devices {
                     juniper {
-                        operating-system junos {
-                            products EX {
-                                platforms EX4600 {
-                                    releases 18.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms EX4650 {
-                                    releases 18.3R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms EX9200 {
-                                    releases 17.3R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                            }
-                            products MX {
-                                platforms MX150 {
-                                    releases 17.3R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms MX2010 {
-                                    releases 16.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms MX2020 {
-                                    releases 16.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms MX240 {
-                                    releases 16.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms MX480 {
-                                    releases 16.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms MX960 {
-                                    releases 16.1R1 {
+                        operating-system junosEvolved {
+                            products ACX {
+                                platforms All {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                             }
                             products PTX {
-                                platforms PTX1000 {
-                                    releases 17.2R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms PTX10000 {
-                                    releases 17.2R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms PTX5000 {
-                                    releases 17.2R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                            }
-                            products QFX {
-                                platforms QFX10000 {
-                                    releases 17.2R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms QFX5100 {
-                                    releases 18.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms QFX5120-48Y {
-                                    releases 18.3R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms QFX5200 {
-                                    releases 17.2R1 {
+                                platforms All {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/interface/interface-get-port-data.rule
+++ b/juniper_official/interface/interface-get-port-data.rule
@@ -1,6 +1,5 @@
 /*
  * Get the port information like port name, description and the part number
- *
  */
 healthbot {
     topic interfaces {


### PR DESCRIPTION
The rule parses the port information from the device. The data is use for selecting the Machine Learning model for bad cable inference