### PR TITLE
updated sensor path for isis adjacency rule

### DIFF
--- a/juniper_official/routing/check-isis-adjacency-status.rule
+++ b/juniper_official/routing/check-isis-adjacency-status.rule
@@ -28,7 +28,7 @@
                     path adjacency-state;
                 }
                 sensor isis-oc {
-                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/adjacencies/adjacency/state/adjacency-state;
+                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/adjacencies/adjacency/state/lan-adjacency-state;
                 }
                 type string;
                 description "Isis neighbor state";


### PR DESCRIPTION
Updated sensor path for field "adjacency-state" in "routing.isis/check-isis-adjacency-status" rule to support broadcast network type.