### PR TITLE
Removed zero-suppression from ISIS rule

### DIFF
--- a/juniper_official/routing/check-isis-statistics.rule
+++ b/juniper_official/routing/check-isis-statistics.rule
@@ -48,7 +48,6 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/csnp/state/dropped;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of csnp drops";
@@ -57,7 +56,6 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/esh/state/dropped;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of esh drops";
@@ -66,7 +64,6 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/iih/state/dropped;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of iih drops";
@@ -83,7 +80,6 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/ish/state/dropped;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of ish drops";
@@ -92,7 +88,6 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/lsp/state/dropped;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of lsp drops";
@@ -101,7 +96,6 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/psnp/state/dropped;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of psnp drops";
@@ -117,7 +111,6 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/unknown/state/dropped;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of unknown drops";


### PR DESCRIPTION
Removed zero-suppression from "routing.isis/check-isis-statistics" rule.