### PR TITLE
Updated Fan RPM Rule

### DIFF
--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -149,7 +149,7 @@ healthbot {
                  */				
                 term normal {
                     when {
-                        less-than-or-equal-to "$rpm-percent" "$low-threshold";
+                        less-than "$rpm-percent" "$low-threshold";
                     }				
                     then {
                         status {
@@ -164,13 +164,13 @@ healthbot {
                  */				
                 term above-low-threshold {
                     when {
-                        greater-than "$rpm-percent" "$low-threshold";
-                        less-than-or-equal-to "$rpm-percent" "$high-threshold";
+                        greater-than-or-equal-to "$rpm-percent" "$low-threshold";
+                        less-than "$rpm-percent" "$high-threshold";
                     }				
                     then {
                         status {
                             color yellow;
-                            message "$fan-name RPM percent $rpm-percent($measurement RPM) is greater than $rpm-low-threshold";
+                            message "$fan-name RPM percent $rpm-percent($measurement RPM) is greater than or equal to $rpm-low-threshold";
                         }
                     }
                 }
@@ -194,13 +194,10 @@ healthbot {
                  * 
                  */				
                 term above-high-threshold {
-                    when {
-                        greater-than "$rpm-percent" "$high-threshold";
-                    }
                     then {
                         status {
                             color red;
-                            message "$fan-name RPM percent $rpm-percent($measurement RPM) is greater than $rpm-high-threshold";
+                            message "$fan-name RPM percent $rpm-percent($measurement RPM) is greater than or equal to $rpm-high-threshold";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -150,6 +150,7 @@ healthbot {
                 term normal {
                     when {
                         less-than "$rpm-percent" "$low-threshold";
+                        less-than-or-equal-to "$rpm-percent-anomaly" 0;						
                     }				
                     then {
                         status {
@@ -159,7 +160,38 @@ healthbot {
                     }
                 }
                 /*
-                 * Sets color to yellow when RPM is more than 50%.
+                 * Sets color to yellow when RPM is below low threshold ($low-threshold)
+                 * and the RPM value is anomalous.
+                 */ 				
+                term is-rpm-percent-anomalous {
+                    when {
+                        less-than "$rpm-percent" "$low-threshold";
+                        equal-to "$rpm-percent-anomaly" 1;
+                    }
+                    then {
+                        status {
+                            color yellow;
+                            message "$fan-name RPM percent($rpm-percent%) is not between the acceptable range of ($rpm-percent-anomaly-lower-boundary and $rpm-percent-anomaly-upper-boundary)";
+                        }
+                    }
+                }
+                /*
+                 * Sets color to green when RPM is below low threshold ($low-threshold)
+                 * 
+                 */				
+                term is-rpm-percent-less-than-low-threshold {
+                    when {
+                        less-than "$rpm-percent" "$low-threshold";
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "$$fan-name RPM percent($rpm-percent) is normal";
+                        }
+                    }
+                }				
+                /*
+                 * Sets color to yellow when RPM is more than or equal to 50%.
                  * 
                  */				
                 term above-low-threshold {
@@ -174,21 +206,6 @@ healthbot {
                         }
                     }
                 }
-                /*
-                 * Sets color to yellow when RPM percent is below low threshold ($low-threshold)
-                 * and the rpm-percent value is anomalous.
-                 */ 
-                term is-rpm-percent-anomalous {
-                    when {
-                        equal-to "$rpm-percent-anomaly" 1;
-                    }
-                    then {
-                        status {
-                            color yellow;
-                            message "$fan-name RPM percent($rpm-percent%) is not between the acceptable range of ($rpm-percent-anomaly-lower-boundary and $rpm-percent-anomaly-upper-boundary)";
-                        }
-                    }
-                }				
                 /*
                  * Sets color to red when RPM is more than 80%.
                  * 


### PR DESCRIPTION
For the rule "hardware.chassis/check-fan-state-rpm", the trigger conditions for "rpm-percent" is modified to match the below condition.
• If value is less than high threshold display is green.
• If value is less than critical threshold display is yellow.
• If value is greater than or equal to high threshold display is yellow.
• If value is greater than or equal to critical threshold display is red.