### PR TITLE
Updated interface-in-out-errors-traffic-state-flaps rule

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -244,7 +244,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name input traffic:$in-mbps mbps and $in-util % is in medium range";
+                            message "$interface-name input traffic:$in-mbps mbps and $in-util % is equal-to or exceeds high threshold";
                         }
                     }
                 }
@@ -258,7 +258,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$interface-name input traffic:$in-mbps mbps and $in-util % is above high threshold";
+                            message "$interface-name input traffic:$in-mbps mbps and $in-util % is equal-to or exceeds critical threshold";
                         }
                     }
                 }				
@@ -501,7 +501,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name output traffic:$out-mbps mbps and $out-util % is in medium range";
+                            message "$interface-name output traffic:$out-mbps mbps and $out-util % is equal-to or exceeds high threshold";
                         }
                     }
                 }
@@ -515,7 +515,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$interface-name output traffic:$out-mbps mbps and $out-util % is above high threshold";
+                            message "$interface-name output traffic:$out-mbps mbps and $out-util % is equal-to or exceeds critical threshold";
                         }
                     }
                 }				

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -215,7 +215,7 @@ healthbot {
                  */				
                 term interface-in-traffic-normal {
                     when {
-                        matches-with-previous "$in-util";
+                        less-than "$in-util" "$low-threshold";
                     }				
                     then {
                         status {
@@ -232,9 +232,13 @@ healthbot {
                  */					
                 term is-interface-in-traffic-median {
                     when {
-                        increasing-at-least-by-value "$in-util" {
-                            value "$low-threshold";
+                        greater-than-or-equal-to "$in-util" "$low-threshold" {
                             time-range 3offset;
+                            any;
+                        }
+                        less-than "$in-util" "$high-threshold" {
+                            time-range 3offset;
+                            any;
                         }
                     }
                     then {
@@ -251,12 +255,6 @@ healthbot {
                  * points in a 180 seconds period.
                  */				
                 term is-interface-in-traffic-abnormal {
-                    when {
-                        increasing-at-least-by-value "$in-util" {
-                            value "$high-threshold";
-                            time-range 3offset;
-                        }
-                    }
                     then {
                         status {
                             color red;
@@ -474,7 +472,7 @@ healthbot {
                  */ 				
                 term is-interface-stats-normal {
                     when {
-                        matches-with-previous "$out-util";
+                        less-than "$out-util" "$low-threshold";
                     }				
                     then {
                         status {
@@ -491,9 +489,13 @@ healthbot {
                  */				
                 term is-interface-stats-median {
                     when {
-                        increasing-at-least-by-value "$out-util" {
-                            value "$low-threshold";
+                        greater-than-or-equal-to "$out-util" "$low-threshold" {
                             time-range 3offset;
+                            any;
+                        }
+                        less-than "$out-util" "$high-threshold" {
+                            time-range 3offset;
+                            any;
                         }
                     }
                     then {
@@ -510,12 +512,6 @@ healthbot {
                  * points in 180 seconds period.
                  */ 				
                 term is-interface-stats-abnormal {
-                    when {
-                        increasing-at-least-by-value "$out-util" {
-                            value "$high-threshold";
-                            time-range 3offset;
-                        }
-                    }
                     then {
                         status {
                             color red;

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -238,7 +238,6 @@ healthbot {
                         }
                         less-than "$in-util" "$high-threshold" {
                             time-range 3offset;
-                            any;
                         }
                     }
                     then {
@@ -495,7 +494,6 @@ healthbot {
                         }
                         less-than "$out-util" "$high-threshold" {
                             time-range 3offset;
-                            any;
                         }
                     }
                     then {


### PR DESCRIPTION
For the rule "check-interface-in-out-errors-traffic-state-flaps", the trigger conditions for "interface-input-traffic" and "interface-out-traffic" is modified.

Earlier we were checking if the traffic is increasing by a rate, we are now checking if it exceeds low and high threshold percentage. 