### PR TITLE
Changed instance sensor path for BGP Received Routes rule

### DIFF
--- a/juniper_official/Protocols/Bgp/bgp-received-routes-kpi.rule
+++ b/juniper_official/Protocols/Bgp/bgp-received-routes-kpi.rule
@@ -57,8 +57,8 @@ healthbot {
              */
             field instance-name {
                 sensor bgp-sensor {
-                    where "/network-instances/network-instance/@instance-name =~ /{{routing-instance}}/";
-                    path "/network-instances/network-instance/@instance-name";
+                    where "/network-instances/network-instance/@name =~ /{{routing-instance}}/";
+                    path "/network-instances/network-instance/@name";
                 }
                 type string;
                 description "Routing instance to find neighbor's parent instance";
@@ -289,6 +289,15 @@ healthbot {
                                 }								
                             }
                         }
+                        operating-system junosEvolved {
+                            products ACX {
+                                   platforms ACX7100 {
+                                    releases 22.4R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }						
                     }
                     other-vendor cisco-IOS-XR {
                         vendor-name cisco;


### PR DESCRIPTION
Changed instance sensor path for "protocol.bgp/check-bgp-received-routes" rule.