### PR TITLE
Updated alert type in triggers for interfaces rules

### DIFF
--- a/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
+++ b/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
@@ -99,6 +99,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger fec-corrected-errors {
+                alert-type interfaces.fec_corrected_errors.fec-corrected-errors;			
                 frequency 1offset;
                 /*
                  * Sets color to green when the fec-corrected-errors count is not increasing
@@ -137,6 +138,7 @@ healthbot {
                 }
             }
             trigger fec-uncorrected-errors {
+                alert-type interfaces.fec_uncorrected_errors.fec-uncorrected-errors;
                 frequency 1offset;
                 /*
                  * Sets color to green when the fec-uncorrected-errors count is not increasing
@@ -175,6 +177,7 @@ healthbot {
                 }				
             }
             trigger framing-errors {
+                alert-type interfaces.rx_errors.framing.framing-errors;
                 frequency 1offset;
                 /*
                  * Defaults color to green.

--- a/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
+++ b/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
@@ -99,7 +99,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger fec-corrected-errors {
-                alert-type interfaces.errors.fec_corrected.fec-corrected-errors;			
+                alert-type interfaces.errors.fec-corrected-errors;			
                 frequency 1offset;
                 /*
                  * Sets color to green when the fec-corrected-errors count is not increasing
@@ -138,7 +138,7 @@ healthbot {
                 }
             }
             trigger fec-uncorrected-errors {
-                alert-type interfaces.errors.fec_uncorrected.fec-uncorrected-errors;
+                alert-type interfaces.errors.fec-uncorrected-errors;
                 frequency 1offset;
                 /*
                  * Sets color to green when the fec-uncorrected-errors count is not increasing
@@ -177,7 +177,7 @@ healthbot {
                 }				
             }
             trigger framing-errors {
-                alert-type interfaces.rx_errors.framing.framing-errors;
+                alert-type interfaces.rx_errors.framing-errors;
                 frequency 1offset;
                 /*
                  * Defaults color to green.

--- a/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
+++ b/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
@@ -99,7 +99,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger fec-corrected-errors {
-                alert-type interfaces.fec_corrected_errors.fec-corrected-errors;			
+                alert-type interfaces.errors.fec_corrected.fec-corrected-errors;			
                 frequency 1offset;
                 /*
                  * Sets color to green when the fec-corrected-errors count is not increasing
@@ -138,7 +138,7 @@ healthbot {
                 }
             }
             trigger fec-uncorrected-errors {
-                alert-type interfaces.fec_uncorrected_errors.fec-uncorrected-errors;
+                alert-type interfaces.errors.fec_uncorrected.fec-uncorrected-errors;
                 frequency 1offset;
                 /*
                  * Sets color to green when the fec-uncorrected-errors count is not increasing

--- a/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
+++ b/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
@@ -216,6 +216,7 @@ healthbot {
                 }
             }
             trigger input-crc-errors {
+                alert-type interfaces.rx_errors.crc.input-crc-errors;
                 frequency 1offset;
                 /*
                  * Sets color to green when the input-crc-errors count is not increasing
@@ -254,6 +255,7 @@ healthbot {
                 }
             }
             trigger output-crc-errors {
+                alert-type interfaces.tx_errors.crc.output-crc-errors;
                 frequency 1offset;
                 /*
                  * Sets color to green when the output-crc-errors count is not increasing

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -265,7 +265,7 @@ healthbot {
                 }				
             }    
             trigger interface-input-errors {
-                alert-type interfaces.rx_errors.input.interface-input-errors;
+                alert-type interfaces.rx_errors.interface-input-errors;
                 synopsis "Interface input-errors kpi";
                 description "Sets health based on the change in input-errors count";
                 frequency 1offset;
@@ -386,7 +386,7 @@ healthbot {
                 }				
             }
             trigger interface-output-errors {
-                alert-type interfaces.tx_errors.output.interface-output-errors;
+                alert-type interfaces.tx_errors.interface-output-errors;
                 synopsis "Interface output-errors kpi";
                 description "Sets health based on the change in output-errors count";
                 frequency 1offset;

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -212,6 +212,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger interface-input-traffic {
+                alert-type interfaces.rx.traffic.interface-input-traffic;
                 synopsis "Interface input traffic kpi";
                 description "Sets health based on input traffic exceed threshold";
                 frequency 1offset;
@@ -264,6 +265,7 @@ healthbot {
                 }				
             }    
             trigger interface-input-errors {
+                alert-type interfaces.rx_errors.input.interface-input-errors;
                 synopsis "Interface input-errors kpi";
                 description "Sets health based on the change in input-errors count";
                 frequency 1offset;
@@ -306,6 +308,7 @@ healthbot {
                 }			
             }
             trigger interface-link-flaps {
+                alert-type interfaces.link_flaps.interface-link-flaps;
                 synopsis "Link flaps KPI";
                 description "Sets health based on the change in flap count";
                 frequency 1offset;
@@ -346,6 +349,7 @@ healthbot {
                 }		
             }
             trigger interface-link-state {
+                alert-type interfaces.link_failure.interface-link-state;
                 synopsis "link state kpi";
                 description "Sets health based on link state";
                 frequency 1offset;
@@ -382,6 +386,7 @@ healthbot {
                 }				
             }
             trigger interface-output-errors {
+                alert-type interfaces.tx_errors.output.interface-output-errors;
                 synopsis "Interface output-errors kpi";
                 description "Sets health based on the change in output-errors count";
                 frequency 1offset;
@@ -424,6 +429,7 @@ healthbot {
                 }			
             }
             trigger interface-output-traffic {
+                alert-type interfaces.tx.traffic.interface-output-traffic;
                 synopsis "Interface output traffic kpi";
                 description "Sets health based on output traffic exceed threshold";
                 frequency 1offset;

--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -223,6 +223,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger uncorrected-forward-error-correction-errors {
+                alert-type interfaces.optical.error.uncorrected-forward-error-correction-errors;
                 synopsis "Uncorrected forward error correction errors KPI";
                 description "Sets health based on Uncorrected forward error correction errors";			
                 frequency 1offset;
@@ -256,6 +257,7 @@ healthbot {
     }
             }
             trigger interface-rx-loss-of-signal-functionality {
+                alert-type interfaces.rx.los.interface-rx-loss-of-signal-functionality;
                 synopsis "Interface rx loss of signal functionality KPI";
                 description "Sets health based on Interface rx loss of signal functionality";			
                 frequency 1offset;
@@ -291,6 +293,7 @@ healthbot {
                 }
             }
             trigger interface-tx-laser-disabled-alarm {
+                alert-type interfaces.tx.laser_disabled_alarm.interface-tx-laser-disabled-alarm;
                 synopsis "Interface tx laser disabled alarm KPI";
                 description "Sets health based on Interface tx laser disabled alarm";			
                 frequency 1offset;
@@ -326,6 +329,7 @@ healthbot {
                 }
             }
             trigger interface-tx-loss-of-signal-functionality {
+                alert-type interfaces.tx.los.interface-tx-loss-of-signal-functionality;
                 synopsis "Interface tx loss of signal functionality KPI";
                 description "Sets health based on Interface tx loss of signal functionality";			
                 frequency 1offset;
@@ -361,6 +365,7 @@ healthbot {
                 }
             }
             trigger interface-optical-rx-power {
+                alert-type interfaces.rx.power.interface-optical-rx-power;
                 synopsis "Interface optical rx high power KPI";
                 description "Sets health based on Interface optical rx high power";
                 frequency 1offset;
@@ -442,6 +447,7 @@ healthbot {
                 }
             }
             trigger interface-optical-tx-power {
+                alert-type interfaces.tx.power.interface-optical-tx-power;
                 synopsis "Interface optical tx high power KPI";
                 description "Sets health based on Interface optical tx high power";
                 frequency 1offset;

--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -223,7 +223,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger uncorrected-forward-error-correction-errors {
-                alert-type interfaces.optical.error.uncorrected-forward-error-correction-errors;
+                alert-type interfaces.optical.errors.uncorrected-forward-error-correction-errors;
                 synopsis "Uncorrected forward error correction errors KPI";
                 description "Sets health based on Uncorrected forward error correction errors";			
                 frequency 1offset;

--- a/juniper_official/interface/check-optical-temp-thresholds.rule
+++ b/juniper_official/interface/check-optical-temp-thresholds.rule
@@ -66,6 +66,7 @@ healthbot {
              * Anomaly detection logic.
              */			
             trigger interface-optical-temperature {
+                alert-type interfaces.temperature.interface-optical-temperature;
                 synopsis "high optical temperature";
                 description "Sets health based on the optical temperature";
                 frequency 1offset;


### PR DESCRIPTION
Updated alert type for below rules :

interfaces/check-interface-fec-crc-framing-errors
interfaces/check-optical-signal-loss-fec-tx-rx-power
interfaces/check-optical-temp-thresholds
interfaces/check-interface-in-out-errors-traffic-state-flaps