### PR TITLE
Adding back zero-suppression in the rule

### DIFF
--- a/juniper_official/chassis/check-system-power-usage-temp-state.rule
+++ b/juniper_official/chassis/check-system-power-usage-temp-state.rule
@@ -85,6 +85,7 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'power-system-maximum'";
                     path /components/component/properties/property/state/value;
+                    zero-suppression;					
                 }
                 type integer;
                 description "System max power available";
@@ -93,6 +94,7 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'power-system-remaining'";
                     path /components/component/properties/property/state/value;
+                    zero-suppression;					
                 }
                 type integer;
                 description "System remaining power";


### PR DESCRIPTION
Adding back zero-suppression in the "hardware.chassis/check-system-power-usage-temp-state" rule.