### PR TITLE
Added enum to link-state and admins-state fields

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -67,8 +67,8 @@ healthbot {
                 type string;
                 description "Interface admin status";
                 enumerate __default__ as -1;
-                enumerate down as 0;
-                enumerate up as 1;				
+                enumerate DOWN as 0;
+                enumerate UP as 1;				
             }
             field flaps {
                 sensor interfaces-oc {
@@ -149,8 +149,8 @@ healthbot {
                 type string;
                 description "Interfaces link operational status";
                 enumerate __default__ as -1;
-                enumerate down as 0;
-                enumerate up as 1;				
+                enumerate DOWN as 0;
+                enumerate UP as 1;				
             }
             field low-threshold {
                 constant {

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -66,6 +66,9 @@ healthbot {
                 }
                 type string;
                 description "Interface admin status";
+                enumerate __default__ as -1;
+                enumerate false as 0;
+                enumerate true as 1;				
             }
             field flaps {
                 sensor interfaces-oc {
@@ -145,6 +148,9 @@ healthbot {
                 }
                 type string;
                 description "Interfaces link operational status";
+                enumerate __default__ as -1;
+                enumerate false as 0;
+                enumerate true as 1;				
             }
             field low-threshold {
                 constant {

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -67,8 +67,8 @@ healthbot {
                 type string;
                 description "Interface admin status";
                 enumerate __default__ as -1;
-                enumerate false as 0;
-                enumerate true as 1;				
+                enumerate down as 0;
+                enumerate up as 1;				
             }
             field flaps {
                 sensor interfaces-oc {
@@ -149,8 +149,8 @@ healthbot {
                 type string;
                 description "Interfaces link operational status";
                 enumerate __default__ as -1;
-                enumerate false as 0;
-                enumerate true as 1;				
+                enumerate down as 0;
+                enumerate up as 1;				
             }
             field low-threshold {
                 constant {


### PR DESCRIPTION
Added enum to "link-state" and "admin-state" fields in "interfaces/check-interface-in-out-errors-traffic-state-flaps" rule.