### PR TITLE
Updated rule properties in "check-isis-adjacency-status" for VMX

### DIFF
--- a/juniper_official/routing/check-isis-adjacency-status.rule
+++ b/juniper_official/routing/check-isis-adjacency-status.rule
@@ -150,6 +150,12 @@
                                     releases 23.2R1 {
                                         release-support min-supported-release;
                                     }
+                                }
+                                platforms vmx {
+                                    releases 23.2R1 {
+                                        sensors isis-oc-junos;									
+                                        release-support min-supported-release;
+                                    }
                                 }								
                             }
                         }

--- a/juniper_official/routing/check-isis-adjacency-status.rule
+++ b/juniper_official/routing/check-isis-adjacency-status.rule
@@ -139,6 +139,7 @@
                     sensors isis-oc;
                     juniper {
                         operating-system junos {
+                            sensors isis-oc-junos;						
                             products MX {
                                 sensors isis-oc-junos;
                                 platforms MX304 {
@@ -151,12 +152,6 @@
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms vmx {
-                                    releases 23.2R1 {
-                                        sensors isis-oc-junos;									
-                                        release-support min-supported-release;
-                                    }
-                                }								
                             }
                         }
                         operating-system junosEvolved {


### PR DESCRIPTION
Updated rule properties for "routing.isis/check-isis-adjacency-status" to include "isis-oc-junos" as default ingest for VMX.