### PR TITLE
Updated sensor preced to support instance-name change

### DIFF
--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -800,21 +800,21 @@ healthbot {
                                     }
                                 }
                                 platforms MX10004 {
-								    sensors lsp-updated;
+                                    sensors lsp-updated;
                                     releases 22.3R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
-								    sensors lsp-updated;
+                                    sensors lsp-updated;
                                     releases 22.3R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
-								    sensors lsp-updated;
+                                    sensors lsp-updated;
                                     releases 22.3R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
@@ -871,7 +871,7 @@ healthbot {
                         }
                         operating-system junosEvolved {
                             products ACX {
-							    sensors lsp-updated;
+                                sensors lsp-updated;
                                 platforms All {
                                     releases 22.3R1 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -1,7 +1,7 @@
 /*
  * Detects rsvp-te global errors and notifies anomalies.
  */
- healthbot {
+healthbot {
     topic routing.mpls {
         rule check-te-rsvp-global-errors {
             keys instance-name;
@@ -9,10 +9,16 @@
             description "Collects RSVP TE global error statistics periodically and notifies when error count increases";
             sensor lsp {
                 open-config {
-                    sensor-name /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state;
+                    sensor-name /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/;
                     frequency 60s;
                 }
             }
+            sensor lsp-updated {
+                open-config {
+                    sensor-name /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/;
+                    frequency 60s;
+                }
+            }			
             field authentication-fail {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
@@ -21,6 +27,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Authentication fail error count";
             }
@@ -32,6 +45,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-checksum;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad checksum error count";
             }
@@ -43,6 +63,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-format;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet format error count";
             }
@@ -54,6 +81,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-length;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet length error count";
             }
@@ -65,6 +99,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-version;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet version error count";
             }
@@ -76,6 +117,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-path-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "In path messages error count";
             }
@@ -87,6 +135,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-reservation-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "In reservation messages error count";
             }
@@ -94,6 +149,9 @@
                 sensor lsp {
                     path "/network-instances/network-instance/@instance-name";
                 }
+                sensor lsp-updated {
+                    path "/network-instances/network-instance/@name";
+                }				
                 type string;
                 description "Instance name to monitor";
             }
@@ -105,6 +163,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/message-out-of-order;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out of order messages error count";
             }
@@ -116,6 +181,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-path-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out of path error count";
             }
@@ -127,6 +199,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-reservation-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out reservation error count";
             }
@@ -138,6 +217,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/received-nack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Received no acknowledgement error count";
             }
@@ -149,6 +235,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/recv-pkt-disabled-intf;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Received packet disable error count";
             }
@@ -160,6 +253,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/send-failure;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Send failure error count";
             }
@@ -171,8 +271,22 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/state-timeout;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "State timeout error count";
+            }
+            field error-threshold {
+                constant {
+                    value "{{error-threshold}}";
+                }
+                type integer;
+                description "Packet error threshold";
             }
             field unknown-ack {
                 sensor lsp {
@@ -182,6 +296,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-ack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Unknown acknowledgement error count";
             }
@@ -193,20 +314,20 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-nack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Unknown no acknowledgement error count";
-            }
-            field error-threshold {
-                constant {
-                    value "{{error-threshold}}";
-                }
-                type integer;
-                description "Packet error threshold";
             }			
             /*
              * Anomaly detection logic to detect rsvp-te global errors.
              */
