### PR TITLE
Updated meta for fields plotting in "check-interface-in-out-errors-traffic-state-flaps" rule

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -157,7 +157,7 @@ healthbot {
                     }
                     thresholds low-threshold {
                         field-name "$low-threshold";
-                        severity major;
+                        severity minor;
                     }					
                 }
             }
@@ -252,7 +252,7 @@ healthbot {
                     }
                     thresholds low-threshold {
                         field-name "$low-threshold";
-                        severity major;
+                        severity minor;
                     }					
                 }
             }

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -77,6 +77,14 @@ healthbot {
                 }
                 type integer;
                 description "Number of interface flaps";
+                plots flaps-plot {
+                    unit flaps-count;
+                    triggers interface-link-flaps;
+                    thresholds flaps-threshold {
+                        field-name "$flaps-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field flaps-threshold {
                 constant {
@@ -99,6 +107,14 @@ healthbot {
                 }
                 type integer;
                 description "Number of input-errors";
+                plots in-error-plots {
+                    unit in-error;
+                    triggers interface-input-errors;
+                    thresholds in-errors-threshold {
+                        field-name "$in-errors-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field in-errors-threshold {
                 constant {
@@ -132,6 +148,18 @@ healthbot {
                 }
                 type float;
                 description "Utilization in percentage which derived based on mbps and interface speed";
+                plots in-util-plots {
+                    unit percentage;
+                    triggers interface-input-traffic;
+                    thresholds high-threshold {
+                        field-name "$high-threshold";
+                        severity critical;
+                    }
+                    thresholds low-threshold {
+                        field-name "$low-threshold";
+                        severity major;
+                    }					
+                }				
             }
             field interface-name {
                 sensor interfaces-oc {
@@ -154,7 +182,11 @@ healthbot {
                 enumerate UNKNOWN as -3;
                 enumerate DORMANT as -4;
                 enumerate NOT_PRESENT as -5;
-                enumerate LOWER_LAYER_DOWN as -6;				
+                enumerate LOWER_LAYER_DOWN as -6;
+                plots link-state-plots {
+                    unit link-state;
+                    triggers interface-link-state;
+                }				
             }
             field low-threshold {
                 constant {
@@ -170,6 +202,14 @@ healthbot {
                 }
                 type integer;
                 description "This field shows interface field's value";
+                plots out-error-plots {
+                    unit out-error;
+                    triggers interface-output-errors;
+                    thresholds out-errors-threshold {
+                        field-name "$out-errors-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field out-errors-threshold {
                 constant {
@@ -203,6 +243,18 @@ healthbot {
                 }
                 type float;
                 description "Utilization in percentage which derived based on mbps and interface speed";
+                plots out-util-plots {
+                    unit percentage;
+                    triggers interface-output-traffic;
+                    thresholds high-threshold {
+                        field-name "$high-threshold";
+                        severity critical;
+                    }
+                    thresholds low-threshold {
+                        field-name "$low-threshold";
+                        severity major;
+                    }					
+                }				
             }
             field speed {
                 sensor interfaces-oc {

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -159,7 +159,7 @@ healthbot {
                         field-name "$low-threshold";
                         severity major;
                     }					
-                }				
+                }
             }
             field interface-name {
                 sensor interfaces-oc {
@@ -186,7 +186,7 @@ healthbot {
                 plots link-state-plots {
                     unit link-state;
                     triggers interface-link-state;
-                }				
+                }
             }
             field low-threshold {
                 constant {
@@ -209,7 +209,7 @@ healthbot {
                         field-name "$out-errors-threshold";
                         severity critical;
                     }
-                }				
+                }
             }
             field out-errors-threshold {
                 constant {
@@ -254,7 +254,7 @@ healthbot {
                         field-name "$low-threshold";
                         severity major;
                     }					
-                }				
+                }
             }
             field speed {
                 sensor interfaces-oc {

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -78,7 +78,7 @@ healthbot {
                 type integer;
                 description "Number of interface flaps";
                 plots flaps-plot {
-                    unit flaps-count;
+                    unit count;
                     triggers interface-link-flaps;
                     thresholds flaps-threshold {
                         field-name "$flaps-threshold";
@@ -108,7 +108,7 @@ healthbot {
                 type integer;
                 description "Number of input-errors";
                 plots in-error-plots {
-                    unit in-error;
+                    unit count;
                     triggers interface-input-errors;
                     thresholds in-errors-threshold {
                         field-name "$in-errors-threshold";
@@ -203,7 +203,7 @@ healthbot {
                 type integer;
                 description "This field shows interface field's value";
                 plots out-error-plots {
-                    unit out-error;
+                    unit count;
                     triggers interface-output-errors;
                     thresholds out-errors-threshold {
                         field-name "$out-errors-threshold";


### PR DESCRIPTION
Updated meta for fields plotting in "check-interface-in-out-errors-traffic-state-flaps" rule.
Fields for which meta is added :

flaps
in-errors-count
out-errors-count
in-util
out-util
link-state