### PR TITLE
Removed zero-suppression from te-rsvp-interface-errors rule

### DIFF
--- a/juniper_official/routing/check-te-rsvp-interface-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-interface-errors.rule
@@ -16,10 +16,6 @@ healthbot {
             field authentication-fail {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/authentication-fail;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Authentication fail error count";
@@ -27,10 +23,6 @@ healthbot {
             field bad-checksum {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/bad-checksum;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Bad checksum error count";
@@ -38,10 +30,6 @@ healthbot {
             field bad-packet-format {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/bad-packet-format;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Bad packet format error count";
@@ -49,10 +37,6 @@ healthbot {
             field bad-packet-length {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/bad-packet-length;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Bad packet length error count";
@@ -60,10 +44,6 @@ healthbot {
             field bad-packet-version {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/bad-packet-version;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Bad packet version error count";
@@ -71,10 +51,6 @@ healthbot {
             field in-path-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/counters/in-path-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "In path messages error count";
@@ -82,10 +58,6 @@ healthbot {
             field in-reservation-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/counters/in-reservation-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "In reservation messages error count";
@@ -93,10 +65,6 @@ healthbot {
             field message-out-of-order {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/message-out-of-order;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Out of order messages error count";
@@ -104,10 +72,6 @@ healthbot {
             field out-path-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/counters/out-path-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Out of path error count";
@@ -115,10 +79,6 @@ healthbot {
             field out-reservation-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/counters/out-reservation-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Out reservation error count";
@@ -126,10 +86,6 @@ healthbot {
             field received-nack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/received-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Received no acknowledgement error count";
@@ -137,10 +93,6 @@ healthbot {
             field recv-pkt-disabled-intf {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/recv-pkt-disabled-intf;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Received packet disable error count";
@@ -148,10 +100,6 @@ healthbot {
             field send-failure {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/send-failure;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Send failure error count";
@@ -159,10 +107,6 @@ healthbot {
             field state-timeout {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/state-timeout;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "State timeout error count";
@@ -178,10 +122,6 @@ healthbot {
             field unknown-ack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/unknown-ack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Unknown acknowledgement error count";
@@ -189,10 +129,6 @@ healthbot {
             field unknown-nack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/interface-attributes/interface/state/error-counters/unknown-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Unknown no acknowledgement error count";


### PR DESCRIPTION
Removed zero-suppression from "routing.mpls/check-te-rsvp-interface-errors" rule