### PR TITLE
Updated speed in interface utilization rule

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -220,7 +220,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name input traffic:$in-mbps mbps and $in-util % is normal";
+                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is normal";
                         }
                     }
                 }							
@@ -240,7 +240,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name input traffic:$in-mbps mbps and $in-util % is in medium range";
+                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is in medium range";
                         }
                     }
                 }
@@ -260,7 +260,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$interface-name input traffic:$in-mbps mbps and $in-util % is above high threshold";
+                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is above high threshold";
                         }
                     }
                 }	
@@ -479,7 +479,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name output traffic:$out-mbps mbps and $out-util % is normal";
+                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is normal";
                         }
                     }
                 }
@@ -499,7 +499,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name output traffic:$out-mbps mbps and $out-util % is in medium range";
+                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is in medium range";
                         }
                     }
                 }
@@ -519,7 +519,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$interface-name output traffic:$out-mbps mbps and $out-util % is above high threshold";
+                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is above high threshold";
                         }
                     }
                 }				


### PR DESCRIPTION
Updated message for input/output traffic to include speed in "check-interface-in-out-errors-traffic-state-flaps" rule.