### PR TITLE
Updated rule to incLude level in xpath (GNATS 1819399)

### DIFF
--- a/juniper_official/routing/check-isis-statistics.rule
+++ b/juniper_official/routing/check-isis-statistics.rule
@@ -40,6 +40,14 @@
                     frequency 60s;
                 }
             }
+            sensor isis-sensor-level {
+                synopsis "ISIS open-config sensor definition";
+                description "Open-config sensor to collect telemetry data from network device";
+                open-config {
+                    sensor-name /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/;
+                    frequency 60s;
+                }
+            }			
             /*
              * Fields defined using sensor path. Map the longer sensor names
              * to the shorter field names used in the rules.
@@ -48,8 +56,11 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/csnp/state/dropped;
-                    zero-suppression;
                 }
+                sensor isis-sensor-level {
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
+                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/packet-counters/csnp/state/dropped;
+                }				
                 type integer;
                 description "Number of csnp drops";
             }
@@ -57,8 +68,11 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/esh/state/dropped;
-                    zero-suppression;
                 }
+                sensor isis-sensor-level {
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
+                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/packet-counters/esh/state/dropped;
+                }				
                 type integer;
                 description "Number of esh drops";
             }
@@ -66,8 +80,11 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/iih/state/dropped;
-                    zero-suppression;
                 }
+                sensor isis-sensor-level {
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
+                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/packet-counters/iih/state/dropped;
+                }				
                 type integer;
                 description "Number of iih drops";
             }
@@ -76,6 +93,10 @@
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id";
                 }
+                sensor isis-sensor-level {
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
+                    path "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id";
+                }				
                 type string;
                 description "Interfaces to be monitored";
             }
@@ -83,8 +104,11 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/ish/state/dropped;
-                    zero-suppression;
                 }
+                sensor isis-sensor-level {
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
+                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/packet-counters/ish/state/dropped;
+                }				
                 type integer;
                 description "Number of ish drops";
             }
@@ -92,8 +116,11 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/lsp/state/dropped;
-                    zero-suppression;
                 }
+                sensor isis-sensor-level {
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
+                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/packet-counters/lsp/state/dropped;
+                }				
                 type integer;
                 description "Number of lsp drops";
             }
@@ -101,8 +128,11 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/psnp/state/dropped;
-                    zero-suppression;
                 }
+                sensor isis-sensor-level {
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
+                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/packet-counters/psnp/state/dropped;
+                }				
                 type integer;
                 description "Number of psnp drops";
             }
@@ -117,8 +147,11 @@
                 sensor isis-sensor {
                     where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
                     path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/packet-counters/unknown/state/dropped;
-                    zero-suppression;
                 }
+                sensor isis-sensor-level {
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/@interface-id =~ /{{interface-name}}/";
+                    path /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/packet-counters/unknown/state/dropped;
+                }				
                 type integer;
                 description "Number of unknown drops";
             }
@@ -436,69 +469,178 @@
                 is-scaling-rule {
                     description "Fields:interface-name ; Directly impacted by number of interfaces running in each network device";
                 }				
-                supported-healthbot-version 1.0.1;
+                supported-healthbot-version 2.3.0;
                 supported-devices {
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-sensor;							
                                 platforms MX240 {
-                                    releases 17.4R1 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
                                         release-support min-supported-release;
                                     }
+                                    releases 17.4R1 {
+                                        sensors isis-sensor;
+                                        release-support min-supported-release;
+                                    }								
                                 }
                                 platforms MX480 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
                                     releases 17.4R1 {
+                                        sensors isis-sensor;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
                                     releases 17.4R1 {
+                                        sensors isis-sensor;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2010 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
                                     releases 17.4R1 {
+                                        sensors isis-sensor;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
                                     releases 17.4R1 {
+                                        sensors isis-sensor;
                                         release-support min-supported-release;
                                     }
                                 }							
                             }
+                            products JNP {
+                                sensors isis-sensor;							
+                                platforms JNP10004 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 17.4R1 {
+                                        sensors isis-sensor;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10008 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 17.4R1 {
+                                        sensors isis-sensor;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10016 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 17.4R1 {
+                                        sensors isis-sensor;
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                             products PTX {
-                                platforms PTX5000 {
-                                    releases 17.4R1 {
+                                sensors isis-sensor;							
+                                platforms PTX10008 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
                                         release-support min-supported-release;
                                     }
-                                }
-                                platforms PTX1000 {
                                     releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms PTX10000 {
-                                    releases 17.4R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }							
-                            }
-                            products ACX {
-                                platforms All {
-                                    releases 22.1R1 {
+                                        sensors isis-sensor;
                                         release-support min-supported-release;
                                     }
                                 }
                             }
+                            products EX {
+                                sensors isis-sensor;							
+                                platforms EX4300-48MP {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms EX9204 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }							
                         }
                         operating-system junosEvolved {
                             products ACX {
-                                platforms All {
+                                sensors isis-sensor;
+                                platforms ACX7024 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
                                     releases 22.3R1 {
+                                        sensors isis-sensor;
+                                        release-support min-supported-release;
+                                    }								
+                                }
+                                platforms ACX7024X {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 22.3R1 {
+                                        sensors isis-sensor;
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                                platforms ACX7100 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 22.3R1 {
+                                        sensors isis-sensor;
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms ACX7348 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 22.3R1 {
+                                        sensors isis-sensor;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms ACX7509 {
+                                    releases 23.2R1 {
+                                        sensors isis-sensor-level;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 22.3R1 {
+                                        sensors isis-sensor;
+                                        release-support min-supported-release;
+                                    }
+                                }								
                             }
                         }						
                     }


### PR DESCRIPTION
For check-isis-statistics, Every counter which was under interface now moved under interface/levels/level.