### PR TITLE
Updated rsvp global errors rule

### DIFF
--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -13,6 +13,12 @@
                     frequency 60s;
                 }
             }
+            sensor lsp-updated {
+                open-config {
+                    sensor-name /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state;
+                    frequency 60s;
+                }
+            }			
             field authentication-fail {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
@@ -21,6 +27,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Authentication fail error count";
             }
@@ -32,6 +45,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-checksum;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad checksum error count";
             }
@@ -43,6 +63,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-format;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet format error count";
             }
@@ -54,6 +81,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-length;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet length error count";
             }
@@ -65,6 +99,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-version;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet version error count";
             }
@@ -76,6 +117,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-path-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "In path messages error count";
             }
@@ -87,6 +135,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-reservation-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "In reservation messages error count";
             }
@@ -94,6 +149,9 @@
                 sensor lsp {
                     path "/network-instances/network-instance/@instance-name";
                 }
+                sensor lsp-updated {
+                    path "/network-instances/network-instance/@name";
+                }				
                 type string;
                 description "Instance name to monitor";
             }
@@ -105,6 +163,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/message-out-of-order;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out of order messages error count";
             }
@@ -116,6 +181,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-path-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out of path error count";
             }
@@ -127,6 +199,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-reservation-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out reservation error count";
             }
@@ -138,6 +217,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/received-nack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Received no acknowledgement error count";
             }
@@ -149,6 +235,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/recv-pkt-disabled-intf;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Received packet disable error count";
             }
@@ -160,6 +253,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/send-failure;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Send failure error count";
             }
@@ -171,6 +271,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/state-timeout;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "State timeout error count";
             }
@@ -182,6 +289,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-ack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Unknown acknowledgement error count";
             }
@@ -193,6 +307,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-nack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Unknown no acknowledgement error count";
             }
