### PR TITLE
Added alert type for triggers in ospf and isis rules

### DIFF
--- a/juniper_official/routing/check-isis-adjacency-status.rule
+++ b/juniper_official/routing/check-isis-adjacency-status.rule
@@ -99,6 +99,7 @@
              * Anomaly detection logic.
              */
             trigger isis-adjacency-state {
+                alert-type routing.isis.state.adjacency-state;
                 frequency 1offset;
                 /*
                  * Sets color to green when the adjacency state is up.

--- a/juniper_official/routing/check-isis-flap-detection.rule
+++ b/juniper_official/routing/check-isis-flap-detection.rule
@@ -59,6 +59,7 @@
              * Anomaly detection logic.
              */
             trigger isis-adjacency-flap {
+                alert-type routing.isis.flaps.isis-adjacency-flap;
                 frequency 1offset;
                 /*
                  * Sets color to green when flap count is not increasing

--- a/juniper_official/routing/check-isis-statistics.rule
+++ b/juniper_official/routing/check-isis-statistics.rule
@@ -126,6 +126,7 @@
              * Anomaly detection logic to detect frame discards
              */
             trigger isis-csnp-drops {
+                alert-type routing.isis.drops.csnp.isis-csnp-drops;
                 synopsis "ISIS csnp drops kpi";
                 description "Sets health based on increase in ISIS session's csnp drop count and notify anomaly";
                 frequency 1offset;
@@ -167,6 +168,7 @@
                 }
             }
             trigger isis-esh-drops {
+                alert-type routing.isis.drops.esh.isis-esh-drops;
                 synopsis "ISIS esh drops kpi";
                 description "Sets health based on increase in ISIS session's esh drop count and notify anomaly";
                 frequency 1offset;
@@ -208,6 +210,7 @@
                 }
             }
             trigger isis-iih-drops {
+                alert-type routing.isis.drops.iih.isis-iih-drops;
                 synopsis "ISIS iih drops kpi";
                 description "Sets health based on increase in ISIS session's iih drop count and notify anomaly";
                 frequency 1offset;
@@ -249,6 +252,7 @@
                 }
             }
             trigger isis-ish-drops {
+                alert-type routing.isis.drops.ish.isis-ish-drops;
                 synopsis "ISIS ish drops kpi";
                 description "Sets health based on increase in ISIS session's ish drop count and notify anomaly";
                 frequency 1offset;
@@ -290,6 +294,7 @@
                 }
             }
             trigger isis-lsp-drops {
+                alert-type routing.isis.drops.lsp.isis-lsp-drops;
                 synopsis "ISIS lsp drops kpi";
                 description "Sets health based on increase in ISIS session's lsp drop count and notify anomaly";
                 frequency 1offset;
@@ -331,6 +336,7 @@
                 }
             }
             trigger isis-psnp-drops {
+                alert-type routing.isis.drops.psnp.isis-psnp-drops;
                 synopsis "ISIS psnp drops kpi";
                 description "Sets health based on increase in ISIS session's psnp drop count and notify anomaly";
                 frequency 1offset;
@@ -372,6 +378,7 @@
                 }
             }
             trigger isis-unknown-drops {
+                alert-type routing.isis.drops.unknown.isis-unknown-drops;
                 synopsis "ISIS unknown drops kpi";
                 description "Sets health based on increase in ISIS session's unknown drop count and notify anomaly";
                 frequency 1offset;

--- a/juniper_official/routing/check-ospf-io-statistics.rule
+++ b/juniper_official/routing/check-ospf-io-statistics.rule
@@ -42,6 +42,7 @@
              * Anomaly detection logic.
              */
             trigger ospf-io-errors {
+                alert-type routing.ospf.errors.io.ospf-io-errors;
                 synopsis "ospf io statistics kpi";
                 description "Sets health based on ospf io errors";
                 frequency 1offset;

--- a/juniper_official/routing/check-ospf-neighbor-state.rule
+++ b/juniper_official/routing/check-ospf-neighbor-state.rule
@@ -75,6 +75,7 @@
              * Anomaly detection logic.
              */
             trigger ospf-neighbor-state {
+                alert-type routing.ospf.state.ospf-neighbor-state;
                 synopsis "ospf neigbor state kpi";
                 description "Sets health based on ospf neighbor state";
                 frequency 1offset;

--- a/juniper_official/routing/check-ospf-statistics.rule
+++ b/juniper_official/routing/check-ospf-statistics.rule
@@ -46,6 +46,7 @@
                 description "Hello count threshold";
             }			
             trigger ospf-hello-received {
+                alert-type routing.ospf.hello.received.ospf-hello-received;
                 synopsis "ospf hello received statistics kpi";
                 description "Sets health based on ospf hello received statistics";
                 frequency 1offset;
@@ -80,6 +81,7 @@
                 }
             }
             trigger ospf-hello-sent {
+                alert-type routing.ospf.hello.sent.ospf-hello-sent;
                 synopsis "ospf hello sent statistics kpi";
                 description "Sets health based on ospf hello sent statistics";
                 frequency 1offset;


### PR DESCRIPTION
Alert type were added for the below rules :

routing.isis/check-isis-adjacency-status
routing.isis/check-isis-flap-detection
routing.isis/check-isis-statistics
routing.ospf/check-ospf-io-statistics
routing.ospf/check-ospf-neighbor-state
routing.ospf/check-ospf-statistics
