### PR TITLE
Added acx7024x in rule properties for ISIS Adjacency rule

### DIFF
--- a/juniper_official/routing/check-isis-adjacency-status.rule
+++ b/juniper_official/routing/check-isis-adjacency-status.rule
@@ -196,6 +196,16 @@
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
+                                }
+                                platforms ACX7024X {
+                                    releases 23.2R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 22.3R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
                                 }								
                             }
                             products PTX {


### PR DESCRIPTION
Added acx7024x in rule properties for "routing.isis/check-isis-adjacency-status" rule.