### PR TITLE
Updated red when condition in check-psm-power-usage-state rule

### DIFF
--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -206,6 +206,11 @@ healthbot {
                  * 
                  */				
                 term state-is-not-online {
+                    when {
+                        does-not-match-with "$psm-state" online {
+                            ignore-case;
+                        }
+                    }				
                     then {
                         status {
                             color red;
@@ -254,6 +259,9 @@ healthbot {
                  * 
                  */				
                 term temperature-exceeds-high-threshold {
+                    when {
+                        greater-than-or-equal-to "$psm-temperature" "$psm-temperature-high-threshold";
+                    }				
                     then {
                         status {
                             color red;


### PR DESCRIPTION
Updated "when" condition for red terms in the rule "check-psm-power-usage-state" rule.