### PR TITLE
Removed zero-suppression

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -70,7 +70,6 @@ healthbot {
             field flaps {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/carrier-transitions;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of interface flaps";
@@ -92,7 +91,6 @@ healthbot {
             field in-errors-count {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/in-errors;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of input-errors";
@@ -117,7 +115,6 @@ healthbot {
             field in-octets {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/in-octets;
-                    zero-suppression;
                 }
                 type integer;
                 description "Interface statistics counter (in-octets) value";
@@ -156,7 +153,6 @@ healthbot {
             field out-errors-count {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/out-errors;
-                    zero-suppression;
                 }
                 type integer;
                 description "This field shows interface field's value";
@@ -181,7 +177,6 @@ healthbot {
             field out-octets {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/out-octets;
-                    zero-suppression;
                 }
                 type integer;
                 description "Interface statistics counter (out-octets) value";


### PR DESCRIPTION
Removed zero-suppression for "interfaces/check-interface-in-out-errors-traffic-state-flaps" rule.