### PR TITLE
updated with VMX platforms and default condn

### DIFF
--- a/juniper_official/routing/collect-isis-counters.rule
+++ b/juniper_official/routing/collect-isis-counters.rule
@@ -64,6 +64,7 @@
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-oc;
                                 platforms MX204 {
                                     releases 22.2R3 {
                                         release-support min-supported-release;
@@ -93,6 +94,7 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
+                                sensors isis-oc;
                                 platforms ACX7100-32C {
                                     releases 23.2R2 {
                                         release-support min-supported-release;
@@ -110,6 +112,7 @@
                                 }
                             }
                             products PTX {
+                                sensors isis-oc;
                                 platforms PTX10001-36MR {
                                     releases 23.2R2 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/collect-isis-lsdb-lsp.rule
+++ b/juniper_official/routing/collect-isis-lsdb-lsp.rule
@@ -76,6 +76,7 @@
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-oc;
                                 platforms MX204 {
                                     releases 22.2R3 {
                                         release-support min-supported-release;
@@ -105,6 +106,7 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
+                                sensors isis-oc;
                                 platforms ACX7100-32C {
                                     releases 23.2R2 {
                                         release-support min-supported-release;
@@ -122,6 +124,7 @@
                                 }
                             }
                             products PTX {
+                                sensors isis-oc;
                                 platforms PTX10001-36MR {
                                     releases 23.2R2 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/collect-isis-lsdb-neighbsysid-v1.rule
+++ b/juniper_official/routing/collect-isis-lsdb-neighbsysid-v1.rule
@@ -89,6 +89,7 @@
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-oc;
                                 platforms MX204 {
                                     releases 22.2R3 {
                                         release-support min-supported-release;
@@ -118,6 +119,7 @@
                         }
                         operating-system junosEvolved {
                             products PTX {
+                                sensors isis-oc;
                                 platforms PTX10008 {
                                     releases 22.2R3 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/collect-isis-lsdb-neighbsysid-v2.rule
+++ b/juniper_official/routing/collect-isis-lsdb-neighbsysid-v2.rule
@@ -102,6 +102,7 @@
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-oc;
                                 platforms MX240 {
                                     releases 23.2R2 {
                                         release-support min-supported-release;
@@ -126,6 +127,7 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
+                                sensors isis-oc;
                                 platforms ACX7100-32C {
                                     releases 23.2R2 {
                                         release-support min-supported-release;
@@ -143,6 +145,7 @@
                                 }
                             }
                             products PTX {
+                                sensors isis-oc;
                                 platforms PTX10001-36MR {
                                     releases 23.2R2 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/collect-isis-lsdb-subtlv.rule
+++ b/juniper_official/routing/collect-isis-lsdb-subtlv.rule
@@ -97,6 +97,7 @@
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-oc;
                                 platforms MX204 {
                                     releases 22.2R3 {
                                         release-support min-supported-release;
@@ -126,6 +127,7 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
+                                sensors isis-oc;
                                 platforms ACX7100-32C {
                                     releases 23.2R2 {
                                         release-support min-supported-release;
@@ -143,6 +145,7 @@
                                 }
                             }
                             products PTX {
+                                sensors isis-oc;
                                 platforms PTX10001-36MR {
                                     releases 23.2R2 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/collect-isis-lsdb-tlv.rule
+++ b/juniper_official/routing/collect-isis-lsdb-tlv.rule
@@ -133,6 +133,7 @@
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-oc-junos;
                                 platforms MX204 {
                                    releases 23.4R1 {
                                         sensors isis-oc-junos;
@@ -183,10 +184,34 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms VMX {
+                                   releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors isis-oc-junos;
+                                platforms VMX {
+                                   releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                         operating-system junosEvolved {
                             products ACX {
+                                sensors isis-oc-junos;
                                 platforms ACX7100-32C {
                                    releases 23.4R1 {
                                         sensors isis-oc-junos;
@@ -219,6 +244,7 @@
                                 }
                             }
                             products PTX {
+                                sensors isis-oc-junos;
                                 platforms PTX10001-36MR {
                                    releases 23.4R1 {
                                         sensors isis-oc-junos;

--- a/juniper_official/routing/collect-isis-lsp-retranx-v1.rule
+++ b/juniper_official/routing/collect-isis-lsp-retranx-v1.rule
@@ -62,6 +62,7 @@
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-oc;
                                 platforms MX204 {
                                     releases 22.2R3 {
                                         release-support min-supported-release;
@@ -91,6 +92,7 @@
                         }
                         operating-system junosEvolved {
                             products PTX {
+                                sensors isis-oc;
                                 platforms PTX10008 {
                                     releases 22.2R3 {
                                         release-support min-supported-release;

--- a/juniper_official/routing/collect-isis-lsp-retranx-v2.rule
+++ b/juniper_official/routing/collect-isis-lsp-retranx-v2.rule
@@ -75,6 +75,7 @@
                     juniper {
                         operating-system junos {
                             products MX {
+                                sensors isis-oc;
                                 platforms MX240 {
                                     releases 23.2R2 {
                                         release-support min-supported-release;
@@ -99,6 +100,7 @@
                         }
                         operating-system junosEvolved {
                             products ACX {
+                                sensors isis-oc;
                                 platforms ACX7100-32C {
                                     releases 23.2R2 {
                                         release-support min-supported-release;
@@ -116,6 +118,7 @@
                                 }
                             }
                             products PTX {
+                                sensors isis-oc;
                                 platforms PTX10001-36MR {
                                     releases 23.2R2 {
                                         release-support min-supported-release;


### PR DESCRIPTION
1. Added a default sensor path for all existing rule-properties products across all rules.
2. Introduced support for platform and product with VMX in the multi-sensor path rule: collect-isis-lsdb-tlv.rule.