### PR TITLE
Removed zero-suppression from bgp rule

### DIFF
--- a/juniper_official/routing/check-bgp-neighbor-stats.rule
+++ b/juniper_official/routing/check-bgp-neighbor-stats.rule
@@ -29,7 +29,6 @@
                 }
                 sensor bgp-oc {
                     path /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/established-transitions;
-                    zero-suppression;
                 }
                 type integer;
                 description "Sensor field to store flap count";


### PR DESCRIPTION
Removed zero-suppression from "routing.bgp/check-bgp-neighbor-stats" rule.