### PR TITLE
remove offset time-range in trigger terms for isis statistics rule

### DIFF
--- a/juniper_official/routing/check-isis-statistics.rule
+++ b/juniper_official/routing/check-isis-statistics.rule
@@ -145,14 +145,12 @@
                 }
                 /*
                  * Sets color to red and sends out an anomaly notification when
-                 * the csnp drop ($csnp-drops) count increases in all points
-                 * in a 3 minute period.
+                 * the csnp drop ($csnp-drops) count increases
                  */
                 term csnp-drops-increasing {
                     when {
                         increasing-at-least-by-value "$csnp-drops" {
                             value "$threshold";
-                            time-range 3offset;
                         }
                     }
                     then {
@@ -183,14 +181,12 @@
                 }				
                 /*
                  * Sets color to red and sends out an anomaly notification when
-                 * the esh drop ($esh-drops) count increases in all points
-                 * in a 3 minute period.
+                 * the esh drop ($esh-drops) count increases
                  */
                 term lsp-drops-increasing {
                     when {
                         increasing-at-least-by-value "$esh-drops" {
                             value "$threshold";
-                            time-range 3offset;
                         }
                     }
                     then {
@@ -221,14 +217,12 @@
                 }				
                 /*
                  * Sets color to red and sends out an anomaly notification when
-                 * the iih drop ($iih-drops) count increases in all points
-                 * in a 3 minute period.
+                 * the iih drop ($iih-drops) count increases
                  */
                 term lsp-drops-increasing {
                     when {
                         increasing-at-least-by-value "$iih-drops" {
                             value "$threshold";
-                            time-range 3offset;
                         }
                     }
                     then {
@@ -259,14 +253,12 @@
                 }				
                 /*
                  * Sets color to red and sends out an anomaly notification when
-                 * the ish drop ($ish-drops) count increases in all points
-                 * in a 3 minute period.
+                 * the ish drop ($ish-drops) count increases
                  */
                 term lsp-drops-increasing {
                     when {
                         increasing-at-least-by-value "$ish-drops" {
                             value "$threshold";
-                            time-range 3offset;
                         }
                     }
                     then {
@@ -297,14 +289,12 @@
                 }				
                 /*
                  * Sets color to red and sends out an anomaly notification when
-                 * the lsp drop ($lsp-drops) count increases in all points
-                 * in a 3 minute period.
+                 * the lsp drop ($lsp-drops) count increases
                  */
                 term lsp-drops-increasing {
                     when {
                         increasing-at-least-by-value "$lsp-drops" {
                             value "$threshold";
-                            time-range 3offset;
                         }
                     }
                     then {
@@ -335,14 +325,12 @@
                 }				
                 /*
                  * Sets color to red and sends out an anomaly notification when
-                 * the psnp drop ($psnp-drops) count increases in all points
-                 * in a 3 minute period.
+                 * the psnp drop ($psnp-drops) count increases
                  */
                 term lsp-drops-increasing {
                     when {
                         increasing-at-least-by-value "$psnp-drops" {
                             value "$threshold";
-                            time-range 3offset;
                         }
                     }
                     then {
@@ -373,14 +361,12 @@
                 }				
                 /*
                  * Sets color to red and sends out an anomaly notification when
-                 * unknown drop ($unknown-drops) count increases in all points
-                 * in a 3 minute period.
+                 * unknown drop ($unknown-drops) count increases
                  */
                 term lsp-drops-increasing {
                     when {
                         increasing-at-least-by-value "$unknown-drops" {
                             value "$threshold";
-                            time-range 3offset;
                         }
                     }
                     then {


### PR DESCRIPTION
Remove time-range offset in trigger terms for "routing.isis/check-isis-statistics" rule.