### PR TITLE
Updated check-interface-fec-crc-framing-errors rule

### DIFF
--- a/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
+++ b/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
@@ -77,7 +77,7 @@ healthbot {
                 sensor errorinfo-netconf {
                     path input-crc-errors;
                 }
-                type string;
+                type integer;
                 description "Checks for input CRC errors";
             }
             field interface-name {


### PR DESCRIPTION
For the rule "check-interface-fec-crc-framing-errors", the field "input-crc-errors" was changed from type "string" to type "integer".