@@ -456,7 +577,9 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+						    sensors lsp;
                             products MX {
+							    sensors lsp;
                                 platforms MX2010 {
                                     releases 17.4R1 {
                                         release-support min-supported-release;
@@ -482,6 +605,24 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms MX10004 {
+                                    releases 24.1 {
+									    sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX10008 {
+                                    releases 24.1 {
+									    sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX10016 {
+                                    releases 24.1 {
+									    sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }								
                             }
                             products PTX {
                                 platforms PTX1000 {

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -687,21 +687,21 @@ healthbot {
                                 }
                                 platforms MX10004 {
 								    sensors lsp-updated;
-                                    releases 24.1 {
+                                    releases 22.3R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
 								    sensors lsp-updated;
-                                    releases 24.1 {
+                                    releases 22.3R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
 								    sensors lsp-updated;
-                                    releases 24.1 {
+                                    releases 22.3R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -686,21 +686,21 @@ healthbot {
                                     }
                                 }
                                 platforms MX10004 {
-								    sensor lsp-updated;
+								    sensors lsp-updated;
                                     releases 24.1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
-								    sensor lsp-updated;
+								    sensors lsp-updated;
                                     releases 24.1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
-								    sensor lsp-updated;
+								    sensors lsp-updated;
                                     releases 24.1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
@@ -708,7 +708,7 @@ healthbot {
                                 }								
                             }
                             products JNP {
-                                sensor lsp-updated;
+                                sensors lsp-updated;
                                 platforms JNP10004 {
                                     releases 22.3R1 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -281,42 +281,6 @@
                 type integer;
                 description "State timeout error count";
             }
-            field unknown-ack {
-                sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-ack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }
-                sensor lsp-updated {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-ack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }				
-                type integer;
-                description "Unknown acknowledgement error count";
-            }
-            field unknown-nack {
-                sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }
-                sensor lsp-updated {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }				
-                type integer;
-                description "Unknown no acknowledgement error count";
-            }
             field error-threshold {
                 constant {
                     value "{{error-threshold}}";
@@ -327,7 +291,7 @@
             /*
              * Anomaly detection logic to detect rsvp-te global errors.
              */
-            trigger rsvp-te-global-errors {
+            trigger authentication-fail {
                 frequency 1offset;
                 term is-authentication-fail {
                     when {
@@ -340,11 +304,22 @@
                     then {
                         status {
                             color red;
-                            message "Authentication failure error count($authentication-fail)increasing";
+                            message "Authentication failure error count($authentication-fail) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-authentication-fail-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global authentication-fail error count ($authentication-fail) is normal";
+                        }
+                    }
+                }
+            }
+            trigger bad-checksum {
+                frequency 1offset;			
                 term is-bad-checksum {
                     when {
                         increasing-at-least-by-value "$bad-checksum" {
@@ -356,11 +331,22 @@
                     then {
                         status {
                             color red;
-                            message "Bad checksum error count($bad-checksum)increasing";
+                            message "Bad checksum error count($bad-checksum) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-bad-checksum-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global bad-checksum error count($bad-checksum) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger bad-packet-format {
+                frequency 1offset;				
                 term is-bad-packet-format {
                     when {
                         increasing-at-least-by-value "$bad-packet-format" {
@@ -372,11 +358,22 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet format error count($bad-packet-format)increasing";
+                            message "Bad packet format error count($bad-packet-format) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-bad-packet-format-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global bad-packet-format error count ($bad-packet-format) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger bad-packet-length {
+                frequency 1offset;				
                 term is-bad-packet-length {
                     when {
                         increasing-at-least-by-value "$bad-packet-length" {
@@ -388,11 +385,21 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet length error count($bad-packet-length)increasing";
+                            message "Bad packet length error count($bad-packet-length) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-bad-packet-length-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global bad-packet-length error count ($bad-packet-length) is normal";
+                        }
+                    }
+                }				
+            trigger bad-packet-version {
+                frequency 1offset;				
                 term is-bad-packet-version {
                     when {
                         increasing-at-least-by-value "$bad-packet-version" {
@@ -404,11 +411,21 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet version error count($bad-packet-version)increasing";
+                            message "Bad packet version error count($bad-packet-version) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-bad-packet-version-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global bad-packet-version error count ($bad-packet-version) is normal";
+                        }
+                    }
+                }				
+            trigger in-path-error-messages {
+                frequency 1offset;				
                 term is-in-path-error-messages {
                     when {
                         increasing-at-least-by-value "$in-path-error-messages" {
@@ -420,11 +437,22 @@
                     then {
                         status {
                             color red;
-                            message "In path error messages count($in-path-error-messages)increasing";
+                            message "In path error messages count($in-path-error-messages) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-in-path-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global in-path-error-messages error count ($in-path-error-messages) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger in-reservation-error-messages {
+                frequency 1offset;				
                 term in-reservation-error-messages {
                     when {
                         increasing-at-least-by-value "$in-reservation-error-messages" {
@@ -436,11 +464,22 @@
                     then {
                         status {
                             color red;
-                            message "In reservation error messages count($in-reservation-error-messages)increasing";
+                            message "In reservation error messages count($in-reservation-error-messages) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-in-reservation-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global in-reservation-error-messages error count ($in-reservation-error-messages) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger message-out-of-order {
+                frequency 1offset;				
                 term is-message-out-of-order {
                     when {
                         increasing-at-least-by-value "$message-out-of-order" {
@@ -452,11 +491,22 @@
                     then {
                         status {
                             color red;
-                            message "Message out of order error count($message-out-of-order)increasing";
+                            message "Message out of order error count($message-out-of-order) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-message-out-of-order-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global message-out-of-order error ($message-out-of-order) count is normal";
+                        }
+                    }
+                }
+            }				
+            trigger out-path-error-messages {
+                frequency 1offset;				
                 term out-path-error-messages {
                     when {
                         increasing-at-least-by-value "$out-path-error-messages" {
@@ -468,11 +518,22 @@
                     then {
                         status {
                             color red;
-                            message "Out path error messages count($out-path-error-messages)increasing";
+                            message "Out path error messages count($out-path-error-messages) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-out-path-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global out-path-error-messages error count ($out-path-error-messages) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger out-reservation-error-messages {
+                frequency 1offset;				
                 term out-reservation-error-messages {
                     when {
                         increasing-at-least-by-value "$out-reservation-error-messages" {
@@ -484,27 +545,22 @@
                     then {
                         status {
                             color red;
-                            message "Out reservation error messages count($out-reservation-error-messages)increasing";
+                            message "Out reservation error messages count($out-reservation-error-messages) is increasing";
                         }
                         next;
                     }
                 }
-                term is-received-nack {
-                    when {
-                        increasing-at-least-by-value "$received-nack" {
-                            value "$error-threshold";
-                            time-range 2.5offset;
-                            latest;
-                        }
-                    }
+                term no-rsvp-te-global-out-reservation-error-messages-errors {
                     then {
                         status {
-                            color red;
-                            message "Received nack error count($received-nack)increasing";
+                            color green;
+                            message "RSVP TE global out-reservation-error-messages error count ($out-reservation-error-messages) is normal";
                         }
-                        next;
                     }
                 }
+            }				
+            trigger recv-pkt-disabled-intf {
+                frequency 1offset;				
                 term recv-pkt-disabled-intf {
                     when {
                         increasing-at-least-by-value "$recv-pkt-disabled-intf" {
@@ -516,11 +572,22 @@
                     then {
                         status {
                             color red;
-                            message "Recv-pkt-disabled-intf error count($recv-pkt-disabled-intf)increasing";
+                            message "Recv-pkt-disabled-intf error count($recv-pkt-disabled-intf) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-recv-pkt-disabled-intf-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global recv-pkt-disabled-intf error count ($recv-pkt-disabled-intf) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger send-failure {
+                frequency 1offset;				
                 term send-failure {
                     when {
                         increasing-at-least-by-value "$send-failure" {
@@ -532,11 +599,22 @@
                     then {
                         status {
                             color red;
-                            message "Send failure error count($send-failure)increasing";
+                            message "Send failure error count($send-failure) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-send-failure-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global send-failure error count ($send-failure) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger state-timeout {
+                frequency 1offset;				
                 term is-state-timeout {
                     when {
                         increasing-at-least-by-value "$state-timeout" {
@@ -548,15 +626,15 @@
                     then {
                         status {
                             color red;
-                            message "State timeout error count($state-timeout)increasing";
+                            message "State timeout error count($state-timeout) is increasing";
                         }
                     }
                 }
-                term no-rsvp-te-global-errors {
+                term no-rsvp-te-global-state-timeout-errors {
                     then {
                         status {
                             color green;
-                            message "RSVP TE global error count is normal";
+                            message "RSVP TE global state-timeout error count ($state-timeout) is normal";
                         }
                     }
                 }
@@ -606,24 +684,45 @@
                                     }
                                 }
                                 platforms MX10004 {
+								    sensor lsp-updated;
                                     releases 24.1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
+								    sensor lsp-updated;
                                     releases 24.1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
+								    sensor lsp-updated;
                                     releases 24.1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }								
                             }
+                            products JNP {
+                                sensors lsp-updated;
+                                platforms JNP10004 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10008 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10016 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                             products PTX {
                                 platforms PTX1000 {
                                     releases 17.4R1 {
@@ -656,12 +755,21 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
+							    sensors lsp-updated;
                                 platforms All {
                                     releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                             }
+                            products PTX {
+                                sensors lsp-updated;
+                                platforms PTX10008 {
+                                    releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                         }						
                     }
                 }

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -577,9 +577,9 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
-						    sensors lsp;
+                            sensors lsp;
                             products MX {
-							    sensors lsp;
+                                sensors lsp;
                                 platforms MX2010 {
                                     releases 17.4R1 {
                                         release-support min-supported-release;
@@ -607,19 +607,19 @@
                                 }
                                 platforms MX10004 {
                                     releases 24.1 {
-									    sensors lsp-updated;
+                                        sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
                                     releases 24.1 {
-									    sensors lsp-updated;
+                                        sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
                                     releases 24.1 {
-									    sensors lsp-updated;
+                                        sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -708,7 +708,7 @@ healthbot {
                                 }								
                             }
                             products JNP {
-                                sensors lsp-updated;
+                                sensor lsp-updated;
                                 platforms JNP10004 {
                                     releases 22.3R1 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -423,7 +423,8 @@
                             message "RSVP TE global bad-packet-version error count ($bad-packet-version) is normal";
                         }
                     }
-                }				
+                }
+            }				
             trigger in-path-error-messages {
                 frequency 1offset;				
                 term is-in-path-error-messages {

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -1,7 +1,7 @@
 /*
  * Detects rsvp-te global errors and notifies anomalies.
  */
- healthbot {
+healthbot {
     topic routing.mpls {
         rule check-te-rsvp-global-errors {
             keys instance-name;

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -397,7 +397,8 @@
                             message "RSVP TE global bad-packet-length error count ($bad-packet-length) is normal";
                         }
                     }
-                }				
+                }
+            }				
             trigger bad-packet-version {
                 frequency 1offset;				
                 term is-bad-packet-version {
@@ -424,7 +425,7 @@
                         }
                     }
                 }
-            }				
+            }
             trigger in-path-error-messages {
                 frequency 1offset;				
                 term is-in-path-error-messages {
@@ -451,7 +452,7 @@
                         }
                     }
                 }
-            }				
+            }
             trigger in-reservation-error-messages {
                 frequency 1offset;				
                 term in-reservation-error-messages {
@@ -478,7 +479,7 @@
                         }
                     }
                 }
-            }				
+            }
             trigger message-out-of-order {
                 frequency 1offset;				
                 term is-message-out-of-order {
@@ -505,7 +506,7 @@
                         }
                     }
                 }
-            }				
+            }
             trigger out-path-error-messages {
                 frequency 1offset;				
                 term out-path-error-messages {
@@ -532,7 +533,7 @@
                         }
                     }
                 }
-            }				
+            }
             trigger out-reservation-error-messages {
                 frequency 1offset;				
                 term out-reservation-error-messages {
@@ -559,7 +560,7 @@
                         }
                     }
                 }
-            }				
+            }
             trigger recv-pkt-disabled-intf {
                 frequency 1offset;				
                 term recv-pkt-disabled-intf {
@@ -586,7 +587,7 @@
                         }
                     }
                 }
-            }				
+            }
             trigger send-failure {
                 frequency 1offset;				
                 term send-failure {
@@ -613,7 +614,7 @@
                         }
                     }
                 }
-            }				
+            }
             trigger state-timeout {
                 frequency 1offset;				
                 term is-state-timeout {


### PR DESCRIPTION
Added sensor precedence to "routing.mpls/check-te-rsvp-global-errors" rule.