### PR TITLE
added meta for hardware chassis rules

### DIFF
--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -81,6 +81,18 @@ healthbot {
                 }
                 type integer;
                 description "RPM percentage";
+                plots rpm-plots {
+                    unit percentage;
+                    triggers rpm-percent;
+                    thresholds high-threshold {
+                        field-name "$high-threshold";
+                        severity critical;
+                    }
+                    thresholds low-threshold {
+                        field-name "$low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field rpm-percent-anomaly {
                 formula {
@@ -100,7 +112,11 @@ healthbot {
                 enumerate __default__ as -99;
                 enumerate Failed as -1;
                 enumerate Absent as 0;				
-                enumerate ok as 1;				
+                enumerate ok as 1;
+                plots fan-state-plots {
+                    unit state;
+                    triggers fan-state;
+                }				
             }
             field high-threshold {
                 constant {

--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -114,7 +114,6 @@ healthbot {
                 enumerate Absent as 0;				
                 enumerate ok as 1;
                 plots fan-state-plots {
-                    unit state;
                     triggers fan-state;
                 }				
             }

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -167,7 +167,6 @@ healthbot {
                 enumerate Offline as 0;
                 enumerate online as 1;
                 plots psm-state-plots {
-                    unit state;
                     triggers psm-state;
                 }				
             }

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -194,7 +194,7 @@ healthbot {
                 }
                 type integer;
                 plots psm-temperature-plots {
-                    unit degree-celsius;
+                    unit celsius;
                     triggers psm-temperature;
                     thresholds temp-high-threshold {
                         field-name "$psm-temperature-high-threshold";

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -106,6 +106,18 @@ healthbot {
                 }
                 type float;
                 description "Stores % of power usage by PSMs";
+                plots psm-plots {
+                    unit percentage;
+                    triggers psm-power-usage;
+                    thresholds psm-high-threshold {
+                        field-name "$psm-power-usage-high-threshold";
+                        severity critical;
+                    }
+                    thresholds psm-low-threshold {
+                        field-name "$psm-power-usage-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field psm-power-usage-high-threshold {
                 constant {
@@ -153,7 +165,11 @@ healthbot {
                 enumerate __default__ as -99;
                 enumerate Fault as -10;				
                 enumerate Offline as 0;
-                enumerate online as 1;				
+                enumerate online as 1;
+                plots psm-state-plots {
+                    unit state;
+                    triggers psm-state;
+                }				
             }
             field psm-temperature-degrees {
                 sensor components-oc {
@@ -178,6 +194,18 @@ healthbot {
                     }
                 }
                 type integer;
+                plots psm-temperature-plots {
+                    unit degree-celsius;
+                    triggers psm-temperature;
+                    thresholds temp-high-threshold {
+                        field-name "$psm-temperature-high-threshold";
+                        severity critical;
+                    }
+                    thresholds temp-low-threshold {
+                        field-name "$psm-temperature-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }			
             /*
              * Anomaly detection logic.

--- a/juniper_official/chassis/check-routing-engine-temperature.rule
+++ b/juniper_official/chassis/check-routing-engine-temperature.rule
@@ -64,6 +64,18 @@ healthbot {
                 }				
                 type integer;
                 description "CPU temperature";
+                plots re-cpu-temperature-plots {
+                    unit degree-celsius;
+                    triggers routing-engine-cpu-temperature;
+                    thresholds high-threshold {
+                        field-name "$high-threshold";
+                        severity critical;
+                    }
+                    thresholds low-threshold {
+                        field-name "$low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field routing-engine-temperature {
                 sensor components-oc {
@@ -76,6 +88,18 @@ healthbot {
                 }				
                 type integer;
                 description "RE temperature";
+                plots re-temperature-plots {
+                    unit degree-celsius;
+                    triggers routing-engine-temperature;
+                    thresholds high-threshold {
+                        field-name "$high-threshold";
+                        severity critical;
+                    }
+                    thresholds low-threshold {
+                        field-name "$low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field routing-engine {
                 sensor components-oc {

--- a/juniper_official/chassis/check-routing-engine-temperature.rule
+++ b/juniper_official/chassis/check-routing-engine-temperature.rule
@@ -65,7 +65,7 @@ healthbot {
                 type integer;
                 description "CPU temperature";
                 plots re-cpu-temperature-plots {
-                    unit degree-celsius;
+                    unit celsius;
                     triggers routing-engine-cpu-temperature;
                     thresholds high-threshold {
                         field-name "$high-threshold";
@@ -89,7 +89,7 @@ healthbot {
                 type integer;
                 description "RE temperature";
                 plots re-temperature-plots {
-                    unit degree-celsius;
+                    unit celsius;
                     triggers routing-engine-temperature;
                     thresholds high-threshold {
                         field-name "$high-threshold";

--- a/juniper_official/chassis/check-system-power-usage-temp-state.rule
+++ b/juniper_official/chassis/check-system-power-usage-temp-state.rule
@@ -59,6 +59,18 @@ healthbot {
                 }
                 type integer;
                 description "Chassis Ambient temperature";
+                plots chassis-temperature-plots {
+                    unit degree-celsius;
+                    triggers chassis-temperature;
+                    thresholds temp-high-threshold {
+                        field-name "$high-threshold";
+                        severity critical;
+                    }
+                    thresholds temp-low-threshold {
+                        field-name "$low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field high-threshold {
                 constant {
@@ -100,6 +112,18 @@ healthbot {
                 }
                 type integer;
                 description "Stores remaining power for system using UDF";
+                plots system-power-plots {
+                    unit percentage;
+                    triggers system-power-usage;
+                    thresholds power-high-threshold {
+                        field-name "$system-power-usage-high-threshold";
+                        severity critical;
+                    }
+                    thresholds power-low-threshold {
+                        field-name "$system-power-usage-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field system-power-usage-high-threshold {
                 constant {

--- a/juniper_official/chassis/check-system-power-usage-temp-state.rule
+++ b/juniper_official/chassis/check-system-power-usage-temp-state.rule
@@ -60,7 +60,7 @@ healthbot {
                 type integer;
                 description "Chassis Ambient temperature";
                 plots chassis-temperature-plots {
-                    unit degree-celsius;
+                    unit celsius;
                     triggers chassis-temperature;
                     thresholds temp-high-threshold {
                         field-name "$high-threshold";


### PR DESCRIPTION
Added meta for below rules :

juniper_official/chassis/check-fan-state-rpm.rule
juniper_official/chassis/check-psm-power-usage-state.rule
juniper_official/chassis/check-routing-engine-temperature.rule
juniper_official/chassis/check-system-power-usage-temp-state.rule

