### PR TITLE
changes in check-interface-in-out-errors-traffic-state-flaps rule

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -209,13 +209,15 @@ healthbot {
             trigger interface-input-traffic {
                 synopsis "Interface input traffic kpi";
                 description "Sets health based on input traffic exceed threshold";
-                frequency 2offset;
+                frequency 1offset;
                 /*
                  * Sets color to green when in-util is not increasing
                  */				
                 term interface-in-traffic-normal {
                     when {
-                        matches-with-previous "$in-util";
+                        matches-with-previous "$in-util"{
+                            time-range 2.5offset;
+                        }
                     }				
                     then {
                         status {
@@ -234,7 +236,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$in-util" {
                             value "$low-threshold";
-                            time-range 3offset;
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -254,7 +256,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$in-util" {
                             value "$high-threshold";
-                            time-range 3offset;
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -269,13 +271,15 @@ healthbot {
             trigger interface-input-errors {
                 synopsis "Interface input-errors kpi";
                 description "Sets health based on the change in input-errors count";
-                frequency 2offset;
+                frequency 1offset;
                 /*
                  * Sets color to green when in-errors-count is not increasing
                  */				
                 term no-interface-in-errors {
                     when {
-                        matches-with-previous "$in-errors-count";
+                        matches-with-previous "$in-errors-count"{
+                            time-range 2.5offset;
+                        }
                     }				
                     then {
                         status {
@@ -292,6 +296,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$in-errors-count" {
                             value "$in-errors-threshold";
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -310,7 +315,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$in-errors-count" {
                             value "$in-errors-threshold";
-                            time-range 3offset;
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -330,7 +335,9 @@ healthbot {
                  */				
                 term is-link-stable {
                     when {
-                        matches-with-previous "$flaps";
+                        matches-with-previous "$flaps"{
+                            time-range 2.5offset;
+                        }
                     }				
                     then {
                         status {
@@ -347,6 +354,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$flaps" {
                             value "$flaps-threshold";
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -363,7 +371,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$flaps" {
                             value "$flaps-threshold";
-                            time-range 3offset;
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -377,7 +385,7 @@ healthbot {
             trigger interface-link-state {
                 synopsis "link state kpi";
                 description "Sets health based on link state";
-                frequency 2offset;
+                frequency 1offset;
                 /*
                  * Sets color to green when both admin and link state is UP
                  */				
@@ -413,13 +421,15 @@ healthbot {
             trigger interface-output-errors {
                 synopsis "Interface output-errors kpi";
                 description "Sets health based on the change in output-errors count";
-                frequency 2offset;
+                frequency 1offset;
                 /*
                  * Sets color to green when out-errors-count is not increasing
                  */				
                 term no-interface-out-errors {
                     when {
-                        matches-with-previous "$out-errors-count";
+                        matches-with-previous "$out-errors-count"{
+                            time-range 2.5offset;
+                        }
                     }				
                     then {
                         status {
@@ -436,6 +446,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$out-errors-count" {
                             value "$out-errors-threshold";
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -454,7 +465,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$out-errors-count" {
                             value "$out-errors-threshold";
-                            time-range 3offset;
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -468,13 +479,15 @@ healthbot {
             trigger interface-output-traffic {
                 synopsis "Interface output traffic kpi";
                 description "Sets health based on output traffic exceed threshold";
-                frequency 2offset;
+                frequency 1offset;
                 /*
                  * Sets color to green when out-util is not increasing
                  */ 				
                 term is-interface-stats-normal {
                     when {
-                        matches-with-previous "$out-util";
+                        matches-with-previous "$out-util"{
+                            time-range 2.5offset;
+                        }
                     }				
                     then {
                         status {
@@ -493,7 +506,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$out-util" {
                             value "$low-threshold";
-                            time-range 3offset;
+                            time-range 2.5offset;
                         }
                     }
                     then {
@@ -513,7 +526,7 @@ healthbot {
                     when {
                         increasing-at-least-by-value "$out-util" {
                             value "$high-threshold";
-                            time-range 3offset;
+                            time-range 2.5offset;
                         }
                     }
                     then {


### PR DESCRIPTION
1. Changed the trigger frequencies to 1offset
2. Added time ranges to match-with-previous and increasing-at-least-by-value conditions
3. changes time-range to 2.5offset