### PR TITLE
Check te rsvp global errors

### DIFF
--- a/juniper_official/routing/check-rsvp-neighbor-state.rule
+++ b/juniper_official/routing/check-rsvp-neighbor-state.rule
@@ -43,7 +43,7 @@
              * Anomaly detection logic to detect rsvp neighbor state changes.
              */
             trigger rsvp-neighbor-state {
-                frequency 1.5offset;
+                frequency 1offset;
                 term rsvp-neighbor-state-up {
                     when {
                         matches-with "$neighbor-state" UP {

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -207,7 +207,7 @@
              * Anomaly detection logic to detect rsvp-te global errors.
              */
             trigger rsvp-te-global-errors {
-                frequency 3offset;
+                frequency 1offset;
                 term is-authentication-fail {
                     when {
                         increasing-at-least-by-value "$authentication-fail" {


### PR DESCRIPTION
In the rule Check-te-rsvp-global-errors, changed the frequency of the trigger is set to 1offset