### PR TITLE
COL-1109: Added More Blackhole RCA Rules

### DIFF
--- a/juniper_official/Solutions/Traffic-Blackhole/chassis-alarms.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/chassis-alarms.rule
@@ -1,0 +1,81 @@
+/*
+	* Rule to collect Chassis Alarms for Blackhole Detection RCA.
+*/
+healthbot {
+	topic hardware.fpc {
+		rule chassis-alarms {
+			keys [ fru-slot fru-type error-name ];
+			synopsis "Chassis Alarms";
+			description "Chassis Alarms";
+			sensor sensor-chassis-alarms {
+				synopsis "Chassis Alarms";
+				description "Chassis Alarms";
+				open-config {
+					sensor-name /junos/system/cmerror/counters/;
+					frequency 60s;
+				}
+			}
+			field fru-slot {
+				sensor sensor-chassis-alarms {
+					path "/junos/chassis/cmerror/counters/fru-slot";
+				}
+				type string;
+				description "FRU Slot";
+			}
+			field fru-type {
+				sensor sensor-chassis-alarms {
+					path "/junos/chassis/cmerror/counters/fru-type";
+				}
+				type string;
+				description "FRU Type";
+			}
+			field error-name {
+				sensor sensor-chassis-alarms {
+					path "/junos/chassis/cmerror/counters/@name";
+				}
+				type string;
+				description "Error Name";
+			}
+			field error-count {
+				sensor sensor-chassis-alarms {
+					path "/junos/chassis/cmerror/counters/occur-count";
+				}
+				type integer;
+				description "Alarm Occurrences";
+			}
+			field error-active {
+				sensor sensor-chassis-alarms {
+					path "/junos/chassis/cmerror/counters/enabled";
+				}
+				type string;
+				description "Alarm State";
+			}
+			rule-properties {
+				version 1;
+				contributor juniper;
+				category advanced;
+				supported-healthbot-version 4.2.0;
+				supported-devices {
+					juniper {
+						operating-system junosEvolved {
+							products PTX {
+								platforms PTX10008 {
+									releases 22.2R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+							products ACX {
+								platforms All {
+									releases 22.3R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/juniper_official/Solutions/Traffic-Blackhole/fabric-interrups.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/fabric-interrups.rule
@@ -1,0 +1,74 @@
+/*
+	* Rule to collect Fabric Block CM Errors and Interrupts for Blackhole Detection RCA.
+*/
+healthbot {
+	topic hardware.fpc {
+		rule fabric-interrupts {
+			keys [ fpc-name error-name ];
+			synopsis "Fabric Block CM Errors and Interrupts";
+			description "Fabric Block CM Errors and Interrupts";
+			sensor sensor-interrupts {
+				synopsis "Fabric Block CM Errors and Interrupts";
+				description "Fabric Block CM Errors and Interrupts";
+				open-config {
+					sensor-name /components/component/integrated-circuit/pipeline-counters/errors/;
+					frequency 60s;
+				}
+			}
+			field fpc-name {
+				sensor sensor-interrupts {
+					path "/components/component/@name";
+				}
+				type string;
+				description "FPC Name";
+			}
+			field error-name {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/fabric-block/fabric-block-error/@name";
+				}
+				type string;
+				description "Error Name";
+			}
+			field error-count {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/fabric-block/fabric-block-error/state/count";
+				}
+				type integer;
+				description "Interrupt Occurrences";
+			}
+			field error-active {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/fabric-block/fabric-block-error/state/active";
+				}
+				type string;
+				description "Interrupt State";
+			}
+			rule-properties {
+				version 1;
+				contributor juniper;
+				category advanced;
+				supported-healthbot-version 4.2.0;
+				supported-devices {
+					juniper {
+						operating-system junosEvolved {
+							products PTX {
+								platforms PTX10008 {
+									releases 22.2R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+							products ACX {
+								platforms All {
+									releases 22.3R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/juniper_official/Solutions/Traffic-Blackhole/host-interface-interrups.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/host-interface-interrups.rule
@@ -1,0 +1,74 @@
+/*
+	* Rule to collect Host-Interface Block CM Errors and Interrupts for Blackhole Detection RCA.
+*/
+healthbot {
+	topic hardware.fpc {
+		rule host-interface-interrupts {
+			keys [ fpc-name error-name ];
+			synopsis "Host-Interface Block CM Errors and Interrupts";
+			description "Host-Interface Block CM Errors and Interrupts";
+			sensor sensor-interrupts {
+				synopsis "Host-Interface Block CM Errors and Interrupts";
+				description "Host-Interface Block CM Errors and Interrupts";
+				open-config {
+					sensor-name /components/component/integrated-circuit/pipeline-counters/errors/;
+					frequency 60s;
+				}
+			}
+			field fpc-name {
+				sensor sensor-interrupts {
+					path "/components/component/@name";
+				}
+				type string;
+				description "FPC Name";
+			}
+			field error-name {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/host-interface-block/host-interface-block-error/@name";
+				}
+				type string;
+				description "Error Name";
+			}
+			field error-count {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/host-interface-block/host-interface-block-error/state/count";
+				}
+				type integer;
+				description "Interrupt Occurrences";
+			}
+			field error-active {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/host-interface-block/host-interface-block-error/state/active";
+				}
+				type string;
+				description "Interrupt State";
+			}
+			rule-properties {
+				version 1;
+				contributor juniper;
+				category advanced;
+				supported-healthbot-version 4.2.0;
+				supported-devices {
+					juniper {
+						operating-system junosEvolved {
+							products PTX {
+								platforms PTX10008 {
+									releases 22.2R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+							products ACX {
+								platforms All {
+									releases 22.3R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/juniper_official/Solutions/Traffic-Blackhole/host-process-cpu-memory.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/host-process-cpu-memory.rule
@@ -1,0 +1,74 @@
+/*
+	* Rule to collect Host Process CPU and Memory Utilization for Blackhole Detection RCA.
+*/
+healthbot {
+	topic hardware.fpc {
+		rule host-process-cpu-memory {
+			keys [ fpc-name process-name ];
+			synopsis "Host Process CPU and Memory Utilization";
+			description "Host Process CPU and Memory Utilization";
+			sensor sensor-host-process-cpu-memory {
+				synopsis "Host Process CPU and Memory Utilization";
+				description "Host Process CPU and Memory Utilization";
+				open-config {
+					sensor-name /junos/system/linecard/cpu/memory/;
+					frequency 60s;
+				}
+			}
+			field fpc-name {
+				sensor sensor-host-process-cpu-memory {
+					path "/system-process/component/@name";
+				}
+				type string;
+				description "FPC Name";
+			}
+			field process-name {
+				sensor sensor-host-process-cpu-memory {
+					path "/system-process/component/process/@processName";
+				}
+				type string;
+				description "Error Name";
+			}
+			field process-cpu {
+				sensor sensor-host-process-cpu-memory {
+					path "/system-process/component/process/processCpu";
+				}
+				type integer;
+				description "Process CPU Utilization";
+			}
+			field process-memory {
+				sensor sensor-host-process-cpu-memory {
+					path "/system-process/component/process/processMem";
+				}
+				type integer;
+				description "Process Memory Utilization";
+			}
+			rule-properties {
+				version 1;
+				contributor juniper;
+				category advanced;
+				supported-healthbot-version 4.2.0;
+				supported-devices {
+					juniper {
+						operating-system junosEvolved {
+							products PTX {
+								platforms PTX10008 {
+									releases 22.2R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+							products ACX {
+								platforms All {
+									releases 22.3R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/juniper_official/Solutions/Traffic-Blackhole/interface-interrups.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/interface-interrups.rule
@@ -1,0 +1,74 @@
+/*
+	* Rule to collect Interface Block CM Errors and Interrupts for Blackhole Detection RCA.
+*/
+healthbot {
+	topic hardware.fpc {
+		rule interface-interrupts {
+			keys [ fpc-name error-name ];
+			synopsis "Interface Block CM Errors and Interrupts";
+			description "Interface Block CM Errors and Interrupts";
+			sensor sensor-interrupts {
+				synopsis "Interface Block CM Errors and Interrupts";
+				description "Interface Block CM Errors and Interrupts";
+				open-config {
+					sensor-name /components/component/integrated-circuit/pipeline-counters/errors/;
+					frequency 60s;
+				}
+			}
+			field fpc-name {
+				sensor sensor-interrupts {
+					path "/components/component/@name";
+				}
+				type string;
+				description "FPC Name";
+			}
+			field error-name {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/interface-block/interface-block-error/@name";
+				}
+				type string;
+				description "Error Name";
+			}
+			field error-count {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/interface-block/interface-block-error/state/count";
+				}
+				type integer;
+				description "Interrupt Occurrences";
+			}
+			field error-active {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/interface-block/interface-block-error/state/active";
+				}
+				type string;
+				description "Interrupt State";
+			}
+			rule-properties {
+				version 1;
+				contributor juniper;
+				category advanced;
+				supported-healthbot-version 4.2.0;
+				supported-devices {
+					juniper {
+						operating-system junosEvolved {
+							products PTX {
+								platforms PTX10008 {
+									releases 22.2R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+							products ACX {
+								platforms All {
+									releases 22.3R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/juniper_official/Solutions/Traffic-Blackhole/lookup-interrupts.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/lookup-interrupts.rule
@@ -1,0 +1,74 @@
+/*
+	* Rule to collect Lookup Block CM Errors and Interrupts for Blackhole Detection RCA.
+*/
+healthbot {
+	topic hardware.fpc {
+		rule lookup-interrupts {
+			keys [ fpc-name error-name ];
+			synopsis "Lookup Block CM Errors and Interrupts";
+			description "Lookup Block CM Errors and Interrupts";
+			sensor sensor-interrupts {
+				synopsis "Lookup Block CM Errors and Interrupts";
+				description "Lookup Block CM Errors and Interrupts";
+				open-config {
+					sensor-name /components/component/integrated-circuit/pipeline-counters/errors/;
+					frequency 60s;
+				}
+			}
+			field fpc-name {
+				sensor sensor-interrupts {
+					path "/components/component/@name";
+				}
+				type string;
+				description "FPC Name";
+			}
+			field error-name {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/lookup-block/lookup-block-error/@name";
+				}
+				type string;
+				description "Error Name";
+			}
+			field error-count {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/lookup-block/lookup-block-error/state/count";
+				}
+				type integer;
+				description "Interrupt Occurrences";
+			}
+			field error-active {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/lookup-block/lookup-block-error/state/active";
+				}
+				type string;
+				description "Interrupt State";
+			}
+			rule-properties {
+				version 1;
+				contributor juniper;
+				category advanced;
+				supported-healthbot-version 4.2.0;
+				supported-devices {
+					juniper {
+						operating-system junosEvolved {
+							products PTX {
+								platforms PTX10008 {
+									releases 22.2R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+							products ACX {
+								platforms All {
+									releases 22.3R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/juniper_official/Solutions/Traffic-Blackhole/queueing-interrupts.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/queueing-interrupts.rule
@@ -1,0 +1,74 @@
+/*
+	* Rule to collect Queueing Block CM Errors and Interrupts for Blackhole Detection RCA.
+*/
+healthbot {
+	topic hardware.fpc {
+		rule queueing-interrupts {
+			keys [ fpc-name error-name ];
+			synopsis "Queueing Block CM Errors and Interrupts";
+			description "Queueing Block CM Errors and Interrupts";
+			sensor sensor-interrupts {
+				synopsis "Queueing Block CM Errors and Interrupts";
+				description "Queueing Block CM Errors and Interrupts";
+				open-config {
+					sensor-name /components/component/integrated-circuit/pipeline-counters/errors/;
+					frequency 60s;
+				}
+			}
+			field fpc-name {
+				sensor sensor-interrupts {
+					path "/components/component/@name";
+				}
+				type string;
+				description "FPC Name";
+			}
+			field error-name {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/queueing-block/queueing-block-error/@name";
+				}
+				type string;
+				description "Error Name";
+			}
+			field error-count {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/queueing-block/queueing-block-error/state/count";
+				}
+				type integer;
+				description "Interrupt Occurrences";
+			}
+			field error-active {
+				sensor sensor-interrupts {
+					path "/components/component/integrated-circuit/pipeline-counters/errors/queueing-block/queueing-block-error/state/active";
+				}
+				type string;
+				description "Interrupt State";
+			}
+			rule-properties {
+				version 1;
+				contributor juniper;
+				category advanced;
+				supported-healthbot-version 4.2.0;
+				supported-devices {
+					juniper {
+						operating-system junosEvolved {
+							products PTX {
+								platforms PTX10008 {
+									releases 22.2R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+							products ACX {
+								platforms All {
+									releases 22.3R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/juniper_official/Solutions/Traffic-Blackhole/trap-stats.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/trap-stats.rule
@@ -1,0 +1,77 @@
+/*
+	* Rule to get Trap Statistics (Drop Counters) for Blackhole Detection.
+	* Each platform will have different trap names.
+*/
+healthbot {
+	topic hardware.fpc {
+		rule trap-stats {
+			keys [ fpc-name trap-name ];
+			synopsis "Forwarding Block Trap Names and Values";
+			description "Forwarding Block Trap Names and Values";
+			sensor sensor-trap-stats {
+				synopsis "Forwarding Block Trap Names and Values";
+				description "Forwarding Block Trap Names and Values";
+				open-config {
+					sensor-name /junos/system/linecard/packet/usage/;
+					frequency 60s;
+				}
+			}
+			field fpc-name {
+				sensor sensor-trap-stats {
+					where "/components/component/@name =~ /PIC[0-9]:NPU/";
+					where "/components/component/properties/property/@name != 'ts-input-packets-pps'";
+					where "/components/component/properties/property/@name != 'ts-output-packets-pps'";
+					path "/components/component/@name";
+				}
+				type string;
+				description "FPC name";
+			}
+			field trap-name {
+				sensor sensor-trap-stats {
+					where "/components/component/@name =~ /PIC[0-9]:NPU/";
+					where "/components/component/properties/property/@name != 'ts-input-packets-pps'";
+					where "/components/component/properties/property/@name != 'ts-output-packets-pps'";
+					path "/components/component/properties/property/@name";
+				}
+				type string;
+				description "Trap Name";
+			}
+			field trap-value {
+				sensor sensor-trap-stats {
+					where "/components/component/@name =~ /PIC[0-9]:NPU/";
+					where "/components/component/properties/property/@name != 'ts-input-packets-pps'";
+					where "/components/component/properties/property/@name != 'ts-output-packets-pps'";
+					path "/components/component/properties/property/state/value";
+				}
+				type integer;
+				description "Trap Value";
+			}
+			rule-properties {
+				version 1;
+				contributor juniper;
+				category advanced;
+				supported-healthbot-version 4.2.0;
+				supported-devices {
+					juniper {
+						operating-system junosEvolved {
+							products PTX {
+								platforms PTX10008 {
+									releases 22.2R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+							products ACX {
+								platforms All {
+									releases 22.3R1 {
+										release-support min-supported-release;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
COL-1109: Added Rules For Collecting: Trap Statistics, CM Errors, Chassis Alarms, Process Resource Utilization