### PR TITLE
Updated trigger term for "interfaces/check-ifl-state" rule

### DIFF
--- a/juniper_official/interface/check-ifl-state.rule
+++ b/juniper_official/interface/check-ifl-state.rule
@@ -96,7 +96,7 @@ healthbot {
                  */				
                 term ifl-up {
                 	when {
-                        does-not-match-with "$ifl-oper-status" UP; {
+                        does-not-match-with "$ifl-oper-status" UP {
                             ignore-case;
                         }
                     }


### PR DESCRIPTION
Updated trigger term for "interfaces/check-ifl-state" rule to match on link states other than UP state.