### PR TITLE
Removed fields and triggers from check-te-rsvp-global-errors rule (GNATS 1853502)

### DIFF
--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -22,17 +22,9 @@
             field authentication-fail {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/authentication-fail;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/authentication-fail;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Authentication fail error count";
@@ -40,17 +32,9 @@
             field bad-checksum {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/bad-checksum;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-checksum;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Bad checksum error count";
@@ -58,17 +42,9 @@
             field bad-packet-format {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/bad-packet-format;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-format;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Bad packet format error count";
@@ -76,71 +52,29 @@
             field bad-packet-length {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/bad-packet-length;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-length;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Bad packet length error count";
             }
-            field bad-packet-version {
-                sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/bad-packet-version;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }
-                sensor lsp-updated {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/bad-packet-version;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }				
-                type integer;
-                description "Bad packet version error count";
-            }
             field in-path-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-path-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-path-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }				
+                }					
                 type integer;
                 description "In path messages error count";
             }
             field in-reservation-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-reservation-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/in-reservation-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "In reservation messages error count";
@@ -155,38 +89,12 @@
                 type string;
                 description "Instance name to monitor";
             }
-            field message-out-of-order {
-                sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/message-out-of-order;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }
-                sensor lsp-updated {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/message-out-of-order;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }				
-                type integer;
-                description "Out of order messages error count";
-            }
             field out-path-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-path-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-path-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Out of path error count";
@@ -194,10 +102,6 @@
             field out-reservation-error-messages {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-reservation-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-reservation-error-messages;
@@ -212,89 +116,19 @@
             field received-nack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/received-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/received-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Received no acknowledgement error count";
             }
-            field recv-pkt-disabled-intf {
-                sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/recv-pkt-disabled-intf;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }
-                sensor lsp-updated {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/recv-pkt-disabled-intf;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }				
-                type integer;
-                description "Received packet disable error count";
-            }
-            field send-failure {
-                sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/send-failure;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }
-                sensor lsp-updated {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/send-failure;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }				
-                type integer;
-                description "Send failure error count";
-            }
-            field state-timeout {
-                sensor lsp {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/state-timeout;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }
-                sensor lsp-updated {
-                    path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/state-timeout;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
-                }				
-                type integer;
-                description "State timeout error count";
-            }
             field unknown-ack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/unknown-ack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-ack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Unknown acknowledgement error count";
@@ -302,17 +136,9 @@
             field unknown-nack {
                 sensor lsp {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/errors/unknown-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/error-counters/unknown-nack;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Unknown no acknowledgement error count";
@@ -447,36 +273,6 @@
                     }
                 }
             }				
-            trigger rsvp-te-bad-packet-version-errors {
-                alert-type routing.mpls.rsvp.errors.rsvp-te-bad-packet-version-errors;			
-                frequency 1offset;				
-                term is-bad-packet-version {
-                    when {
-                        increasing-at-least-by-value "$bad-packet-version" {
-                            value "$error-threshold";
-                            time-range 2.5offset;
-                            latest;
-                        }
-                    }
-                    then {
-                        status {
-                            color red;
-                            message "Bad packet version error count($bad-packet-version) is increasing";
-                        }
-                    }
-                }
-                term no-rsvp-te-bad-packet-version-errors {
-                    when {
-                        exists "$bad-packet-version";
-                    }				
-                    then {
-                        status {
-                            color green;
-                            message "Authentication failure error count($bad-packet-version) is not increasing";
-                        }
-                    }
-                }
-            }				
             trigger rsvp-te-in-path-error-messages-errors {
                 alert-type routing.mpls.rsvp.errors.rsvp-te-in-path-error-messages-errors;			
                 frequency 1offset;				
@@ -533,36 +329,6 @@
                         status {
                             color green;
                             message "Authentication failure error count($in-reservation-error-messages) is not increasing";
-                        }
-                    }
-                }
-            }				
-            trigger rsvp-te-message-out-of-order-errors {
-                alert-type routing.mpls.rsvp.errors.rsvp-te-message-out-of-order-errors;			
-                frequency 1offset;				
-                term is-message-out-of-order {
-                    when {
-                        increasing-at-least-by-value "$message-out-of-order" {
-                            value "$error-threshold";
-                            time-range 2.5offset;
-                            latest;
-                        }
-                    }
-                    then {
-                        status {
-                            color red;
-                            message "Message out of order error count($message-out-of-order) is increasing";
-                        }
-                    }
-                }
-                term no-rsvp-te-message-out-of-order-errors {
-                    when {
-                        exists "$message-out-of-order";
-                    }				
-                    then {
-                        status {
-                            color green;
-                            message "Authentication failure error count($message-out-of-order) is not increasing";
                         }
                     }
                 }
@@ -657,96 +423,6 @@
                     }
                 }
             }				
