### PR TITLE
Removed zero-suppress from interfaces-state rule fields

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -73,7 +73,6 @@ healthbot {
             field flaps {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/carrier-transitions;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of interface flaps";
@@ -95,7 +94,6 @@ healthbot {
             field in-errors-count {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/in-errors;
-                    zero-suppression;
                 }
                 type integer;
                 description "Number of input-errors";
@@ -120,7 +118,6 @@ healthbot {
             field in-octets {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/in-octets;
-                    zero-suppression;
                 }
                 type integer;
                 description "Interface statistics counter (in-octets) value";
@@ -162,7 +159,6 @@ healthbot {
             field out-errors-count {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/out-errors;
-                    zero-suppression;
                 }
                 type integer;
                 description "This field shows interface field's value";
@@ -187,7 +183,6 @@ healthbot {
             field out-octets {
                 sensor interfaces-oc {
                     path /interfaces/interface/state/counters/out-octets;
-                    zero-suppression;
                 }
                 type integer;
                 description "Interface statistics counter (out-octets) value";


### PR DESCRIPTION
Removed zero-suppress from interfacescheck-interface-in-out-errors-traffic-state-flaps rule for the fields in-octets,out-octets,flaps,in-errors-count and out-errors-count.