### PR TITLE
Added meta to system and fpc rules

### DIFF
--- a/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
+++ b/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
@@ -99,6 +99,18 @@ healthbot {
                     }
                 }
                 type integer;
+                plots cpu-utilization-plots {
+                    unit percentage;
+                    triggers fpc-cpu-utilization;
+                    thresholds fpc-cpu-high-threshold {
+                        field-name "$cpu-high-threshold";
+                        severity critical;
+                    }
+                    thresholds fpc-cpu-low-threshold {
+                        field-name "$cpu-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field fpc-cpu-utilization-anomaly {
                 formula {
@@ -116,6 +128,18 @@ healthbot {
                 }
                 type integer;
                 description "FPC buffer memory utilization";
+                plots buffer-memory-utilization-plots {
+                    unit percentage;
+                    triggers fpc-buffer-memory-utilization;
+                    thresholds buffer-memory-high-threshold {
+                        field-name "$memory-high-threshold";
+                        severity critical;
+                    }
+                    thresholds buffer-memory-low-threshold {
+                        field-name "$memory-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field fpc-memory-buffer-anomaly {
                 formula {
@@ -133,6 +157,18 @@ healthbot {
                 }
                 type integer;
                 description "FPC heap memory utilization";
+                plots heap-memory-utilization-plots {
+                    unit percentage;
+                    triggers fpc-heap-memory-utilization;
+                    thresholds heap-memory-high-threshold {
+                        field-name "$memory-high-threshold";
+                        severity critical;
+                    }
+                    thresholds heap-memory-low-threshold {
+                        field-name "$memory-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field temperature {
                 sensor components-oc {
@@ -141,6 +177,18 @@ healthbot {
                 }
                 type float;
                 description "Temperature of the line card.";
+                plots temperature-plots {
+                    unit degree-celsius;
+                    triggers fpc-temperature;
+                    thresholds temp-high-threshold {
+                        field-name "$temp-high-threshold";
+                        severity critical;
+                    }
+                    thresholds temp-low-threshold {
+                        field-name "$temp-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }			
             field fpc-utilization-idle {
                 sensor components-oc {
@@ -175,7 +223,10 @@ healthbot {
                 enumerate Offline as -6;
                 enumerate Offlining as -5;
                 enumerate Onlining as 0;				
-                enumerate online as 1;				
+                enumerate online as 1;
+                plots fpc-state-plots {
+                    triggers fpc-state;
+                }				
             }
             field temp-high-threshold {
                 constant {

--- a/juniper_official/linecard/check-pfe-discards.rule
+++ b/juniper_official/linecard/check-pfe-discards.rule
@@ -37,6 +37,14 @@ healthbot {
                 }
                 type integer;
                 description "Bad route discard count";
+                plots bad-route-discard-plot {
+                    unit count;
+                    triggers pfe-bad-route-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field bits-to-test-discard {
                 sensor pfe-sensor-netconf {
@@ -44,6 +52,14 @@ healthbot {
                 }
                 type integer;
                 description "Bits to test discard count";
+                plots bits-to-test-discard-plot {
+                    unit count;
+                    triggers pfe-bits-to-test-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field data-error-discard {
                 sensor pfe-sensor-netconf {
@@ -51,6 +67,14 @@ healthbot {
                 }
                 type integer;
                 description "Data error discard count";
+                plots data-error-discard-plot {
+                    unit count;
+                    triggers pfe-data-error-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field drop-threshold {
                 constant {
@@ -65,6 +89,14 @@ healthbot {
                 }
                 type integer;
                 description "Fabric discard count";
+                plots fabric-discards-plot {
+                    unit count;
+                    triggers pfe-fabric-discards;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field info-cell-discard {
                 sensor pfe-sensor-netconf {
@@ -72,6 +104,14 @@ healthbot {
                 }
                 type integer;
                 description "Info cell discard count";
+                plots info-cell-discard-plot {
+                    unit count;
+                    triggers pfe-info-cell-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field invalid-iif-discard {
                 sensor pfe-sensor-netconf {
@@ -79,6 +119,14 @@ healthbot {
                 }
                 type integer;
                 description "Invalid IIF discard count";
+                plots invalid-iif-discard-plot {
+                    unit count;
+                    triggers pfe-invalid-iif-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field nexthop-discard {
                 sensor pfe-sensor-netconf {
@@ -86,6 +134,14 @@ healthbot {
                 }
                 type integer;
                 description "Nexthop discard count";
+                plots nexthop-discard-plot {
+                    unit count;
+                    triggers pfe-nexthop-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field stack-overflow-discard {
                 sensor pfe-sensor-netconf {
@@ -93,6 +149,14 @@ healthbot {
                 }
                 type integer;
                 description "Stack overflow discard count";
+                plots stack-overflow-discard-plot {
+                    unit count;
+                    triggers pfe-stack-overflow-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field stack-underflow-discard {
                 sensor pfe-sensor-netconf {
@@ -100,6 +164,14 @@ healthbot {
                 }
                 type integer;
                 description "Stack underflow discard count";
+                plots stack-underflow-discard-plot {
+                    unit count;
+                    triggers pfe-stack-underflow-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field tcp-header-error-discard {
                 sensor pfe-sensor-netconf {
@@ -107,6 +179,14 @@ healthbot {
                 }
                 type integer;
                 description "TCP header error discard count";
+                plots tcp-header-error-discard-plot {
+                    unit count;
+                    triggers pfe-tcp-header-error-discard;
+                    thresholds drop-threshold {
+                        field-name "$drop-threshold";
+                        severity critical;
+                    }
+                }				
             }
             field bad-route-discard-rate {
                 formula {

--- a/juniper_official/system/check-ntp-synchronization-status.rule
+++ b/juniper_official/system/check-ntp-synchronization-status.rule
@@ -60,6 +60,9 @@ healthbot {
                 }
                 type string;
                 description "Reference identifier of the remote peer. If the reference identifier is not known, this field shows a value of 0.0.0.0.";
+                plots ntp-sync-plot {
+                    triggers ntp-sync;
+                }                				
             }
             field reference-time {
                 sensor ntp-status {

--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -55,6 +55,18 @@ healthbot {
                 }
                 type float;
                 description "Collects RE CPU utilization";
+                plots re-cpu-utilization-plots {
+                    unit percentage;
+                    triggers routing-engine-cpu-utilization;
+                    thresholds re-cpu-high-threshold {
+                        field-name "$re-cpu-utilization-high-threshold";
+                        severity critical;
+                    }
+                    thresholds re-cpu-low-threshold {
+                        field-name "$re-cpu-utilization-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field re-cpu-utilization-anomaly {
                 formula {
@@ -87,6 +99,18 @@ healthbot {
                 }
                 type integer;
                 description "RE system memory buffer value";
+                plots re-memory-buffer-plots {
+                    unit percentage;
+                    triggers routing-engine-memory-buffer-utilization;
+                    thresholds re-memory-high-threshold {
+                        field-name "$re-memory-buffer-high-threshold";
+                        severity critical;
+                    }
+                    thresholds re-memory-low-threshold {
+                        field-name "$re-memory-buffer-low-threshold";
+                        severity minor;
+                    }					
+                }				
             }
             field re-memory-buffer-anomaly {
                 formula {


### PR DESCRIPTION
Meta is added for fields in below rules :

juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
juniper_official/linecard/check-pfe-discards.rule
juniper_official/system/check-system-cpu-memory.rule
juniper_official/system/check-ntp-synchronization-status.rule

