### PR TITLE
updated interface admin condition

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -62,7 +62,6 @@ healthbot {
              */			
             field admin-state {
                 sensor interfaces-oc {
-                    where "/interfaces/interface/state/admin-status == UP";
                     path /interfaces/interface/state/admin-status;
                 }
                 type string;


### PR DESCRIPTION
Removed match condition of admin "UP" from the rule "check-interface-in-out-errors-traffic-state-flaps".