### PR TITLE
Changed the offset to 1 in check-rsvp-neighbor-state rule

### DIFF
--- a/juniper_official/routing/check-rsvp-neighbor-state.rule
+++ b/juniper_official/routing/check-rsvp-neighbor-state.rule
@@ -43,7 +43,7 @@
              * Anomaly detection logic to detect rsvp neighbor state changes.
              */
             trigger rsvp-neighbor-state {
-                frequency 1.5offset;
+                frequency 1offset;
                 term rsvp-neighbor-state-up {
                     when {
                         matches-with "$neighbor-state" UP {


### PR DESCRIPTION
In the rule Check-rsvp-neighbor-state, changed the frequency of the trigger is set to 1offset