-            trigger rsvp-te-recv-pkt-disabled-intf-errors {
-                alert-type routing.mpls.rsvp.errors.rsvp-te-recv-pkt-disabled-intf-errors;			
-                frequency 1offset;				
-                term recv-pkt-disabled-intf {
-                    when {
-                        increasing-at-least-by-value "$recv-pkt-disabled-intf" {
-                            value "$error-threshold";
-                            time-range 2.5offset;
-                            latest;
-                        }
-                    }
-                    then {
-                        status {
-                            color red;
-                            message "Recv-pkt-disabled-intf error count($recv-pkt-disabled-intf) is increasing";
-                        }
-                    }
-                }
-                term no-rsvp-te-recv-pkt-disabled-intf-errors {
-                    when {
-                        exists "$recv-pkt-disabled-intf";
-                    }				
-                    then {
-                        status {
-                            color green;
-                            message "Authentication failure error count($recv-pkt-disabled-intf) is not increasing";
-                        }
-                    }
-                }
-            }				
-            trigger rsvp-te-send-failure-errors {
-                alert-type routing.mpls.rsvp.errors.rsvp-te-send-failure-errors;			
-                frequency 1offset;				
-                term send-failure {
-                    when {
-                        increasing-at-least-by-value "$send-failure" {
-                            value "$error-threshold";
-                            time-range 2.5offset;
-                            latest;
-                        }
-                    }
-                    then {
-                        status {
-                            color red;
-                            message "Send failure error count($send-failure) is increasing";
-                        }
-                    }
-                }
-                term no-rsvp-te-send-failure-errors {
-                    when {
-                        exists "$send-failure";
-                    }				
-                    then {
-                        status {
-                            color green;
-                            message "Authentication failure error count($send-failure) is not increasing";
-                        }
-                    }
-                }
-            }				
-            trigger rsvp-te-state-timeout-errors {
-                alert-type routing.mpls.rsvp.errors.rsvp-te-state-timeout-errors;			
-                frequency 1offset;				
-                term is-state-timeout {
-                    when {
-                        increasing-at-least-by-value "$state-timeout" {
-                            value "$error-threshold";
-                            time-range 2.5offset;
-                            latest;
-                        }
-                    }
-                    then {
-                        status {
-                            color red;
-                            message "State timeout error count($state-timeout) is increasing";
-                        }
-                    }
-                }
-                term no-rsvp-te-state-timeout-errors {
-                    when {
-                        exists "$state-timeout";
-                    }				
-                    then {
-                        status {
-                            color green;
-                            message "State timeout error count($state-timeout) is not increasing";
-                        }
-                    }
-                }
-            }
             trigger rsvp-te-unknown-ack-errors {
                 alert-type routing.mpls.rsvp.errors.rsvp-te-unknown-ack-errors;			
                 frequency 1offset;				

--- a/juniper_official/routing/check-te-rsvp-global-errors.rule
+++ b/juniper_official/routing/check-te-rsvp-global-errors.rule
@@ -105,10 +105,6 @@
                 }
                 sensor lsp-updated {
                     path /network-instances/network-instance/mpls/signaling-protocols/rsvp-te/global/state/counters/out-reservation-error-messages;
-                    zero-suppression;
-                    data-if-missing {
-                        value 0;
-                    }
                 }				
                 type integer;
                 description "Out reservation error count";


### PR DESCRIPTION
Removed fields and triggers from check-te-rsvp-global-errors rule.

Fields : bad-packet-version, message-out-of-order, recv-pkt-disabled-intf, send-failure and state-timeout

Triggers : rsvp-te-bad-packet-version-errors, rsvp-te-message-out-of-order-errors, rsvp-te-recv-pkt-disabled-intf-errors, rsvp-te-send-failure-errors and rsvp-te-state-timeout-errors.