### PR TITLE
Removed zero-suppress from routing.mpls/check-te-rsvp-global-errors rule fields

### DIFF
--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -16,10 +16,6 @@
             field authentication-fail {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Authentication fail error count";
@@ -27,10 +23,6 @@
             field bad-checksum {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-checksum;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Bad checksum error count";
@@ -38,10 +30,6 @@
             field bad-packet-format {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-format;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Bad packet format error count";
@@ -49,10 +37,6 @@
             field bad-packet-length {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-length;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Bad packet length error count";
@@ -60,10 +44,6 @@
             field bad-packet-version {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-version;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Bad packet version error count";
@@ -71,10 +51,6 @@
             field in-path-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-path-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "In path messages error count";
@@ -82,10 +58,6 @@
             field in-reservation-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-reservation-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "In reservation messages error count";
@@ -100,10 +72,6 @@
             field message-out-of-order {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/message-out-of-order;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Out of order messages error count";
@@ -111,10 +79,6 @@
             field out-path-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-path-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Out of path error count";
@@ -122,10 +86,6 @@
             field out-reservation-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-reservation-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Out reservation error count";
@@ -133,10 +93,6 @@
             field received-nack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/received-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Received no acknowledgement error count";
@@ -144,10 +100,6 @@
             field recv-pkt-disabled-intf {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/recv-pkt-disabled-intf;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Received packet disable error count";
@@ -155,10 +107,6 @@
             field send-failure {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/send-failure;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Send failure error count";
@@ -166,10 +114,6 @@
             field state-timeout {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/state-timeout;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "State timeout error count";
@@ -177,10 +121,6 @@
             field unknown-ack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-ack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Unknown acknowledgement error count";
@@ -188,10 +128,6 @@
             field unknown-nack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 type integer;
                 description "Unknown no acknowledgement error count";


### PR DESCRIPTION
Removed zero-suppress from routing.mpls/check-te-rsvp-global-errors rule for the fields.