### PR TITLE
Removed zero suppression

### DIFF
--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -43,7 +43,6 @@ healthbot {
             field measurements {
                 sensor fan-netconf {
                     path measurement;
-                    zero-suppression;
                     data-if-missing {
                         value 0;
                     }					
@@ -64,7 +63,6 @@ healthbot {
             field rpm-percents {
                 sensor fan-netconf {
                     path rpm;
-                    zero-suppression;
                     data-if-missing {
                         value 0;
                     }

--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -1,5 +1,5 @@
 /*
- * Monitors fan state and RPM percentage and notifies when anomalies are found.
+ * Monitors the fan state and RPM percentage and notifies when anomalies are found.
  * 2 Variables :
  *
  *   1) high-threshold, defaults to 80% 

--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -1,5 +1,5 @@
 /*
- * Monitors the fan state and RPM percentage and notifies when anomalies are found.
+ * Monitors the fan state and  RPM percentage and notifies when anomalies are found.
  * 2 Variables :
  *
  *   1) high-threshold, defaults to 80% 


### PR DESCRIPTION
Removed zero-suppression from fields in "hardware.chassis/check-fan-state-rpm" rule.