### PR TITLE
Rules for SR LSP and SR Color LSP stats (junos/evo)

### DIFF
--- a/juniper_official/routing/collect-sr-color-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-color-lsp-stats.rule
@@ -1,0 +1,195 @@
+/*
+ * Collect SR Color LSP traffic statistics for pathfinder dynamic topology.
+ *
+ * Req TBD: TBD
+ *
+ * Two input control detection
+ *
+ *   1) input-to-address, is a regular expression that matches the SR color lsp 
+ *      destination address that must be monitored.  By default it's '.*', which matches
+ *      all destination address. Use something like '11.0.0*' to match only destination 
+ *      address starting with '11.0.0'.  
+ *
+ *   2) input-color, is a regular expression that matches the color of SR color lsp 
+ *      that must be monitored.  By default it's '.*', which matches
+ *      all colors. Use something like '10*' to match LSPs starting with color '10'.
+ *
+ */
+healthbot {
+    topic routing.spring {
+        rule collect-sr-color-lsp-stats {
+            keys [ lsp-name ];
+            description "Collects SR color LSP stats periodically";
+            sensor jnpr-sr-color-lsp {
+                open-config {
+                    sensor-name /junos/services/segment-routing/traffic-engineering/ingress/usage/;
+                    frequency 60s;
+                }
+            }
+            field lsp-destination {
+                sensor jnpr-sr-color-lsp {
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address =~ /{{input-to-address}}/";
+                    path "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address";
+                }                
+                type string;
+                description "LSP destination in case of SR color LSP and name in case of SR LSP";
+            }
+            field lsp-color {
+                sensor jnpr-sr-color-lsp {
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color =~ /{{input-color}}/";
+                    path "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color";
+                }                
+                type string;
+                description "Color of the LSP being monitored";
+            }
+            field lsp-stats-bytes {
+                sensor jnpr-sr-color-lsp {
+                    path /mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/state/counters/bytes;
+                }
+                type integer;
+                description "LSP bytes counter";
+            }      
+            field lsp-stats-packets {
+                sensor jnpr-sr-color-lsp {
+                    path /mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/state/counters/packets;
+                }
+                type integer;
+                description "LSP packet counter";
+            }
+            field lsp-name {
+                formula {
+                    concatenate {
+                        strings [ "srte_c_" "$lsp-color" "_ep_" "$lsp-destination" ];
+                    }
+                }
+                type string;
+                description "LSP name";
+            }
+            field lsp-stats-bps {
+                formula {
+                    rate-of-change {
+                        field-name "$lsp-stats-bytes";
+                        multiplication-factor 8;
+                    }
+                }
+                type integer;
+                description "LSP byte rate";
+            }            
+            field lsp-stats-pps {
+                formula {
+                    rate-of-change {
+                        field-name "$lsp-stats-packets";
+                    }
+                }
+                type integer;
+                description "LSP packet rate";
+            }
+            variable input-to-address {
+                value .*;
+                description "SR color LSP destination address to monitor, regular expression, eg '11.0.0.*|10.52.135.*'";
+                type string;
+            }
+            variable input-color {
+                value .*;
+                description "SR color LSP colors to monitor, regular expression, eg '100|20*'";
+                type string;
+            }
+            rule-properties {
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            sensors jnpr-sr-color-lsp;
+                            products MX {
+                                sensors jnpr-sr-color-lsp;
+                                platforms MX960 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2008 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2010 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2020  {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products PTX {
+                                sensors jnpr-sr-color-lsp;
+                                platforms PTX1000 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10000  {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products QFX {
+                                sensors jnpr-sr-color-lsp;
+                                platforms QFX5200 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                        operating-system junosEvolved {
+                            sensors jnpr-sr-color-lsp;	
+                            products PTX {
+                                sensors jnpr-sr-color-lsp;	
+                                platforms PTX10001-36MR {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;	
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10003 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;	
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10004 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;	
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                                platforms PTX10008 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;	
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10016  {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-color-lsp;	
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/routing/collect-sr-color-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-color-lsp-stats.rule
@@ -73,7 +73,7 @@ healthbot {
                     }
                 }
                 type integer;
-                description "LSP byte rate";
+                description "LSP bit rate";
             }            
             field lsp-stats-pps {
                 formula {

--- a/juniper_official/routing/collect-sr-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-lsp-stats.rule
@@ -52,7 +52,7 @@ healthbot {
                     }
                 }
                 type integer;
-                description "LSP byte rate";
+                description "LSP bit rate";
             }            
             field lsp-stats-pps {
                 formula {

--- a/juniper_official/routing/collect-sr-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-lsp-stats.rule
@@ -1,0 +1,169 @@
+/*
+ * Collect SR LSP traffic statistics for pathfinder dynamic topology.
+ *
+ * Req <TBD>: TBD 
+ *
+ * One input control detection
+ *
+ *   1) input-lsp-name, is a regular expression that matches the SR lsp name
+ *      that must be monitored.  By default it's '.*', which matches
+ *      all lsps. Use something like 'Silver*' to match only lsp names starting
+ *      with 'Silver'.
+ *
+ */
+healthbot {
+    topic routing.spring {
+        rule collect-sr-lsp-stats {
+            keys [ lsp-name ];
+            description "Collects SR LSP stats periodically";
+            sensor jnpr-sr-lsp {
+                open-config {
+                    sensor-name /junos/services/segment-routing/traffic-engineering/tunnel/ingress/usage/;
+                    frequency 60s;
+                }
+            }
+            field lsp-name {
+                sensor jnpr-sr-lsp {
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name =~ /{{input-lsp-name}}/";
+                    path "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name";
+                }              
+                type string;
+                description "LSP destination in case of SR color LSP and name in case of SR LSP";
+            }
+            field lsp-stats-bytes {
+                sensor jnpr-sr-lsp {
+                    path /mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/state/counters/bytes;
+                }
+                type integer;
+                description "LSP bytes counter";
+            }      
+            field lsp-stats-packets {
+                sensor jnpr-sr-lsp {
+                    path /mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/state/counters/packets;
+                }
+                type integer;
+                description "LSP packet counter";
+            }
+            field lsp-stats-bps {
+                formula {
+                    rate-of-change {
+                        field-name "$lsp-stats-bytes";
+                        multiplication-factor 8;
+                    }
+                }
+                type integer;
+                description "LSP byte rate";
+            }            
+            field lsp-stats-pps {
+                formula {
+                    rate-of-change {
+                        field-name "$lsp-stats-packets";
+                    }
+                }
+                type integer;
+                description "LSP packet rate";
+            }
+            variable input-lsp-name {
+                value .*;
+                description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
+                type string;
+            }
+            rule-properties {
+                supported-devices {
+                    juniper {
+                        operating-system junos {
+                            sensors jnpr-sr-lsp;	
+                            products MX {
+                                sensors jnpr-sr-lsp;
+                                platforms MX960 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2008 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2010 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2020  {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products PTX {
+                                sensors jnpr-sr-lsp;
+                                platforms PTX1000 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10000  {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products QFX {
+                                sensors jnpr-sr-lsp;
+                                platforms QFX5200 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                        operating-system junosEvolved {
+                            sensors jnpr-sr-lsp;
+                            products PTX {
+                                sensors jnpr-sr-lsp;
+                                platforms PTX10001-36MR {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10003 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10004 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                                platforms PTX10008 {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms PTX10016  {
+                                    releases 22.1R1 {
+                                        sensors jnpr-sr-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The requirement is to collect the SR LSP and SR Color LSP traffic statistics from Juniper devices, for which two new rules have been added under the new topic, "routing.spring", the two new rules are,
- collect-sr-lsp-stats
- collect-sr-color-lsp-stats

Since the rules are implemented to collect data from SR or segment routing LSPs and SR is also know as Source Packet Routing in Networking (SPRING), hence the rules are created under a new topic named "routing.spring"

Note:
1. The feature is planned for 2.6.0, but it must be available in 2.5.0 with feature flag disabled by default.
2. The REQ is left as TBD since the same is yet to be created, will be updated once the same is made available.