-            trigger rsvp-te-global-errors {
+            trigger authentication-fail {
                 frequency 1offset;
                 term is-authentication-fail {
                     when {
@@ -219,11 +340,22 @@
                     then {
                         status {
                             color red;
-                            message "Authentication failure error count($authentication-fail)increasing";
+                            message "Authentication failure error count($authentication-fail) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-authentication-fail-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global authentication-fail error count ($authentication-fail) is normal";
+                        }
+                    }
+                }
+            }
+            trigger bad-checksum {
+                frequency 1offset;			
                 term is-bad-checksum {
                     when {
                         increasing-at-least-by-value "$bad-checksum" {
@@ -235,11 +367,22 @@
                     then {
                         status {
                             color red;
-                            message "Bad checksum error count($bad-checksum)increasing";
+                            message "Bad checksum error count($bad-checksum) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-bad-checksum-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global bad-checksum error count($bad-checksum) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger bad-packet-format {
+                frequency 1offset;				
                 term is-bad-packet-format {
                     when {
                         increasing-at-least-by-value "$bad-packet-format" {
@@ -251,11 +394,22 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet format error count($bad-packet-format)increasing";
+                            message "Bad packet format error count($bad-packet-format) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-bad-packet-format-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global bad-packet-format error count ($bad-packet-format) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger bad-packet-length {
+                frequency 1offset;				
                 term is-bad-packet-length {
                     when {
                         increasing-at-least-by-value "$bad-packet-length" {
@@ -267,11 +421,22 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet length error count($bad-packet-length)increasing";
+                            message "Bad packet length error count($bad-packet-length) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-bad-packet-length-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global bad-packet-length error count ($bad-packet-length) is normal";
+                        }
+                    }
+                }
+            }				
+            trigger bad-packet-version {
+                frequency 1offset;				
                 term is-bad-packet-version {
                     when {
                         increasing-at-least-by-value "$bad-packet-version" {
@@ -283,11 +448,22 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet version error count($bad-packet-version)increasing";
+                            message "Bad packet version error count($bad-packet-version) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-bad-packet-version-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global bad-packet-version error count ($bad-packet-version) is normal";
+                        }
+                    }
+                }
+            }
+            trigger in-path-error-messages {
+                frequency 1offset;				
                 term is-in-path-error-messages {
                     when {
                         increasing-at-least-by-value "$in-path-error-messages" {
@@ -299,11 +475,22 @@
                     then {
                         status {
                             color red;
-                            message "In path error messages count($in-path-error-messages)increasing";
+                            message "In path error messages count($in-path-error-messages) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-in-path-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global in-path-error-messages error count ($in-path-error-messages) is normal";
+                        }
+                    }
+                }
+            }
+            trigger in-reservation-error-messages {
+                frequency 1offset;				
                 term in-reservation-error-messages {
                     when {
                         increasing-at-least-by-value "$in-reservation-error-messages" {
@@ -315,11 +502,22 @@
                     then {
                         status {
                             color red;
-                            message "In reservation error messages count($in-reservation-error-messages)increasing";
+                            message "In reservation error messages count($in-reservation-error-messages) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-in-reservation-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global in-reservation-error-messages error count ($in-reservation-error-messages) is normal";
+                        }
+                    }
+                }
+            }
+            trigger message-out-of-order {
+                frequency 1offset;				
                 term is-message-out-of-order {
                     when {
                         increasing-at-least-by-value "$message-out-of-order" {
@@ -331,11 +529,22 @@
                     then {
                         status {
                             color red;
-                            message "Message out of order error count($message-out-of-order)increasing";
+                            message "Message out of order error count($message-out-of-order) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-message-out-of-order-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global message-out-of-order error ($message-out-of-order) count is normal";
+                        }
+                    }
+                }
+            }
+            trigger out-path-error-messages {
+                frequency 1offset;				
                 term out-path-error-messages {
                     when {
                         increasing-at-least-by-value "$out-path-error-messages" {
@@ -347,11 +556,22 @@
                     then {
                         status {
                             color red;
-                            message "Out path error messages count($out-path-error-messages)increasing";
+                            message "Out path error messages count($out-path-error-messages) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-out-path-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global out-path-error-messages error count ($out-path-error-messages) is normal";
+                        }
+                    }
+                }
+            }
+            trigger out-reservation-error-messages {
+                frequency 1offset;				
                 term out-reservation-error-messages {
                     when {
                         increasing-at-least-by-value "$out-reservation-error-messages" {
@@ -363,27 +583,22 @@
                     then {
                         status {
                             color red;
-                            message "Out reservation error messages count($out-reservation-error-messages)increasing";
+                            message "Out reservation error messages count($out-reservation-error-messages) is increasing";
                         }
                         next;
                     }
                 }
-                term is-received-nack {
-                    when {
-                        increasing-at-least-by-value "$received-nack" {
-                            value "$error-threshold";
-                            time-range 2.5offset;
-                            latest;
-                        }
-                    }
+                term no-rsvp-te-global-out-reservation-error-messages-errors {
                     then {
                         status {
-                            color red;
-                            message "Received nack error count($received-nack)increasing";
+                            color green;
+                            message "RSVP TE global out-reservation-error-messages error count ($out-reservation-error-messages) is normal";
                         }
-                        next;
                     }
                 }
+            }
+            trigger recv-pkt-disabled-intf {
+                frequency 1offset;				
                 term recv-pkt-disabled-intf {
                     when {
                         increasing-at-least-by-value "$recv-pkt-disabled-intf" {
@@ -395,11 +610,22 @@
                     then {
                         status {
                             color red;
-                            message "Recv-pkt-disabled-intf error count($recv-pkt-disabled-intf)increasing";
+                            message "Recv-pkt-disabled-intf error count($recv-pkt-disabled-intf) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-recv-pkt-disabled-intf-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global recv-pkt-disabled-intf error count ($recv-pkt-disabled-intf) is normal";
+                        }
+                    }
+                }
+            }
+            trigger send-failure {
+                frequency 1offset;				
                 term send-failure {
                     when {
                         increasing-at-least-by-value "$send-failure" {
@@ -411,11 +637,22 @@
                     then {
                         status {
                             color red;
-                            message "Send failure error count($send-failure)increasing";
+                            message "Send failure error count($send-failure) is increasing";
                         }
                         next;
                     }
                 }
+                term no-rsvp-te-global-send-failure-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global send-failure error count ($send-failure) is normal";
+                        }
+                    }
+                }
+            }
+            trigger state-timeout {
+                frequency 1offset;				
                 term is-state-timeout {
                     when {
                         increasing-at-least-by-value "$state-timeout" {
@@ -427,19 +664,97 @@
                     then {
                         status {
                             color red;
-                            message "State timeout error count($state-timeout)increasing";
+                            message "State timeout error count($state-timeout) is increasing";
                         }
                     }
                 }
-                term no-rsvp-te-global-errors {
+                term no-rsvp-te-global-state-timeout-errors {
                     then {
                         status {
                             color green;
-                            message "RSVP TE global error count is normal";
+                            message "RSVP TE global state-timeout error count ($state-timeout) is normal";
                         }
                     }
                 }
             }
+            trigger received-nack {
+                frequency 1offset;				
+                term is-received-nack {
+                    when {
+                        increasing-at-least-by-value "$received-nack" {
+                            value "$error-threshold";
+                            time-range 2.5offset;
+                            latest;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "RSVP TE global received-nack error count($received-nack) is increasing";
+                        }
+                    }
+                }
+                term no-rsvp-te-global-received-nack-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global received-nack error count ($received-nack) is normal";
+                        }
+                    }
+                }
+            }
+            trigger unknown-ack {
+                frequency 1offset;				
+                term is-unknown-ack {
+                    when {
+                        increasing-at-least-by-value "$unknown-ack" {
+                            value "$error-threshold";
+                            time-range 2.5offset;
+                            latest;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "RSVP TE global unknown-ack error count($unknown-ack) is increasing";
+                        }
+                    }
+                }
+                term no-rsvp-te-global-unknown-ack-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global unknown-ack error count ($unknown-ack) is normal";
+                        }
+                    }
+                }
+            }
+            trigger unknown-nack {
+                frequency 1offset;				
+                term is-unknown-nack {
+                    when {
+                        increasing-at-least-by-value "$unknown-nack" {
+                            value "$error-threshold";
+                            time-range 2.5offset;
+                            latest;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "RSVP TE global unknown-nack error count($unknown-nack) is increasing";
+                        }
+                    }
+                }
+                term no-rsvp-te-global-unknown-nack-errors {
+                    then {
+                        status {
+                            color green;
+                            message "RSVP TE global unknown-nack error count ($unknown-nack) is normal";
+                        }
+                    }
+                }
+            }			
             variable error-threshold {
                 value 1;
                 type int;
@@ -456,7 +771,9 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors lsp;
                             products MX {
+                                sensors lsp;
                                 platforms MX2010 {
                                     releases 17.4R1 {
                                         release-support min-supported-release;
@@ -482,7 +799,46 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms MX10004 {
+								    sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX10008 {
+								    sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX10016 {
+								    sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }								
                             }
+                            products JNP {
+                                sensors lsp-updated;
+                                platforms JNP10004 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10008 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10016 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                             products PTX {
                                 platforms PTX1000 {
                                     releases 17.4R1 {
@@ -515,12 +871,21 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
+							    sensors lsp-updated;
                                 platforms All {
                                     releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                             }
+                            products PTX {
+                                sensors lsp-updated;
+                                platforms PTX10008 {
+                                    releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                         }						
                     }
                 }


### PR DESCRIPTION
Added ingest to "routing.mpls/check-te-rsvp-global-errors" rule.