### PR TITLE
Interface traffic sensor paths updated

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -117,7 +117,7 @@ healthbot {
             }
             field in-octets {
                 sensor interfaces-oc {
-                    path /interfaces/interface/state/counters/if_in_octets;
+                    path /interfaces/interface/state/counters/in-octets;
                     zero-suppression;
                 }
                 type integer;
@@ -181,7 +181,7 @@ healthbot {
             }
             field out-octets {
                 sensor interfaces-oc {
-                    path /interfaces/interface/state/counters/if_out_octets;
+                    path /interfaces/interface/state/counters/out-octets;
                     zero-suppression;
                 }
                 type integer;


### PR DESCRIPTION
For the interfaces/check-interface-in-out-errors-traffic-state-flaps rule the "in-octets" and "out-octets" fields have been updated.

Before :
/interfaces/interface/state/counters/if_in_octets
/interfaces/interface/state/counters/if_out_octets

Updated :

/interfaces/interface/state/counters/in-octets
/interfaces/interface/state/counters/out-octets

