### PR TITLE
Updated rule properties for system cpu memory rule

### DIFF
--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -344,6 +344,13 @@ healthbot {
                                     }
                                 }								
                             }
+                            products PTX {
+                                platforms PTX10008 {
+                                    releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                         }
                         operating-system junos {
                             sensors components-oc;						
@@ -359,6 +366,21 @@ healthbot {
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms MX10004 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX10008 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX10016 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
                             }
                             products JNP {
                                 sensors components-oc;


### PR DESCRIPTION
Added MX10K and PTX rule properties in "hardware.system/check-system-cpu-memory" rule.