### PR TITLE
Removed zero-suppress frominterfaces/check-interface-fec-crc-framing-errors rule field

### DIFF
--- a/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
+++ b/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
@@ -68,7 +68,6 @@ healthbot {
             field optical-fec-corrected {
                 sensor errorinfo-netconf {
                     path optical_fec_corr_err;
-                    zero-suppression;
                 }
                 type integer;
                 description "Checks for FEC Un-Corrected errors";


### PR DESCRIPTION
Removed zero-suppress from interfaces/check-interface-fec-crc-framing-errors rule for the field optical-fec-corrected.