### PR TITLE
Updated rule properties for check-psm-power-usage-state rule

### DIFF
--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -403,6 +403,11 @@ healthbot {
                                     releases 24.4R1 {
                                         release-support min-supported-release;
                                     }
+                                }
+                                platforms MX240 {
+                                    releases 24.4R1 {
+                                        release-support min-supported-release;
+                                    }
                                 }								
                                 platforms MX304 {
                                     releases 24.4R1 {

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -362,7 +362,11 @@ healthbot {
                 value 45;
                 description "Default PSM low threshold is 45 degree celsius";
                 type int;
-            }			
+            }
+            /*
+             * For MX204 temperature is not available.
+             * power-dc-output and psm-power-capacity-maximum are available from 24.4R1.
+             */			
             rule-properties {
                 version 1;
                 contributor juniper;
@@ -400,27 +404,27 @@ healthbot {
                                 sensors components-oc-junos;
                                 platforms MX204 {
                                     sensors components-oc;								
-                                    releases 24.4R1 {
+                                    releases 22.2R3 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX240 {
-                                    releases 24.4R1 {
+                                    releases 22.2R3 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms MX304 {
-                                    releases 24.4R1 {
+                                    releases 22.2R3 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 24.4R1 {
+                                    releases 23.2R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 24.4R1 {
+                                    releases 23.2R1 {
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -399,22 +399,23 @@ healthbot {
                             products MX {
                                 sensors components-oc-junos;
                                 platforms MX204 {
-                                    releases 22.2R3 {
+                                    sensors components-oc;								
+                                    releases 24.4R1 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms MX304 {
-                                    releases 22.2R3 {
+                                    releases 24.4R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 23.2R1 {
+                                    releases 24.4R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 23.2R1 {
+                                    releases 24.4R1 {
                                         release-support min-supported-release;
                                     }
                                 }


### PR DESCRIPTION
power usage is supported now on mx204, but temperature is still not supported.

Temperature is supported for mx240,mx480 and mx960.