### PR TITLE
Updated checkoptical-signal-loss-fec-tx-rx-power rule

### DIFF
--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -310,14 +310,14 @@ healthbot {
                         greater-than-or-equal-to "$optics-rx-power" "$rx-high-warning-threshold" {
                             time-range 2offset;
                         }
-                        less-than-or-equal-to "$optics-rx-power" "$rx-high-alarm-threshold" {
+                        less-than "$optics-rx-power" "$rx-high-alarm-threshold" {
                             time-range 2offset;
                         }
                     }
                     then {
                         status {
                             color yellow;
-                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is above high warning threshold ($rx-high-warning-threshold) ";
+                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is equal to or above high warning threshold ($rx-high-warning-threshold) ";
                         }
                     }
                 }
@@ -327,7 +327,7 @@ healthbot {
                  */				
                 term rx-below-low-warning-threshold {
                     when {
-                        greater-than-or-equal-to "$optics-rx-power" "$rx-low-alarm-threshold";
+                        greater-than "$optics-rx-power" "$rx-low-alarm-threshold";
                         less-than-or-equal-to "$optics-rx-power" "$rx-low-warning-threshold" {
                             time-range 2offset;
                         }
@@ -335,7 +335,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is below low warning threshold ($rx-low-warning-threshold) ";
+                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is equal to or below low warning threshold ($rx-low-warning-threshold) ";
                         }
                     }
                 }
