### PR TITLE
Updated alert type for FPC and System rules

### DIFF
--- a/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
+++ b/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
@@ -204,6 +204,7 @@ healthbot {
              * Anomaly detection logic
              */			
             trigger fpc-buffer-memory-utilization {
+                alert-type hardware.memory.fpc.buffer.fpc-buffer-memory-utilization;
                 synopsis "FPC buffer memory utilization KPI";
                 description "Sets health based on increase in fpc buffer memory utilization";
                 frequency 1offset;
@@ -266,6 +267,7 @@ healthbot {
                 }
             }
             trigger fpc-cpu-utilization {
+                alert-type hardware.cpu.fpc.fpc-cpu-utilization;
                 synopsis "FPC CPU utilization KPI";
                 description "Sets health based on increase in FPC CPU utilization";
                 frequency 1offset;
@@ -328,6 +330,7 @@ healthbot {
                 }
             }
             trigger fpc-heap-memory-utilization {
+                alert-type hardware.memory.fpc.heap.fpc-heap-memory-utilization;
                 synopsis "FPC heap memory utilization KPI";
                 description "Sets health based on increase in fpc heap memory utilization";
                 frequency 1offset;
@@ -375,6 +378,7 @@ healthbot {
                 }
             }
             trigger fpc-state {
+                alert-type hardware.state.fpc.fpc-state;
                 synopsis "FPC State kpi";
                 description "Sets health based on FPC State";			
                 frequency 1offset;
@@ -412,6 +416,7 @@ healthbot {
                 }
             }
             trigger fpc-temperature {
+                alert-type hardware.temperature.fpc.fpc-temperature;
                 synopsis "FPC Temperature kpi";
                 description "Sets health based on FPC Temperature";
                 frequency 1offset;

--- a/juniper_official/linecard/check-pfe-discards.rule
+++ b/juniper_official/linecard/check-pfe-discards.rule
@@ -514,7 +514,7 @@ healthbot {
                 }
             }
             trigger pfe-stack-underflow-discard {
-                alert-type hardware.fpc.pfe.pfe-stack-overflow-discard;			
+                alert-type hardware.fpc.pfe.pfe-stack-underflow-discard;			
                 synopsis "PFE stack underflow discards KPI";
                 description "Sets health based on the change in PFE stack underflow discard count";
                 frequency 1offset;
@@ -553,7 +553,7 @@ healthbot {
                 }
             }
             trigger pfe-tcp-header-error-discard {
-                alert-type hardware.fpc.pfe.pfe-stack-overflow-discard;			
+                alert-type hardware.fpc.pfe.pfe-tcp-header-error-discard;			
                 synopsis "PFE TCP header error discards KPI";
                 description "Sets health based on the change in PFE TCP header error discard count";
                 frequency 1offset;

--- a/juniper_official/linecard/check-pfe-discards.rule
+++ b/juniper_official/linecard/check-pfe-discards.rule
@@ -202,6 +202,7 @@ healthbot {
             * Anomaly detection logic.
             */			
             trigger pfe-data-error-discard {
+                alert-type hardware.fpc.pfe.pfe-data-error-discard;
                 synopsis "PFE data error discards KPI";
                 description "Sets health based on the change in PFE data error discard count";
                 frequency 1offset;
@@ -240,6 +241,7 @@ healthbot {
                 }
             }
             trigger pfe-bad-route-discard {
+                alert-type hardware.fpc.pfe.pfe-bad-route-discard;			
                 synopsis "PFE bad route discards KPI";
                 description "Sets health based on the change in PFE bad route discard count";
                 frequency 1offset;
@@ -278,6 +280,7 @@ healthbot {
                 }
             }
             trigger pfe-bits-to-test-discard {
+                alert-type hardware.fpc.pfe.pfe-bits-to-test-discard;			
                 synopsis "PFE bits to test discards KPI";
                 description "Sets health based on the change in PFE bits to test discard count";
                 frequency 1offset;
@@ -316,6 +319,7 @@ healthbot {
                 }
             }
             trigger pfe-fabric-discards {
+                alert-type hardware.fpc.pfe.pfe-fabric-discards;			
                 synopsis "PFE fabric discards KPI";
                 description "Sets health based on the change in PFE fabric discard count";
                 frequency 1offset;
@@ -354,6 +358,7 @@ healthbot {
                 }
             }
             trigger pfe-info-cell-discard {
+                alert-type hardware.fpc.pfe.pfe-info-cell-discard;			
                 synopsis "PFE info cell discards KPI";
                 description "Sets health based on the change in PFE info cell discard count";
                 frequency 1offset;
@@ -392,6 +397,7 @@ healthbot {
                 }
             }
             trigger pfe-invalid-iif-discard {
+                alert-type hardware.fpc.pfe.pfe-invalid-iif-discard;			
                 synopsis "PFE invalid IIF discards KPI";
                 description "Sets health based on the change in PFE invalid IIF discard count";
                 frequency 1offset;
@@ -430,6 +436,7 @@ healthbot {
                 }
             }
             trigger pfe-nexthop-discard {
+                alert-type hardware.fpc.pfe.pfe-nexthop-discard;			
                 synopsis "PFE nexthop discards KPI";
                 description "Sets health based on the change in PFE nexthop discard count";
                 frequency 1offset;
@@ -468,6 +475,7 @@ healthbot {
                 }
             }
             trigger pfe-stack-overflow-discard {
+                alert-type hardware.fpc.pfe.pfe-stack-overflow-discard;			
                 synopsis "PFE stack overflow discards KPI";
                 description "Sets health based on the change in PFE stack overflow discard count";
                 frequency 1offset;
@@ -506,6 +514,7 @@ healthbot {
                 }
             }
             trigger pfe-stack-underflow-discard {
+                alert-type hardware.fpc.pfe.pfe-stack-overflow-discard;			
                 synopsis "PFE stack underflow discards KPI";
                 description "Sets health based on the change in PFE stack underflow discard count";
                 frequency 1offset;
@@ -544,6 +553,7 @@ healthbot {
                 }
             }
             trigger pfe-tcp-header-error-discard {
+                alert-type hardware.fpc.pfe.pfe-stack-overflow-discard;			
                 synopsis "PFE TCP header error discards KPI";
                 description "Sets health based on the change in PFE TCP header error discard count";
                 frequency 1offset;

--- a/juniper_official/system/check-ntp-synchronization-status.rule
+++ b/juniper_official/system/check-ntp-synchronization-status.rule
@@ -101,6 +101,7 @@ healthbot {
              * Anomaly detection logic.
              */
             trigger ntp-sync {
+                alert-type hardware.ntp.ntp-sync;			
                 frequency 1offset;
                 /*
                  * Sets color to red when reference-id is INIT

--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -122,6 +122,7 @@ healthbot {
             * Anomaly detection logic.
             */
              trigger routing-engine-cpu-utilization {
+                 alert-type hardware.cpu.routing_engine.routing-engine-cpu-utilization;
                  synopsis "Routing engine CPU KPI";
                  description "Sets health based on increase in RE CPU utilization";
                  frequency 1offset;
@@ -204,6 +205,7 @@ healthbot {
                  }				 
              }
              trigger routing-engine-memory-buffer-utilization {
+                 alert-type hardware.memory.routing_engine.routing-engine-memory-buffer-utilization;
                  synopsis "RE system memory buffer utilization kpi";
                  description "Sets health based on increase in system memory buffer utilization";
                  frequency 1offset;


### PR DESCRIPTION
Added alert type for below rules :

hardware.fpc/check-pfe-discards
hardware.fpc/check-fpc-cpu-memory-state-temp
hardware.system/check-system-cpu-memory
hardware.system/check-ntp-synchronization-status