### PR TITLE
Update optical-signal-loss-fec-tx-rx-power lane index field

### DIFF
--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -12,7 +12,7 @@ healthbot {
              * threshold values and notifies by displaying green,yellow and red alarms.
              * Use interface-name as key for the rule.
              */		
-            keys interface-name;
+            keys [ interface-name lane-index ];
             synopsis "KPI for  interface optical degradation";
             description "Monitor the interface optical degradation";
             /*
@@ -39,7 +39,7 @@ healthbot {
             }
             field lane-index {
                 sensor optical-sensor-oc {
-                    path "/interfaces/interface/optics/lanediags/lane/@number";
+                    path "/interfaces/interface/optics/lanediags/lane/@lane_number";
                 }
                 type string;
                 description "Interface lane index";


### PR DESCRIPTION
Update optical-signal-loss-fec-tx-rx-power lane index field.
Changed the sensor path for "lane-index" field from /interfaces/interface/optics/lanediags/lane/@number to /interfaces/interface/optics/lanediags/lane/@lane_number.
This is because of difference in paths for GRPC and GNMI sensors.

Also added lane-index as key.