### PR TITLE
Updated no-errors term in ospf-io-stats rule

### DIFF
--- a/juniper_official/routing/OspfIoStatsTable.yml
+++ b/juniper_official/routing/OspfIoStatsTable.yml
@@ -8,7 +8,7 @@ OspfIoStatsTable:
 ospfioview:
   fields:
     packets-read: packets-read
-    ospf-error: ospf-errors/*
+    ospf-error: ospf-errors/no-interface-error
 
 xslt: "<xsl:stylesheet version=\"1.0\"
  xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"

--- a/juniper_official/routing/check-ospf-io-statistics.rule
+++ b/juniper_official/routing/check-ospf-io-statistics.rule
@@ -17,6 +17,9 @@
             field ospf-error {
                 sensor ospf-io-statistics-netconf {
                     path ospf-error;
+                    data-if-missing {
+                        value 0;
+                    }					
                 }
                 type integer;
                 description "Ospf IO error count";
@@ -56,6 +59,20 @@
                         status {
                             color green;
                             message "OSPF IO error ($ospf-error)is not increasing";
+                        }
+                    }
+                }
+                /*
+                 * Sets color to green when there are no ospf-errors.
+                 */				
+                term no-error {
+                    when {
+                        equal-to "$ospf-error" 0;
+                    }
+                    then {
+                        status {
+                            color green;
+                            message "OSPF IO errors are not present";
                         }
                     }
                 }				
@@ -143,6 +160,13 @@
                                     }
                                 }
                             }
+                            products PTX {
+                                platforms PTX10008 {
+                                    releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                         }						
                     }
                 }

--- a/juniper_official/routing/check-ospf-io-statistics.rule
+++ b/juniper_official/routing/check-ospf-io-statistics.rule
@@ -137,6 +137,13 @@
                                     }
                                 }
                             }
+                            products VMX {
+                                platforms VMX {
+                                    releases 23.2R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                         }
                         operating-system junosEvolved {
                             products ACX {

--- a/juniper_official/routing/check-ospf-io-statistics.rule
+++ b/juniper_official/routing/check-ospf-io-statistics.rule
@@ -94,6 +94,7 @@
                 supported-healthbot-version 1.0.1;
                 supported-devices {
                     juniper {
+                        sensors ospf-io-statistics-netconf;					
                         operating-system junos {
                             products ACX {
                                 platforms All {

--- a/juniper_official/routing/check-ospf-io-statistics.rule
+++ b/juniper_official/routing/check-ospf-io-statistics.rule
@@ -63,20 +63,6 @@
                     }
                 }
                 /*
-                 * Sets color to green when there are no ospf-errors.
-                 */				
-                term no-error {
-                    when {
-                        equal-to "$ospf-error" 0;
-                    }
-                    then {
-                        status {
-                            color green;
-                            message "OSPF IO errors are not present";
-                        }
-                    }
-                }				
-                /*
                  * Sets color to red and sends out an anomaly notification
                  * when the ospf error count increases by 1.
                  */


### PR DESCRIPTION
Updated no-errors term in "routing.ospf/check-ospf-io-statistics" rule.