### PR TITLE
error counters path change for routing.mpls/check-te-rsvp-global-errors rule

### DIFF
--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -21,7 +21,7 @@
             }			
             field authentication-fail {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/authentication-fail;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -39,7 +39,7 @@
             }
             field bad-checksum {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-checksum;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/bad-checksum;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -57,7 +57,7 @@
             }
             field bad-packet-format {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-format;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/bad-packet-format;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -75,7 +75,7 @@
             }
             field bad-packet-length {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-length;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/bad-packet-length;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -93,7 +93,7 @@
             }
             field bad-packet-version {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-version;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/bad-packet-version;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -147,7 +147,7 @@
             }
             field instance-name {
                 sensor lsp {
-                    path "/network-instances/network-instance/@instance-name";
+                    path "/network-instances/network-instance/@name";
                 }
                 sensor lsp-updated {
                     path "/network-instances/network-instance/@name";
@@ -157,7 +157,7 @@
             }
             field message-out-of-order {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/message-out-of-order;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/message-out-of-order;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -211,7 +211,7 @@
             }
             field received-nack {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/received-nack;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/received-nack;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -229,7 +229,7 @@
             }
             field recv-pkt-disabled-intf {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/recv-pkt-disabled-intf;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/recv-pkt-disabled-intf;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -247,7 +247,7 @@
             }
             field send-failure {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/send-failure;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/send-failure;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -265,7 +265,7 @@
             }
             field state-timeout {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/state-timeout;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/state-timeout;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -283,7 +283,7 @@
             }
             field unknown-ack {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-ack;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/unknown-ack;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -301,7 +301,7 @@
             }
             field unknown-nack {
                 sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-nack;
+                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/unknown-nack;
                     zero-suppression;
                     data-if-missing {
                         value 0;
@@ -776,73 +776,73 @@
                     juniper {
                         operating-system junos {
                             products MX {
-                                sensors lsp;							
+                                sensors lsp-updated;							
                                 platforms MX240 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;				
+                                    releases 22.3R1 {
+                                        sensors lsp;				
                                         release-support min-supported-release;
                                     }								
                                 }
                                 platforms MX480 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;				
+                                    releases 22.3R1 {
+                                        sensors lsp;				
                                         release-support min-supported-release;
                                     }								
                                 }
                                 platforms MX960 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;				
+                                    releases 22.3R1 {
+                                        sensors lsp;				
                                         release-support min-supported-release;
                                     }								
                                 }
                                 platforms MX304 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;				
+                                    releases 22.3R1 {
+                                        sensors lsp;				
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX204 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10004 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;									
+                                    releases 22.3R1 {
+                                        sensors lsp;									
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;									
+                                    releases 22.3R1 {
+                                        sensors lsp;									
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
-                                     releases 20.1R1 {
-                                        sensors lsp-updated;									
+                                     releases 22.3R1 {
+                                        sensors lsp;									
                                         release-support min-supported-release;
                                     }
                                 }								
                             }
                             products JNP {
-                                sensors lsp;							
+                                sensors lsp-updated;							
                                 platforms JNP10004 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;									
+                                    releases 22.3R1 {
+                                        sensors lsp;									
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms JNP10008 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;									
+                                    releases 22.3R1 {
+                                        sensors lsp;									
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms JNP10016 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;									
+                                    releases 22.3R1 {
+                                        sensors lsp;									
                                         release-support min-supported-release;
                                     }
                                 }								
@@ -850,67 +850,67 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
-                                sensors lsp;			
+                                sensors lsp-updated;			
                                 platforms ACX7024 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7100 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7348 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7332 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms ACX7024X {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7509 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                             }
                             products PTX {
-                                sensors lsp;
+                                sensors lsp-updated;
                                 platforms PTX10001 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10008 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10016 {
-                                    releases 20.1R1 {
-                                        sensors lsp-updated;
+                                    releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -857,12 +857,18 @@
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms ACX7100 {
+                                platforms ACX7100-32C {
                                     releases 22.3R1 {
                                         sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms ACX7100-48L {
+                                    releases 22.3R1 {
+                                        sensors lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }								
                                 platforms ACX7348 {
                                     releases 22.3R1 {
                                         sensors lsp;
@@ -890,12 +896,24 @@
                             }
                             products PTX {
                                 sensors lsp-updated;
-                                platforms PTX10001 {
+                                platforms PTX10001-36MR-K {
                                     releases 22.3R1 {
                                         sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms PTX10001-36MR {
+                                    releases 22.3R1 {
+                                        sensors lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10001-20C {
+                                    releases 22.3R1 {
+                                        sensors lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }																
                                 platforms PTX10004 {
                                     releases 22.3R1 {
                                         sensors lsp;

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -328,7 +328,7 @@
              * Anomaly detection logic to detect rsvp-te global errors.
              */
             trigger rsvp-te-authentication-fail-errors {
-                alert-type routing.rsvp.errors.rsvp-te-authentication-fail-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-authentication-fail-errors;			
                 frequency 1offset;
                 term is-authentication-fail {
                     when {
@@ -355,7 +355,7 @@
                 }
             }
             trigger rsvp-te-bad-checksum-errors {
-                alert-type routing.rsvp.errors.rsvp-te-bad-checksum-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-bad-checksum-errors;			
                 frequency 1offset;			
                 term is-bad-checksum {
                     when {
@@ -382,7 +382,7 @@
                 }
             }
             trigger rsvp-te-bad-packet-format-errors {
-                alert-type routing.rsvp.errors.rsvp-te-bad-packet-format-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-bad-packet-format-errors;			
                 frequency 1offset;			
                 term is-bad-packet-format {
                     when {
@@ -409,7 +409,7 @@
                 }
             }				
             trigger rsvp-te-bad-packet-length-errors {
-                alert-type routing.rsvp.errors.rsvp-te-bad-packet-length-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-bad-packet-length-errors;			
                 frequency 1offset;				
                 term is-bad-packet-length {
                     when {
@@ -436,7 +436,7 @@
                 }
             }				
             trigger rsvp-te-bad-packet-version-errors {
-                alert-type routing.rsvp.errors.rsvp-te-bad-packet-version-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-bad-packet-version-errors;			
                 frequency 1offset;				
                 term is-bad-packet-version {
                     when {
@@ -463,7 +463,7 @@
                 }
             }				
             trigger rsvp-te-in-path-error-messages-errors {
-                alert-type routing.rsvp.errors.rsvp-te-in-path-error-messages-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-in-path-error-messages-errors;			
                 frequency 1offset;				
                 term is-in-path-error-messages {
                     when {
@@ -490,7 +490,7 @@
                 }
             }				
             trigger rsvp-te-in-reservation-error-messages-errors {
-                alert-type routing.rsvp.errors.rsvp-te-in-reservation-error-messages-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-in-reservation-error-messages-errors;			
                 frequency 1offset;				
                 term in-reservation-error-messages {
                     when {
@@ -517,7 +517,7 @@
                 }
             }				
             trigger rsvp-te-message-out-of-order-errors {
-                alert-type routing.rsvp.errors.rsvp-te-message-out-of-order-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-message-out-of-order-errors;			
                 frequency 1offset;				
                 term is-message-out-of-order {
                     when {
@@ -544,7 +544,7 @@
                 }
             }				
             trigger rsvp-te-out-path-error-messages-errors {
-                alert-type routing.rsvp.errors.rsvp-te-out-path-error-messages-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-out-path-error-messages-errors;			
                 frequency 1offset;				
                 term out-path-error-messages {
                     when {
@@ -571,7 +571,7 @@
                 }
             }				
             trigger rsvp-te-out-reservation-error-messages-errors {
-                alert-type routing.rsvp.errors.rsvp-te-out-reservation-error-messages-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-out-reservation-error-messages-errors;			
                 frequency 1offset;				
                 term out-reservation-error-messages {
                     when {
@@ -598,7 +598,7 @@
                 }
             }				
             trigger rsvp-te-received-nack-errors {
-                alert-type routing.rsvp.errors.rsvp-te-received-nack-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-received-nack-errors;			
                 frequency 1offset;				
                 term is-received-nack {
                     when {
@@ -625,7 +625,7 @@
                 }
             }				
             trigger rsvp-te-recv-pkt-disabled-intf-errors {
-                alert-type routing.rsvp.errors.rsvp-te-recv-pkt-disabled-intf-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-recv-pkt-disabled-intf-errors;			
                 frequency 1offset;				
                 term recv-pkt-disabled-intf {
                     when {
@@ -652,7 +652,7 @@
                 }
             }				
             trigger rsvp-te-send-failure-errors {
-                alert-type routing.rsvp.errors.rsvp-te-send-failure-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-send-failure-errors;			
                 frequency 1offset;				
                 term send-failure {
                     when {
@@ -679,7 +679,7 @@
                 }
             }				
             trigger rsvp-te-state-timeout-errors {
-                alert-type routing.rsvp.errors.rsvp-te-state-timeout-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-state-timeout-errors;			
                 frequency 1offset;				
                 term is-state-timeout {
                     when {
@@ -706,7 +706,7 @@
                 }
             }
             trigger rsvp-te-unknown-ack-errors {
-                alert-type routing.rsvp.errors.rsvp-te-unknown-ack-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-unknown-ack-errors;			
                 frequency 1offset;				
                 term is-unknown-ack {
                     when {
@@ -733,7 +733,7 @@
                 }
             }
             trigger rsvp-te-unknown-nack-errors {
-                alert-type routing.rsvp.errors.rsvp-te-unknown-nack-errors;			
+                alert-type routing.mpls.rsvp.errors.rsvp-te-unknown-nack-errors;			
                 frequency 1offset;				
                 term is-unknown-nack {
                     when {

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -346,6 +346,9 @@
                     }
                 }
                 term no-rsvp-te-authentication-fail-errors {
+                    when {
+                        exists "$authentication-fail";
+                    }				
                     then {
                         status {
                             color green;
@@ -373,6 +376,9 @@
                      }
                 }
                 term no-rsvp-te-bad-checksum-errors {
+                    when {
+                        exists "$bad-checksum";
+                    }				
                     then {
                         status {
                             color green;
@@ -400,6 +406,9 @@
                     }
                 }
                 term no-rsvp-te-bad-packet-format-errors {
+                    when {
+                        exists "$bad-packet-format";
+                    }				
                     then {
                         status {
                             color green;
@@ -427,6 +436,9 @@
                     }
                 }
                 term no-rsvp-te-bad-packet-length-errors {
+                    when {
+                        exists "$bad-packet-length";
+                    }				
                     then {
                         status {
                             color green;
@@ -454,6 +466,9 @@
                     }
                 }
                 term no-rsvp-te-bad-packet-version-errors {
+                    when {
+                        exists "$bad-packet-version";
+                    }				
                     then {
                         status {
                             color green;
@@ -481,6 +496,9 @@
                     }
                 }
                 term no-rsvp-te-in-path-error-messages-errors {
+                    when {
+                        exists "$in-path-error-messages";
+                    }				
                     then {
                         status {
                             color green;
@@ -508,6 +526,9 @@
                     }
                 }
                 term no-rsvp-te-in-reservation-error-messages-errors {
+                    when {
+                        exists "$in-reservation-error-messages";
+                    }				
                     then {
                         status {
                             color green;
@@ -535,6 +556,9 @@
                     }
                 }
                 term no-rsvp-te-message-out-of-order-errors {
+                    when {
+                        exists "$message-out-of-order";
+                    }				
                     then {
                         status {
                             color green;
@@ -562,6 +586,9 @@
                     }
                 }
                 term no-rsvp-te-out-path-error-messages-errors {
+                    when {
+                        exists "$out-path-error-messages";
+                    }				
                     then {
                         status {
                             color green;
@@ -589,6 +616,9 @@
                     }
                 }
                 term no-rsvp-te-out-reservation-error-messages-errors {
+                    when {
+                        exists "$out-reservation-error-messages";
+                    }				
                     then {
                         status {
                             color green;
@@ -616,6 +646,9 @@
                     }
                 }
                 term no-rsvp-te-received-nack-errors {
+                    when {
+                        exists "$received-nack";
+                    }				
                     then {
                         status {
                             color green;
@@ -643,6 +676,9 @@
                     }
                 }
                 term no-rsvp-te-recv-pkt-disabled-intf-errors {
+                    when {
+                        exists "$recv-pkt-disabled-intf";
+                    }				
                     then {
                         status {
                             color green;
@@ -670,6 +706,9 @@
                     }
                 }
                 term no-rsvp-te-send-failure-errors {
+                    when {
+                        exists "$send-failure";
+                    }				
                     then {
                         status {
                             color green;
@@ -697,6 +736,9 @@
                     }
                 }
                 term no-rsvp-te-state-timeout-errors {
+                    when {
+                        exists "$state-timeout";
+                    }				
                     then {
                         status {
                             color green;
@@ -724,6 +766,9 @@
                     }
                 }
                 term no-rsvp-te-unknown-ack-errors {
+                    when {
+                        exists "$unknown-ack";
+                    }				
                     then {
                         status {
                             color green;
@@ -751,6 +796,9 @@
                     }
                 }
                 term no-rsvp-te-unknown-nack-errors {
+                    when {
+                        exists "$unknown-nack";
+                    }				
                     then {
                         status {
                             color green;


### PR DESCRIPTION
Error counters path change for routing.mpls/check-te-rsvp-global-errors rule.

GNATS 1826792, AT16 :

To understand the history behind the error counters xpath.

Before error-counters path was introduced with openconfig, we were streaming the values with augment xpath 
"/network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail"

After error-counters xpath was introduced in rsvp openconfig model, with RLI 50517 committed in 22.3R1, 
In accordance with the new OC model, "counters" hierarchy was added.
"/network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/authentication-fail"

Earlier "error-counters" hierarchy were moved to augments for backwards compatibility. 

Recently, there was a customer PR [1805762](https://gnats.juniper.net/web/default/1805762) in 24.3R1, where customer was getting too many values as they had subscribed to rsvp hierarchy level, when subscribed at the parent level, both these hierarchy xpaths are being streamed out. 

So, with PR [1805762](https://gnats.juniper.net/web/default/1805762), "error-counters" xpath is removed to reduce the confusion and to be in completely in accordance with OC model only.


To answer your query to create new rule,

For releases 22.3R1 onwards,
Please use "/network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/authentication-fail"

For earlier releases,
please use "/network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail"