### PR TITLE
Added acx7509 in rule properties for psm-power rule

### DIFF
--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -372,6 +372,12 @@ healthbot {
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms AX7509 {
+                                    sensors components-oc-ptx;								
+                                    releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }								
                             }
                             products PTX {
                                 sensors components-oc-ptx;


### PR DESCRIPTION
Added acx7509 in rule properties for "hardware.chassis/check-psm-power-usage-state" rule.