### PR TITLE
added router-capability router-id field

### DIFF
--- a/juniper_official/routing/collect-isis-lsdb-tlv.rule
+++ b/juniper_official/routing/collect-isis-lsdb-tlv.rule
@@ -85,7 +85,17 @@
                     path "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/ipv4-te-router-id/state/te-router-id";
                 }
                 sensor isis-oc-junos {
-                    path "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/ipv4-te-router-id/state/te-router-id";
+                    path "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/ipv4-te-router-id/state/router-id";
+                }
+                type string;
+                description "router-id from the lsdb path";
+            }
+            field capability-router-id {
+                sensor isis-oc {
+                    path "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/router-capabilities/capability/state/router-id";
+                }
+                sensor isis-oc-junos {
+                    path "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/router-capabilities/capability/state/router-id";
                 }
                 type string;
                 description "router-id from the lsdb path";

--- a/juniper_official/routing/collect-isis-lsdb-tlv.rule
+++ b/juniper_official/routing/collect-isis-lsdb-tlv.rule
@@ -98,7 +98,7 @@
                     path "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/router-capabilities/capability/state/router-id";
                 }
                 type string;
-                description "router-id from the lsdb path";
+                description "router-capabilities router-id from the lsdb path";
             }
             field ipv4-ext-prefix {
                 sensor isis-oc {


### PR DESCRIPTION
1. Modified OC path of existing field(router-id) for releases above 23.4
2. Added new field /network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/router-capabilities/capability/state/router-id under collect-isis-lsdb-tlv.rule
