### PR TITLE
Added alert type to BGP,RIB and FIB rules

### DIFF
--- a/juniper_official/routing/check-bgp-neighbor-prefixes.rule
+++ b/juniper_official/routing/check-bgp-neighbor-prefixes.rule
@@ -85,6 +85,7 @@
              * Anomaly detection logic.
              */			
             trigger advertised-routes {
+                alert-type routing.bgp.advertised_routes.advertised-routes;
                 synopsis "BGP max advertised routes KPI";
                 description "Sets health based on increase in advertised routes on neighbor session";
                 frequency 1offset;
@@ -118,6 +119,7 @@
                 }
             }
             trigger received-routes {
+                alert-type routing.bgp.received_routes.received-routes;			
                 synopsis "BGP max received routes KPI";
                 description "Sets health based on increase in received routes on neighbor session";
                 frequency 1offset;

--- a/juniper_official/routing/check-bgp-neighbor-stats.rule
+++ b/juniper_official/routing/check-bgp-neighbor-stats.rule
@@ -74,6 +74,7 @@
              * Anomaly detection logic.
              */
             trigger bgp-neighbor-flap {
+                alert-type routing.bgp.flaps.bgp-neighbor-flap;
                 synopsis "BGP neighbor session flaps KPI";
                 description "Sets health based on increase in bgp neighbor session flaps";
                 frequency 1offset;
@@ -115,6 +116,7 @@
                 }				
             }
             trigger bgp-neighbor-status {
+                alert-type routing.bgp.status.bgp-neighbor-status;			
                 frequency 1offset;
                 term neighbor-up {
                     when {

--- a/juniper_official/routing/collect-fib-stats.rule
+++ b/juniper_official/routing/collect-fib-stats.rule
@@ -58,6 +58,7 @@
              * Anomaly detection logic.
              */			
             trigger fib-route-count {
+                alert-type routing.fib.routes.count.fib-route-count;
                 frequency 1offset;
                 /*
                  * Sets color to green when route-count is less than threshold.

--- a/juniper_official/routing/collect-rib-table-protocol-routes.rule
+++ b/juniper_official/routing/collect-rib-table-protocol-routes.rule
@@ -54,6 +54,7 @@
                 description "Route count static threshold";
             }
             trigger protocol-routes-count {
+                alert-type routing.rib.protocol.routes.count.protocol-routes-count;
                 frequency 1offset;
                 term protocol-route-count-ok {
                     when {

--- a/juniper_official/routing/collect-rib-table-routes.rule
+++ b/juniper_official/routing/collect-rib-table-routes.rule
@@ -70,6 +70,7 @@
              * Anomaly detection logic.
              */			
             trigger route-table-total-routes-count {
+                alert-type routing.rib.routes.count.route-table-total-routes-count;			
                 frequency 1offset;
                 /*
                  * Sets color to green when route-count is less-than-or-equal-to than threshold


### PR DESCRIPTION
Alert type added to below rules :

routing.rib/collect-rib-table-routes
routing.rib/collect-rib-table-protocol-routes
routing.fib/collect-fib-stats
routing.bgp/check-bgp-neighbor-prefixes
routing.bgp/check-bgp-neighbor-stats
