### PR TITLE
rsvp-te-global-errors-instance-name-change

### DIFF
--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -879,10 +879,10 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
-                                sensors lsp;						
+                                sensors lsp;			
 			                    platforms ACX7024 {
                                     releases 20.1R1 {
-                                        sensors lsp-updated;									
+                                        sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -906,7 +906,7 @@
                                 }
 			                    platforms ACX7509 {
                                     releases 20.1R1 {
-                                        sensors lsp-updated;				
+                                        sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -915,12 +915,12 @@
                                 sensors lsp;
                                 platforms PTX10008 {
                                     releases 20.1R1 {
-                                        sensors lsp-updated;				
+                                        sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }						
-                        }					
+                            }				
+                        }				
                     }
                 }
             }

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -880,31 +880,31 @@
                         operating-system junosEvolved {
                             products ACX {
                                 sensors lsp;			
-			                    platforms ACX7024 {
+                                platforms ACX7024 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
-			                    platforms ACX7100 {
+                                platforms ACX7100 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
-			                    platforms ACX7348 {
+                                platforms ACX7348 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
-			                    platforms ACX7024X {
+                                platforms ACX7024X {
                                     releases 20.1R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
-			                    platforms ACX7509 {
+                                platforms ACX7509 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -328,6 +328,7 @@
              * Anomaly detection logic to detect rsvp-te global errors.
              */
             trigger rsvp-te-authentication-fail-errors {
+                alert-type routing.rsvp.errors.rsvp-te-authentication-fail-errors;			
                 frequency 1offset;
                 term is-authentication-fail {
                     when {
@@ -354,6 +355,7 @@
                 }
             }
             trigger rsvp-te-bad-checksum-errors {
+                alert-type routing.rsvp.errors.rsvp-te-bad-checksum-errors;			
                 frequency 1offset;			
                 term is-bad-checksum {
                     when {
@@ -380,6 +382,7 @@
                 }
             }
             trigger rsvp-te-bad-packet-format-errors {
+                alert-type routing.rsvp.errors.rsvp-te-bad-packet-format-errors;			
                 frequency 1offset;			
                 term is-bad-packet-format {
                     when {
@@ -406,6 +409,7 @@
                 }
             }				
             trigger rsvp-te-bad-packet-length-errors {
+                alert-type routing.rsvp.errors.rsvp-te-bad-packet-length-errors;			
                 frequency 1offset;				
                 term is-bad-packet-length {
                     when {
@@ -432,6 +436,7 @@
                 }
             }				
             trigger rsvp-te-bad-packet-version-errors {
+                alert-type routing.rsvp.errors.rsvp-te-bad-packet-version-errors;			
                 frequency 1offset;				
                 term is-bad-packet-version {
                     when {
@@ -458,6 +463,7 @@
                 }
             }				
             trigger rsvp-te-in-path-error-messages-errors {
+                alert-type routing.rsvp.errors.rsvp-te-in-path-error-messages-errors;			
                 frequency 1offset;				
                 term is-in-path-error-messages {
                     when {
@@ -484,6 +490,7 @@
                 }
             }				
             trigger rsvp-te-in-reservation-error-messages-errors {
+                alert-type routing.rsvp.errors.rsvp-te-in-reservation-error-messages-errors;			
                 frequency 1offset;				
                 term in-reservation-error-messages {
                     when {
@@ -510,6 +517,7 @@
                 }
             }				
             trigger rsvp-te-message-out-of-order-errors {
+                alert-type routing.rsvp.errors.rsvp-te-message-out-of-order-errors;			
                 frequency 1offset;				
                 term is-message-out-of-order {
                     when {
@@ -536,6 +544,7 @@
                 }
             }				
             trigger rsvp-te-out-path-error-messages-errors {
+                alert-type routing.rsvp.errors.rsvp-te-out-path-error-messages-errors;			
                 frequency 1offset;				
                 term out-path-error-messages {
                     when {
@@ -562,6 +571,7 @@
                 }
             }				
             trigger rsvp-te-out-reservation-error-messages-errors {
+                alert-type routing.rsvp.errors.rsvp-te-out-reservation-error-messages-errors;			
                 frequency 1offset;				
                 term out-reservation-error-messages {
                     when {
@@ -588,6 +598,7 @@
                 }
             }				
             trigger rsvp-te-received-nack-errors {
+                alert-type routing.rsvp.errors.rsvp-te-received-nack-errors;			
                 frequency 1offset;				
                 term is-received-nack {
                     when {
@@ -614,6 +625,7 @@
                 }
             }				
             trigger rsvp-te-recv-pkt-disabled-intf-errors {
+                alert-type routing.rsvp.errors.rsvp-te-recv-pkt-disabled-intf-errors;			
                 frequency 1offset;				
                 term recv-pkt-disabled-intf {
                     when {
@@ -640,6 +652,7 @@
                 }
             }				
             trigger rsvp-te-send-failure-errors {
+                alert-type routing.rsvp.errors.rsvp-te-send-failure-errors;			
                 frequency 1offset;				
                 term send-failure {
                     when {
@@ -666,6 +679,7 @@
                 }
             }				
             trigger rsvp-te-state-timeout-errors {
+                alert-type routing.rsvp.errors.rsvp-te-state-timeout-errors;			
                 frequency 1offset;				
                 term is-state-timeout {
                     when {
@@ -692,6 +706,7 @@
                 }
             }
             trigger rsvp-te-unknown-ack-errors {
+                alert-type routing.rsvp.errors.rsvp-te-unknown-ack-errors;			
                 frequency 1offset;				
                 term is-unknown-ack {
                     when {
@@ -718,6 +733,7 @@
                 }
             }
             trigger rsvp-te-unknown-nack-errors {
+                alert-type routing.rsvp.errors.rsvp-te-unknown-nack-errors;			
                 frequency 1offset;				
                 term is-unknown-nack {
                     when {
@@ -761,42 +777,23 @@
                         operating-system junos {
                                 products MX {
                                 sensors lsp;							
-                                platforms MX2010 {
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms MX2020 {
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
                                 platforms MX240 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;				
                                         release-support min-supported-release;
                                     }								
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
                                 }
                                 platforms MX480 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;				
                                         release-support min-supported-release;
                                     }								
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
                                 }
                                 platforms MX960 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;				
                                         release-support min-supported-release;
                                     }								
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
                                 }
                                 platforms MX304 {
                                     releases 20.1R1 {
@@ -850,32 +847,6 @@
                                     }
                                 }								
                             }							
-                            products PTX {
-                                sensors lsp;                                
-								platforms PTX1000 {
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms PTX5000 {
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                            }
-                            products QFX {
-                                sensors lsp;							
-                                platforms QFX10000 {
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms QFX5200 {
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                            }
                         }
                         operating-system junosEvolved {
                             products ACX {

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -759,8 +759,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
-                            sensors lsp;                            						
-                            products MX {
+                                products MX {
                                 sensors lsp;							
                                 platforms MX2010 {
                                     releases 17.4R1 {
@@ -788,47 +787,48 @@
                                     }
                                 }
                                 platforms MX10004 {
-                                    sensors lsp-updated;
-                                    releases 22.3R1 {
-                                        sensors lsp-updated;
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;									
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
-                                    sensors lsp-updated;
-                                    releases 22.3R1 {
-                                        sensors lsp-updated;
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;									
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
-                                    sensors lsp-updated;
-                                    releases 22.3R1 {
-                                        sensors lsp-updated;
+                                     releases 20.1R1 {
+                                        sensors lsp-updated;									
                                         release-support min-supported-release;
                                     }
                                 }								
                             }
                             products JNP {
-                                sensors lsp-updated;
+                                sensors lsp;							
                                 platforms JNP10004 {
-                                    releases 22.3R1 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;									
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms JNP10008 {
-                                    releases 22.3R1 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;									
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms JNP10016 {
-                                    releases 22.3R1 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;									
                                         release-support min-supported-release;
                                     }
                                 }								
                             }							
                             products PTX {
-                                platforms PTX1000 {
+                                sensors lsp;                                
+								platforms PTX1000 {
                                     releases 17.4R1 {
                                         release-support min-supported-release;
                                     }
@@ -845,6 +845,7 @@
                                 }
                             }
                             products QFX {
+                                sensors lsp;							
                                 platforms QFX10000 {
                                     releases 17.4R1 {
                                         release-support min-supported-release;
@@ -859,17 +860,19 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
-                                sensors lsp-updated;							
-                                platforms All {
-                                    releases 22.3R1 {
+                                sensors lsp;     							
+			                    platforms All {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;									
                                         release-support min-supported-release;
-                                    }
+                                    }									
                                 }
                             }
                             products PTX {
-                                sensors lsp-updated;
+                                sensors lsp;
                                 platforms PTX10008 {
-                                    releases 22.2R3 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;									
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -772,17 +772,41 @@
                                     }
                                 }
                                 platforms MX240 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;				
+                                        release-support min-supported-release;
+                                    }								
                                     releases 17.4R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;				
+                                        release-support min-supported-release;
+                                    }								
                                     releases 17.4R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;				
+                                        release-support min-supported-release;
+                                    }								
                                     releases 17.4R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX304 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;				
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX204 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -856,9 +880,33 @@
                         operating-system junosEvolved {
                             products ACX {
                                 sensors lsp;						
-			                    platforms All {
+			                    platforms ACX7024 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;									
+                                        release-support min-supported-release;
+                                    }
+                                }
+			                    platforms ACX7100 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+			                    platforms ACX7348 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+			                    platforms ACX7024X {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+			                    platforms ACX7509 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;				
                                         release-support min-supported-release;
                                     }
                                 }
@@ -867,12 +915,12 @@
                                 sensors lsp;
                                 platforms PTX10008 {
                                     releases 20.1R1 {
-                                        sensors lsp-updated;									
+                                        sensors lsp-updated;				
                                         release-support min-supported-release;
                                     }
-                                }								
-                            }							
-                        }						
+                                }
+                            }						
+                        }					
                     }
                 }
             }

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -833,11 +833,6 @@
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms PTX10000 {
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
                                 platforms PTX5000 {
                                     releases 17.4R1 {
                                         release-support min-supported-release;
@@ -860,12 +855,12 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
-                                sensors lsp;     							
+                                sensors lsp;						
 			                    platforms All {
                                     releases 20.1R1 {
                                         sensors lsp-updated;									
                                         release-support min-supported-release;
-                                    }									
+                                    }
                                 }
                             }
                             products PTX {

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -775,7 +775,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
-                                products MX {
+                            products MX {
                                 sensors lsp;							
                                 platforms MX240 {
                                     releases 20.1R1 {
@@ -869,6 +869,12 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms ACX7332 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }								
                                 platforms ACX7024X {
                                     releases 20.1R1 {
                                         sensors lsp-updated;
@@ -884,12 +890,30 @@
                             }
                             products PTX {
                                 sensors lsp;
+                                platforms PTX10001 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10004 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
                                 platforms PTX10008 {
                                     releases 20.1R1 {
                                         sensors lsp-updated;
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms PTX10016 {
+                                    releases 20.1R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }								
                             }				
                         }				
                     }

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -13,6 +13,12 @@
                     frequency 60s;
                 }
             }
+            sensor lsp-updated {
+                open-config {
+                    sensor-name /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state;
+                    frequency 60s;
+                }
+            }			
             field authentication-fail {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
@@ -21,6 +27,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Authentication fail error count";
             }
@@ -32,6 +45,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-checksum;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad checksum error count";
             }
@@ -43,6 +63,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-format;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet format error count";
             }
@@ -54,6 +81,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-length;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet length error count";
             }
@@ -65,6 +99,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-version;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Bad packet version error count";
             }
@@ -76,6 +117,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-path-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "In path messages error count";
             }
@@ -87,6 +135,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-reservation-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "In reservation messages error count";
             }
@@ -94,6 +149,9 @@
                 sensor lsp {
                     path "/network-instances/network-instance/@instance-name";
                 }
+                sensor lsp-updated {
+                    path "/network-instances/network-instance/@name";
+                }				
                 type string;
                 description "Instance name to monitor";
             }
@@ -105,6 +163,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/message-out-of-order;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out of order messages error count";
             }
@@ -116,6 +181,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-path-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out of path error count";
             }
@@ -127,6 +199,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-reservation-error-messages;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Out reservation error count";
             }
@@ -138,6 +217,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/received-nack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Received no acknowledgement error count";
             }
@@ -149,6 +235,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/recv-pkt-disabled-intf;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Received packet disable error count";
             }
@@ -160,6 +253,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/send-failure;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Send failure error count";
             }
@@ -171,6 +271,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/state-timeout;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "State timeout error count";
             }
@@ -182,6 +289,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-ack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Unknown acknowledgement error count";
             }
@@ -193,6 +307,13 @@
                         value 0;
                     }
                 }
+                sensor lsp-updated {
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-nack;
+                    zero-suppression;
+                    data-if-missing {
+                        value 0;
+                    }
+                }				
                 type integer;
                 description "Unknown no acknowledgement error count";
             }
@@ -206,7 +327,7 @@
             /*
              * Anomaly detection logic to detect rsvp-te global errors.
              */
-            trigger rsvp-te-global-errors {
+            trigger rsvp-te-authentication-fail-errors {
                 frequency 1offset;
                 term is-authentication-fail {
                     when {
@@ -219,11 +340,21 @@
                     then {
                         status {
                             color red;
-                            message "Authentication failure error count($authentication-fail)increasing";
+                            message "Authentication failure error count($authentication-fail) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-authentication-fail-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($authentication-fail) is not increasing";
+                        }
+                    }
+                }
+            }
+            trigger rsvp-te-bad-checksum-errors {
+                frequency 1offset;			
                 term is-bad-checksum {
                     when {
                         increasing-at-least-by-value "$bad-checksum" {
@@ -235,11 +366,21 @@
                     then {
                         status {
                             color red;
-                            message "Bad checksum error count($bad-checksum)increasing";
+                            message "Bad checksum error count($bad-checksum) is increasing";
                         }
-                        next;
+                     }
+                }
+                term no-rsvp-te-bad-checksum-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($bad-checksum) is not increasing";
+                        }
                     }
                 }
+            }
+            trigger rsvp-te-bad-packet-format-errors {
+                frequency 1offset;			
                 term is-bad-packet-format {
                     when {
                         increasing-at-least-by-value "$bad-packet-format" {
@@ -251,11 +392,21 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet format error count($bad-packet-format)increasing";
+                            message "Bad packet format error count($bad-packet-format) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-bad-packet-format-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($bad-packet-format) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-bad-packet-length-errors {
+                frequency 1offset;				
                 term is-bad-packet-length {
                     when {
                         increasing-at-least-by-value "$bad-packet-length" {
@@ -267,11 +418,21 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet length error count($bad-packet-length)increasing";
+                            message "Bad packet length error count($bad-packet-length) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-bad-packet-length-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($bad-packet-length) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-bad-packet-version-errors {
+                frequency 1offset;				
                 term is-bad-packet-version {
                     when {
                         increasing-at-least-by-value "$bad-packet-version" {
@@ -283,11 +444,21 @@
                     then {
                         status {
                             color red;
-                            message "Bad packet version error count($bad-packet-version)increasing";
+                            message "Bad packet version error count($bad-packet-version) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-bad-packet-version-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($bad-packet-version) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-in-path-error-messages-errors {
+                frequency 1offset;				
                 term is-in-path-error-messages {
                     when {
                         increasing-at-least-by-value "$in-path-error-messages" {
@@ -299,11 +470,21 @@
                     then {
                         status {
                             color red;
-                            message "In path error messages count($in-path-error-messages)increasing";
+                            message "In path error messages count($in-path-error-messages) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-in-path-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($in-path-error-messages) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-in-reservation-error-messages-errors {
+                frequency 1offset;				
                 term in-reservation-error-messages {
                     when {
                         increasing-at-least-by-value "$in-reservation-error-messages" {
@@ -315,11 +496,21 @@
                     then {
                         status {
                             color red;
-                            message "In reservation error messages count($in-reservation-error-messages)increasing";
+                            message "In reservation error messages count($in-reservation-error-messages) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-in-reservation-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($in-reservation-error-messages) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-message-out-of-order-errors {
+                frequency 1offset;				
                 term is-message-out-of-order {
                     when {
                         increasing-at-least-by-value "$message-out-of-order" {
@@ -331,11 +522,21 @@
                     then {
                         status {
                             color red;
-                            message "Message out of order error count($message-out-of-order)increasing";
+                            message "Message out of order error count($message-out-of-order) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-message-out-of-order-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($message-out-of-order) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-out-path-error-messages-errors {
+                frequency 1offset;				
                 term out-path-error-messages {
                     when {
                         increasing-at-least-by-value "$out-path-error-messages" {
@@ -347,11 +548,21 @@
                     then {
                         status {
                             color red;
-                            message "Out path error messages count($out-path-error-messages)increasing";
+                            message "Out path error messages count($out-path-error-messages) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-out-path-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($out-path-error-messages) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-out-reservation-error-messages-errors {
+                frequency 1offset;				
                 term out-reservation-error-messages {
                     when {
                         increasing-at-least-by-value "$out-reservation-error-messages" {
@@ -363,11 +574,21 @@
                     then {
                         status {
                             color red;
-                            message "Out reservation error messages count($out-reservation-error-messages)increasing";
+                            message "Out reservation error messages count($out-reservation-error-messages) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-out-reservation-error-messages-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($out-reservation-error-messages) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-received-nack-errors {
+                frequency 1offset;				
                 term is-received-nack {
                     when {
                         increasing-at-least-by-value "$received-nack" {
@@ -379,11 +600,21 @@
                     then {
                         status {
                             color red;
-                            message "Received nack error count($received-nack)increasing";
+                            message "Received nack error count($received-nack) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-received-nack-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($received-nack) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-recv-pkt-disabled-intf-errors {
+                frequency 1offset;				
                 term recv-pkt-disabled-intf {
                     when {
                         increasing-at-least-by-value "$recv-pkt-disabled-intf" {
@@ -395,11 +626,21 @@
                     then {
                         status {
                             color red;
-                            message "Recv-pkt-disabled-intf error count($recv-pkt-disabled-intf)increasing";
+                            message "Recv-pkt-disabled-intf error count($recv-pkt-disabled-intf) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-recv-pkt-disabled-intf-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($recv-pkt-disabled-intf) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-send-failure-errors {
+                frequency 1offset;				
                 term send-failure {
                     when {
                         increasing-at-least-by-value "$send-failure" {
@@ -411,11 +652,21 @@
                     then {
                         status {
                             color red;
-                            message "Send failure error count($send-failure)increasing";
+                            message "Send failure error count($send-failure) is increasing";
                         }
-                        next;
                     }
                 }
+                term no-rsvp-te-send-failure-errors {
+                    then {
+                        status {
+                            color green;
+                            message "Authentication failure error count($send-failure) is not increasing";
+                        }
+                    }
+                }
+            }				
+            trigger rsvp-te-state-timeout-errors {
+                frequency 1offset;				
                 term is-state-timeout {
                     when {
                         increasing-at-least-by-value "$state-timeout" {
@@ -427,19 +678,71 @@
                     then {
                         status {
                             color red;
-                            message "State timeout error count($state-timeout)increasing";
+                            message "State timeout error count($state-timeout) is increasing";
                         }
                     }
                 }
-                term no-rsvp-te-global-errors {
+                term no-rsvp-te-state-timeout-errors {
                     then {
                         status {
                             color green;
-                            message "RSVP TE global error count is normal";
+                            message "State timeout error count($state-timeout) is not increasing";
                         }
                     }
                 }
             }
+            trigger rsvp-te-unknown-ack-errors {
+                frequency 1offset;				
+                term is-unknown-ack {
+                    when {
+                        increasing-at-least-by-value "$unknown-ack" {
+                            value "$error-threshold";
+                            time-range 2.5offset;
+                            latest;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "State timeout error count($unknown-ack) is increasing";
+                        }
+                    }
+                }
+                term no-rsvp-te-unknown-ack-errors {
+                    then {
+                        status {
+                            color green;
+                            message "State timeout error count($unknown-ack) is not increasing";
+                        }
+                    }
+                }
+            }
+            trigger rsvp-te-unknown-nack-errors {
+                frequency 1offset;				
+                term is-unknown-nack {
+                    when {
+                        increasing-at-least-by-value "$unknown-nack" {
+                            value "$error-threshold";
+                            time-range 2.5offset;
+                            latest;
+                        }
+                    }
+                    then {
+                        status {
+                            color red;
+                            message "State timeout error count($unknown-nack) is increasing";
+                        }
+                    }
+                }
+                term no-rsvp-te-unknown-nack-errors {
+                    then {
+                        status {
+                            color green;
+                            message "State timeout error count($unknown-nack) not increasing";
+                        }
+                    }
+                }
+            }			
             variable error-threshold {
                 value 1;
                 type int;
@@ -456,7 +759,9 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors lsp;                            						
                             products MX {
+                                sensors lsp;							
                                 platforms MX2010 {
                                     releases 17.4R1 {
                                         release-support min-supported-release;
@@ -482,7 +787,46 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms MX10004 {
+                                    sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX10008 {
+                                    sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX10016 {
+                                    sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp-updated;
+                                        release-support min-supported-release;
+                                    }
+                                }								
                             }
+                            products JNP {
+                                sensors lsp-updated;
+                                platforms JNP10004 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10008 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10016 {
+                                    releases 22.3R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                             products PTX {
                                 platforms PTX1000 {
                                     releases 17.4R1 {
@@ -515,12 +859,21 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
+                                sensors lsp-updated;							
                                 platforms All {
                                     releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                             }
+                            products PTX {
+                                sensors lsp-updated;
+                                platforms PTX10008 {
+                                    releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                         }						
                     }
                 }


### PR DESCRIPTION
Added Ingest to support instance name path from "/network-instances/network-instance/@instance-name" to "/network-instances/network-instance/@name".