### PR TITLE
Updated routing-engine field sensor path

### DIFF
--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -113,7 +113,7 @@ healthbot {
             }
             field routing-engine {
                 sensor components-oc {
-                    where "/components/component/@name =~ /{{re-slot-no}}/";
+                    where "/components/component/@name =~ /^Routing Engine[{{re-slot-no}}]$|^RE[{{re-slot-no}}]$/";
                     path "/components/component/@name";
                 }
                 description "RE name to monitor";
@@ -327,7 +327,7 @@ healthbot {
                 type int;
             }
             variable re-slot-no {
-                value "^Routing Engine[0-1]$|^RE[0-1]$";
+                value 0-1;
                 description "Routing engine numbers to monitor, regular expression, e.g. '0'";
                 type string;
             }

--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -113,7 +113,7 @@ healthbot {
             }
             field routing-engine {
                 sensor components-oc {
-                    where "/components/component/@name =~ /^Routing Engine[{{re-slot-no}}]$/";
+                    where "/components/component/@name =~ /{{re-slot-no}}/";
                     path "/components/component/@name";
                 }
                 description "RE name to monitor";
@@ -327,7 +327,7 @@ healthbot {
                 type int;
             }
             variable re-slot-no {
-                value 0-1;
+                value "^Routing Engine[0-1]$|^RE[0-1]$";
                 description "Routing engine numbers to monitor, regular expression, e.g. '0'";
                 type string;
             }


### PR DESCRIPTION
Updated "check-system-cpu-memory" field routing-engine to match on both "Routing Engine" and "RE" in sensor path.