### PR TITLE
Removed zero-suppression in fpc rule

### DIFF
--- a/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
+++ b/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
@@ -113,7 +113,6 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'memory-utilization-buffer'";
                     path /components/component/properties/property/state/value;
-                    zero-suppression;
                 }
                 type integer;
                 description "FPC buffer memory utilization";
@@ -131,7 +130,6 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'memory-utilization-heap'";
                     path /components/component/properties/property/state/value;
-                    zero-suppression;
                 }
                 type integer;
                 description "FPC heap memory utilization";
@@ -148,7 +146,6 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'cpu-utilization-idle'";
                     path /components/component/properties/property/state/value;
-                    zero-suppression;
                 }
                 type integer;
                 description "FPC IDLE CPU utilization";


### PR DESCRIPTION
Removed zero-suppression in "hardware.fpc/check-fpc-cpu-memory-state-temp" rule.