### PR TITLE
Added enum to fan-state field in hardware.chassis/check-fan-state-rpm rule

### DIFF
--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -97,8 +97,8 @@ healthbot {
                 }
                 type string;
                 description "Status of the fan";
-                enumerate __default__ as -1;
-                enumerate Failed as 0;
+                enumerate __default__ as -99;
+                enumerate Failed as -1;
                 enumerate Absent as 0;				
                 enumerate ok as 1;				
             }

--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -97,6 +97,10 @@ healthbot {
                 }
                 type string;
                 description "Status of the fan";
+                enumerate __default__ as -1;
+                enumerate Failed as 0;
+                enumerate Absent as 0;				
+                enumerate ok as 1;				
             }
             field high-threshold {
                 constant {


### PR DESCRIPTION
Added enum to field "status" in "hardware.chassis/check-fan-state-rpm" rule.