### PR TITLE
Removed zero-suppress from  routing.bgp/check-bgp-neighbor-stats rule field

### DIFF
--- a/juniper_official/routing/check-bgp-neighbor-stats.rule
+++ b/juniper_official/routing/check-bgp-neighbor-stats.rule
@@ -29,7 +29,6 @@
                 }
                 sensor bgp-oc {
                     path /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/established-transitions;
-                    zero-suppression;
                 }
                 type integer;
                 description "Sensor field to store flap count";


### PR DESCRIPTION
Removed zero-suppress from routing.bgp/check-bgp-neighbor-stats rule for the field flap-count.