### PR TITLE
Updated trigger term for "vpn.l3vpn/check-l3vpn-ospf-state" rule

### DIFF
--- a/juniper_official/vpn/l3vpn/l3vpn-proto-ospf-nw.rule
+++ b/juniper_official/vpn/l3vpn/l3vpn-proto-ospf-nw.rule
@@ -100,14 +100,14 @@ healthbot {
                 }
                 term is-pe-interface-down {
                     when {
-                        matches-with "$instance-interface-status" DOWN {
+                        does-not-match-with "$instance-interface-status" UP {
                             ignore-case;
                         }
                     }
                     then {
                         status {
                             color red;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is DOWN";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is $instance-interface-status";
                         }
                     }
                 }


### PR DESCRIPTION
Updated trigger term for "vpn.l3vpn/check-l3vpn-ospf-state" rule to match on link states other than UP state.