### PR TITLE
remove offset time-range in trigger terms for rib table routes rule

### DIFF
--- a/juniper_official/routing/collect-rib-table-routes.rule
+++ b/juniper_official/routing/collect-rib-table-routes.rule
@@ -76,7 +76,7 @@
                  */				
                 term route-count-normal {
                     when {
-                        less-than-or-equal-to "$table-total-route-count" "$threshold";
+                        less-than "$table-total-route-count" "$threshold";
                     }
                     then {
                         status {
@@ -86,13 +86,11 @@
                     }
                 }
                 /*
-                 * Sets color to red when route-count is greater than threshold for 3offset
+                 * Sets color to red when route-count is greater than threshold
                  */				
                 term is-route-count-abnormal {
                     when {
-                        greater-than "$table-total-route-count" "$threshold" {
-                            time-range 3offset;
-                        }
+                        greater-than-or-equal-to "$table-total-route-count" "$threshold";
                     }
                     then {
                         status {


### PR DESCRIPTION
Remove offset time-range in trigger terms for "collect-rib-table-routes".