### PR TITLE
Removed zero-suppression from RSVP rule

### DIFF
--- a/juniper_official/routing/check-rsvp-neighbor-state.rule
+++ b/juniper_official/routing/check-rsvp-neighbor-state.rule
@@ -24,7 +24,6 @@
             field neighbor-interface {
                 sensor rsvp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/neighbors/neighbor/state/detected-interface;
-                    zero-suppression;
                     data-if-missing {
                         value node;
                     }


### PR DESCRIPTION
Removed zero-suppression from "routing.mpls/check-rsvp-neighbor-state" rule