### PR TITLE
Removed zero-suppress from hardware.system/check-system-cpu-memory rule fields

### DIFF
--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -51,7 +51,6 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'cpu-utilization-total'";
                     path /components/component/properties/property/state/value;
-                    zero-suppression;
                 }
                 type float;
                 description "Collects RE CPU utilization";
@@ -83,7 +82,6 @@ healthbot {
                 sensor components-oc {
                     where "/components/component/properties/property/@name == 'memory-utilization-buffer'";
                     path /components/component/properties/property/state/value;
-                    zero-suppression;
                 }
                 type integer;
                 description "RE system memory buffer value";


### PR DESCRIPTION
Removed zero-suppress from hardware.system/check-system-cpu-memory rule for the fields re-memory-buffer and re-cpu-utilization.