### PR TITLE
Removed zero-suppress from hardware.system/check-system-power-usage-temp-state rule fields

### DIFF
--- a/juniper_official/chassis/check-system-power-usage-temp-state.rule
+++ b/juniper_official/chassis/check-system-power-usage-temp-state.rule
@@ -78,7 +78,6 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'power-system-maximum'";
                     path /components/component/properties/property/state/value;
-                    zero-suppression;					
                 }
                 type integer;
                 description "System max power available";
@@ -87,7 +86,6 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'power-system-remaining'";
                     path /components/component/properties/property/state/value;
-                    zero-suppression;					
                 }
                 type integer;
                 description "System remaining power";


### PR DESCRIPTION
Removed zero-suppress from hardware.system/check-system-power-usage-temp-state rule for the fields power-system-maximum and power-system-remaining.