### PR TITLE
Updated alert type in triggers for fan,psm,re and system rules

### DIFF
--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -156,6 +156,7 @@ healthbot {
              * Anomaly detection logic
              */			
             trigger fan-state {
+                alert-type hardware.state.fan.fan-state;
                 synopsis "Fan State KPI";
                 description "Sets health based on Fan state";			
                 frequency 1offset;
@@ -195,6 +196,7 @@ healthbot {
                 }
             }
             trigger rpm-percent {
+                alert-type hardware.rpm.fan.fan-state;
                 synopsis "Fan RPM KPI";
                 description "Sets health based on Fan RPM percentage";			
                 frequency 1offset;

--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -196,7 +196,7 @@ healthbot {
                 }
             }
             trigger rpm-percent {
-                alert-type hardware.rpm.fan.fan-state;
+                alert-type hardware.rpm.fan.rpm-percent;
                 synopsis "Fan RPM KPI";
                 description "Sets health based on Fan RPM percentage";			
                 frequency 1offset;

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -183,6 +183,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger psm-power-usage {
+                alert-type hardware.power.psm.usage.psm-power-usage;
                 synopsis "PSM power usage KPI";
                 description "Sets health based on increasing psm power usage";
                 frequency 1offset;
@@ -237,6 +238,7 @@ healthbot {
                 }
             }
             trigger psm-state {
+                alert-type hardware.state.psm.psm-state;			
                 synopsis "PSM State KPI";
                 description "Sets health based on PSM state";
                 frequency 1offset;
@@ -277,6 +279,7 @@ healthbot {
                 }
             }
             trigger psm-temperature {
+                alert-type hardware.temperature.psm.psm-temperature;
                 frequency 1offset;
                 /*
                  * Sets color to green when psm-temperature is lesser than psm-temperature-low-threshold

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -183,7 +183,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger psm-power-usage {
-                alert-type hardware.power.psm.usage.psm-power-usage;
+                alert-type hardware.power.psm.psm-power-usage;
                 synopsis "PSM power usage KPI";
                 description "Sets health based on increasing psm power usage";
                 frequency 1offset;

--- a/juniper_official/chassis/check-routing-engine-temperature.rule
+++ b/juniper_official/chassis/check-routing-engine-temperature.rule
@@ -124,6 +124,7 @@ healthbot {
              * Anomaly detection logic.
              */
             trigger routing-engine-temperature {
+                alert-type hardware.temperature.routing_engine.routing-engine-temperature;			
                 synopsis "RE temperature KPI";
                 description "Sets health based increase in RE temperature";
                 frequency 1offset;
@@ -206,6 +207,7 @@ healthbot {
                 }
             }
             trigger routing-engine-cpu-temperature {
+                alert-type hardware.temperature.routing_engine.cpu.routing-engine-cpu-temperature;			
                 synopsis "RE CPU temperature KPI";
                 description "Sets health based increase in RE CPU temperature";
                 frequency 1offset;

--- a/juniper_official/chassis/check-system-power-usage-temp-state.rule
+++ b/juniper_official/chassis/check-system-power-usage-temp-state.rule
@@ -119,6 +119,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger chassis-temperature {
+                alert-type hardware.temperature.chassis.chassis-temperature;
                 synopsis "Chassis Temperature KPI";
                 description "Sets health based on Chassis Temperature";			
                 frequency 1offset;
@@ -170,6 +171,7 @@ healthbot {
                 }
             }
             trigger system-power-usage {
+                alert-type hardware.power.system.system-power-usage;
                 synopsis "System power usage KPI";
                 description "Sets health based on increasing system power usage";
                 frequency 1offset;


### PR DESCRIPTION
Alert type were added for the below rules :

hardware.chassis/check-fan-state-rpm
hardware.chassis/check-psm-power-usage-state
hardware.chassis/check-routing-engine-temperature
hardware.chassis/check-system-power-usage-temp-state