### PR TITLE
changed frequency to 1offset in check-ospf-io-statistics rule

### DIFF
--- a/juniper_official/routing/check-ospf-io-statistics.rule
+++ b/juniper_official/routing/check-ospf-io-statistics.rule
@@ -41,7 +41,7 @@
             trigger ospf-io-errors {
                 synopsis "ospf io statistics kpi";
                 description "Sets health based on ospf io errors";
-                frequency 1.5offset;
+                frequency 1offset;
                 /*
                  * Sets color to green when no ospf errors.
                  */


### PR DESCRIPTION
In the rule check-ospf-io-statistics  changed the frequency of the trigger is set to 1offset