### PR TITLE
Added rule properties for PTX10008

### DIFF
--- a/juniper_official/chassis/check-routing-engine-temperature.rule
+++ b/juniper_official/chassis/check-routing-engine-temperature.rule
@@ -324,6 +324,14 @@ healthbot {
                                     }
                                 }
                             }
+                            products PTX {
+                                sensors components-oc-junos;
+                                platforms PTX10008 {
+                                    releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                         }							
                         operating-system junos {							
                             products MX {

--- a/juniper_official/chassis/check-routing-engine-temperature.rule
+++ b/juniper_official/chassis/check-routing-engine-temperature.rule
@@ -1,5 +1,5 @@
 /*
- * Monitors routing-engine temperature and notifies when anomalies are found
+ * Monitors routing-engine temperature and notifies when anomalies are found.
  * 
  * Three inputs control detection
  *


### PR DESCRIPTION
Added rule properties for  PTX10008 in "hardware.chassis/check-routing-engine-temperature" rule.