### PR TITLE
Modified system-power-usage-temp-state rule

### DIFF
--- a/juniper_official/chassis/check-system-power-usage-temp-state.rule
+++ b/juniper_official/chassis/check-system-power-usage-temp-state.rule
@@ -153,7 +153,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "Chassis ambient temperature($chassis-temperature degree celsius) exceeds low threshold";
+                            message "Chassis ambient temperature($chassis-temperature degree celsius) exceeds high threshold";
                         }
                     }
                 }
@@ -165,7 +165,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "Chassis ambient temperature($chassis-temperature degree celsius) exceeds high threshold";
+                            message "Chassis ambient temperature($chassis-temperature degree celsius) exceeds critical threshold";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-system-power-usage-temp-state.rule
+++ b/juniper_official/chassis/check-system-power-usage-temp-state.rule
@@ -162,9 +162,6 @@ healthbot {
                  * 
                  */				
                 term temperature-abnormal {
-                    when {
-                        greater-than "$chassis-temperature" "$high-threshold";
-                    }				
                     then {
                         status {
                             color red;
@@ -217,7 +214,7 @@ healthbot {
                  */				
                 term power-usage-normal {
                     when {
-                        greater-than-or-equal-to "$system-power-remaining-in-percentage" "$system-power-usage-high-threshold";
+                        greater-than "$system-power-remaining-in-percentage" "$system-power-usage-high-threshold";
                     }
                     then {
                         status {
@@ -232,8 +229,8 @@ healthbot {
                  */				
                 term is-power-remaining-less-than-high-threshold {
                     when {
-                        greater-than-or-equal-to "$system-power-remaining-in-percentage" "$system-power-usage-low-threshold";
-                        less-than "$system-power-remaining-in-percentage" "$system-power-usage-high-threshold";
+                        greater-than "$system-power-remaining-in-percentage" "$system-power-usage-low-threshold";
+                        less-than-or-equal-to "$system-power-remaining-in-percentage" "$system-power-usage-high-threshold";
                     }
                     then {
                         status {
@@ -248,7 +245,7 @@ healthbot {
                  */				
                 term is-power-remaining-less-than-low-threshold {
                     when {
-                        less-than "$system-power-remaining-in-percentage" "$system-power-usage-low-threshold";
+                        less-than-or-equal-to "$system-power-remaining-in-percentage" "$system-power-usage-low-threshold";
                     }
                     then {
                         status {


### PR DESCRIPTION
For the rule "check-system-power-usage-temp-state", the trigger conditions for "chassis-temperature" and "system-power-usage" is modified to match the below condition.
• If value is less than high threshold display is green.
• If value is less than critical threshold display is yellow.
• If value is greater than or equal to high threshold display is yellow.
• If value is greater than or equal to critical threshold display is red.

Trigger "chassis-temperature" - Removed "when" condition for default red term.
Trigger "system-power-usage" - Modified match conditions