### PR TITLE
Updated instance name field match condition for routing.mpls/check-te-rsvp-global-errors rule

### DIFF
--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -147,9 +147,11 @@
             }
             field instance-name {
                 sensor lsp {
+                    where "/network-instances/network-instance/@name =~ /DEFAULT|master/";				
                     path "/network-instances/network-instance/@name";
                 }
                 sensor lsp-updated {
+                    where "/network-instances/network-instance/@name =~ /DEFAULT|master/";				
                     path "/network-instances/network-instance/@name";
                 }				
                 type string;
@@ -894,6 +896,33 @@
                                         release-support min-supported-release;
                                     }
                                 }								
+                            }
+                            products EX {
+                                sensors lsp-updated;							
+                                platforms EX9204 {
+                                    releases 22.3R1 {
+                                        sensors lsp;									
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms EX9208 {
+                                    releases 22.3R1 {
+                                        sensors lsp;									
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms EX9216{
+                                    releases 22.3R1 {
+                                        sensors lsp;									
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms ex4300-48mp {
+                                    releases 22.3R1 {
+                                        sensors lsp;									
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }							
                         }
                         operating-system junosEvolved {


### PR DESCRIPTION
Updated instance name field match condition for routing.mpls/check-te-rsvp-global-errors rule.