### PR TITLE
Reverted zero-suppression for mx304 in "hardware.system/check-system-cpu-memory" rule

### DIFF
--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -43,14 +43,6 @@ healthbot {
                     frequency 60s;
                 }
             }
-            sensor components-oc-mx {
-                synopsis "system cpu and memory KPI";
-                description "/components open-config sensor to collect telemetry data from MX network device";
-                open-config {
-                    sensor-name /components/component;
-                    frequency 60s;
-                }
-            }			
             /*
              * Fields defined using sensor path. Map the longer sensor names
              * to the shorter field names used in the rules.
@@ -61,10 +53,6 @@ healthbot {
                     path /components/component/properties/property/state/value;
                     zero-suppression;
                 }
-                sensor components-oc-mx {
-                    where "/components/component/properties/property/@name == 'cpu-utilization-total'";
-                    path /components/component/properties/property/state/value;
-                }				
                 type float;
                 description "Collects RE CPU utilization";
             }
@@ -97,11 +85,6 @@ healthbot {
                     path /components/component/properties/property/state/value;
                     zero-suppression;
                 }
-                sensor components-oc-mx {
-                    where "/components/component/properties/property/@name == 'memory-utilization-buffer'";
-                    path /components/component/properties/property/state/value;
-                    zero-suppression;
-                }				
                 type integer;
                 description "RE system memory buffer value";
             }
@@ -133,10 +116,6 @@ healthbot {
                     where "/components/component/@name =~ /^Routing Engine[{{re-slot-no}}]$|^RE[{{re-slot-no}}]$/";
                     path "/components/component/@name";
                 }
-                sensor components-oc-mx {
-                    where "/components/component/@name =~ /^Routing Engine[{{re-slot-no}}]$|^RE[{{re-slot-no}}]$/";
-                    path "/components/component/@name";
-                }				
                 description "RE name to monitor";
             }
             /*
@@ -351,7 +330,7 @@ healthbot {
                         }
                         operating-system junos {							
                             products MX {
-                                sensors components-oc-mx;
+                                sensors components-oc;
                                 platforms MX204 {
                                     releases 22.2R3 {
                                         release-support min-supported-release;


### PR DESCRIPTION
Reverted changes in https://github.com/Juniper/healthbot-rules/pull/862/