@@ -344,12 +344,12 @@ healthbot {
                  */				
                 term rx-above-high-alarm-threshold {
                     when {
-                        greater-than "$optics-rx-power" "$rx-high-alarm-threshold";
+                        greater-than-or-equal-to "$optics-rx-power" "$rx-high-alarm-threshold";
                     }
                     then {
                         status {
                             color red;
-                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is above high alarm threshold ($rx-high-alarm-threshold)";
+                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is equal to or above high alarm threshold ($rx-high-alarm-threshold)";
                         }
                     }
                 }
@@ -358,12 +358,12 @@ healthbot {
                  */				
                 term rx-below-low-alarm-threshold {
                     when {
-                        less-than "$optics-rx-power" "$rx-low-alarm-threshold";
+                        less-than-or-equal-to "$optics-rx-power" "$rx-low-alarm-threshold";
                     }
                     then {
                         status {
                             color red;
-                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is below low alarm threshold ($rx-low-alarm-threshold)";
+                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is equal to or below low alarm threshold ($rx-low-alarm-threshold)";
                         }
                     }
                 }
@@ -397,7 +397,7 @@ healthbot {
                         greater-than-or-equal-to "$optics-tx-power" "$tx-high-warning-threshold" {
                             time-range 2offset;
                         }
-                        less-than-or-equal-to "$optics-tx-power" "$tx-high-alarm-threshold" {
+                        less-than "$optics-tx-power" "$tx-high-alarm-threshold" {
                             time-range 2offset;
                         }
                     }
@@ -414,7 +414,7 @@ healthbot {
                  */				
                 term tx-below-low-warning-threshold {
                     when {
-                        greater-than-or-equal-to "$optics-tx-power" "$tx-low-alarm-threshold" {
+                        greater-than "$optics-tx-power" "$tx-low-alarm-threshold" {
                             time-range 2offset;
                         }
                         less-than-or-equal-to "$optics-tx-power" "$tx-low-warning-threshold" {
@@ -433,7 +433,7 @@ healthbot {
                  */				
                 term tx-above-high-alarm-threshold {
                     when {
-                        greater-than "$optics-tx-power" "$tx-high-alarm-threshold";
+                        greater-than-or-equal-to "$optics-tx-power" "$tx-high-alarm-threshold";
                     }
                     then {
                         status {
@@ -447,7 +447,7 @@ healthbot {
                  */				
                 term tx-lesser-than-low-alarm-threshold {
                     when {
-                        less-than "$optics-tx-power" "$tx-low-alarm-threshold";
+                        less-than-or-equal-to "$optics-tx-power" "$tx-low-alarm-threshold";
                     }
                     then {
                         status {

--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -404,7 +404,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name,lane $lane-index Tx power $optics-tx-power is above warning threshold ($tx-high-warning-threshold)";
+                            message "$interface-name,lane $lane-index Tx power $optics-tx-power is equal-to or above high warning threshold ($tx-high-warning-threshold)";
                         }
                     }
                 }
@@ -424,7 +424,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name,lane $lane-index Tx power $optics-tx-power is below warning threshold ($tx-low-warning-threshold)";
+                            message "$interface-name,lane $lane-index Tx power $optics-tx-power is equal-to or below low warning threshold ($tx-low-warning-threshold)";
                         }
                     }
                 }
@@ -438,7 +438,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$interface-name,lane $lane-index Tx power $optics-tx-power is above alarm threshold ($tx-high-alarm-threshold)";
+                            message "$interface-name,lane $lane-index Tx power $optics-tx-power is equal-to or above high alarm threshold ($tx-high-alarm-threshold)";
                         }
                     }
                 }
@@ -452,7 +452,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$interface-name,lane $lane-index Tx power $optics-tx-power is below alarm threshold ($tx-low-alarm-threshold)";
+                            message "$interface-name,lane $lane-index Tx power $optics-tx-power is equal-to or below low alarm threshold ($tx-low-alarm-threshold)";
                         }
                     }
                 }

--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -307,13 +307,9 @@ healthbot {
                  */				
                 term rx-above-high-warning-threshold {
                     when {
-                        greater-than-or-equal-to "$optics-rx-power" "$rx-high-warning-threshold" {
-                            time-range 2offset;
-                        }
-                        less-than "$optics-rx-power" "$rx-high-alarm-threshold" {
-                            time-range 2offset;
-                        }
-                    }
+                        greater-than-or-equal-to "$optics-rx-power" "$rx-high-warning-threshold";
+                        less-than "$optics-rx-power" "$rx-high-alarm-threshold";
+						}
                     then {
                         status {
                             color yellow;
@@ -328,9 +324,7 @@ healthbot {
                 term rx-below-low-warning-threshold {
                     when {
                         greater-than "$optics-rx-power" "$rx-low-alarm-threshold";
-                        less-than-or-equal-to "$optics-rx-power" "$rx-low-warning-threshold" {
-                            time-range 2offset;
-                        }
+                        less-than-or-equal-to "$optics-rx-power" "$rx-low-warning-threshold";
                     }
                     then {
                         status {
@@ -394,12 +388,8 @@ healthbot {
                  */				
                 term tx-above-high-warning-threshold {
                     when {
-                        greater-than-or-equal-to "$optics-tx-power" "$tx-high-warning-threshold" {
-                            time-range 2offset;
-                        }
-                        less-than "$optics-tx-power" "$tx-high-alarm-threshold" {
-                            time-range 2offset;
-                        }
+                        greater-than-or-equal-to "$optics-tx-power" "$tx-high-warning-threshold";
+                        less-than "$optics-tx-power" "$tx-high-alarm-threshold";
                     }
                     then {
                         status {
@@ -414,12 +404,8 @@ healthbot {
                  */				
                 term tx-below-low-warning-threshold {
                     when {
-                        greater-than "$optics-tx-power" "$tx-low-alarm-threshold" {
-                            time-range 2offset;
-                        }
-                        less-than-or-equal-to "$optics-tx-power" "$tx-low-warning-threshold" {
-                            time-range 2offset;
-                        }
+                        greater-than "$optics-tx-power" "$tx-low-alarm-threshold";
+                        less-than-or-equal-to "$optics-tx-power" "$tx-low-warning-threshold";
                     }
                     then {
                         status {


### PR DESCRIPTION
For the rule "checkoptical-signal-loss-fec-tx-rx-power", the trigger conditions for "interface-optical-rx-power" and "interface-optical-tx-power" is modified to match the below conditions.

• If value is less than high threshold display is green.
• If value is less than critical threshold display is yellow.
• If value is greater than or equal to high threshold display is yellow.
• If value is greater than or equal to critical threshold display is red.