### PR TITLE
fixed level-number var in collect-isis-lsp-retranx-v2

### DIFF
--- a/juniper_official/routing/collect-isis-lsp-retranx-v2.rule
+++ b/juniper_official/routing/collect-isis-lsp-retranx-v2.rule
@@ -39,7 +39,7 @@
             }
             field level-number {
                 sensor isis-oc {
-                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/@level-number =~ /{{level-numb}}/";
+                    where "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/@level-number =~ /{{level-number}}/";
                     path "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/@level-number";
                 }
                 type string;


### PR DESCRIPTION
Fixed the variable used by level-number field in collect-isis-lsp-retranx-v2.rule