### PR TITLE
Added alert type for mpls and rsvp rules

### DIFF
--- a/juniper_official/routing/check-ldp-session.rule
+++ b/juniper_official/routing/check-ldp-session.rule
@@ -41,6 +41,7 @@
              * Anomaly detection logic.
              */
             trigger ldp-session-state {
+                alert-type routing.ldp.state.ldp-session-state;
                 frequency 1offset;
                 /*
                  * Sets color to green when the session state is operational.

--- a/juniper_official/routing/check-lsp-state.rule
+++ b/juniper_official/routing/check-lsp-state.rule
@@ -44,6 +44,7 @@
              * Anomaly detection logic to detect lsp state changes.
              */
             trigger lsp-state {
+                alert-type routing.lsp.state.lsp-state;			
                 frequency 1offset;
                 term lsp-up {
                     when {
@@ -77,6 +78,7 @@
              * Anomaly detection logic to detect lsp flaps.
              */
             trigger lsp-flaps {
+                alert-type routing.lsp.flaps.lsp-flaps;
                 frequency 1offset;
                 term lsp-stable {
                     when {

--- a/juniper_official/routing/check-rsvp-neighbor-state.rule
+++ b/juniper_official/routing/check-rsvp-neighbor-state.rule
@@ -46,6 +46,7 @@
              * Anomaly detection logic to detect rsvp neighbor state changes.
              */
             trigger rsvp-neighbor-state {
+                alert-type routing.rsvp.state.rsvp-neighbor-state;			
                 frequency 1offset;
                 term rsvp-neighbor-state-up {
                     when {

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -207,6 +207,7 @@
              * Anomaly detection logic to detect rsvp-te global errors.
              */
             trigger rsvp-te-global-errors {
+                alert-type routing.rsvp.errors.global.rsvp-te-global-errors;
                 frequency 1offset;
                 term is-authentication-fail {
                     when {

--- a/juniper_official/routing/check-te-rsvp-interface-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-interface-errors.rule
@@ -201,6 +201,7 @@ healthbot {
              * Anomaly detection logic to detect rsvp-te interface errors.
              */
             trigger rsvp-te-interface-errors {
+                alert-type routing.rsvp.errors.interface.rsvp-te-interface-errors;
                 frequency 1offset;
                 term is-authentication-fail {
                     when {


### PR DESCRIPTION
Added alert type for below rules :

routing.mpls/check-lsp-state
routing.mpls/check-rsvp-neighbor-state
routing.mpls/check-te-rsvp-global-errors
routing.mpls/check-te-rsvp-interface-errors
routing.mpls/check-ldp-session
