### PR TITLE
IGP updated ruleprops

### DIFF
--- a/juniper_official/routing/collect-isis-counters.rule
+++ b/juniper_official/routing/collect-isis-counters.rule
@@ -67,32 +67,32 @@
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX240 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX304 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms VMX {
-                                   releases 23.2R2 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -100,7 +100,7 @@
                             products VMX {
                                 sensors isis-oc;
                                 platforms VMX {
-                                   releases 23.2R2 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -111,17 +111,17 @@
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7100-48L {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7509 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -129,22 +129,22 @@
                             products PTX {
                                 sensors isis-oc;
                                 platforms PTX10001-36MR {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10008 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10016 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/collect-isis-counters.rule
+++ b/juniper_official/routing/collect-isis-counters.rule
@@ -63,6 +63,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors isis-oc;
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
@@ -90,9 +91,23 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors isis-oc;
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                         operating-system junosEvolved {
+                            sensors isis-oc;
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {

--- a/juniper_official/routing/collect-isis-lsdb-lsp.rule
+++ b/juniper_official/routing/collect-isis-lsdb-lsp.rule
@@ -79,32 +79,32 @@
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX240 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX304 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms VMX {
-                                   releases 23.2R2 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -112,7 +112,7 @@
                             products VMX {
                                 sensors isis-oc;
                                 platforms VMX {
-                                   releases 23.2R2 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -123,17 +123,17 @@
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7100-48L {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7509 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -141,22 +141,22 @@
                             products PTX {
                                 sensors isis-oc;
                                 platforms PTX10001-36MR {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10008 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10016 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/collect-isis-lsdb-lsp.rule
+++ b/juniper_official/routing/collect-isis-lsdb-lsp.rule
@@ -75,6 +75,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors isis-oc;
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
@@ -102,9 +103,23 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors isis-oc;
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                         operating-system junosEvolved {
+                            sensors isis-oc;
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {

--- a/juniper_official/routing/collect-isis-lsdb-neighbsysid-v1.rule
+++ b/juniper_official/routing/collect-isis-lsdb-neighbsysid-v1.rule
@@ -88,6 +88,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors isis-oc;
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
@@ -115,9 +116,23 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms VMX {
+                                   releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors isis-oc;
+                                platforms VMX {
+                                   releases 22.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                         operating-system junosEvolved {
+                            sensors isis-oc;
                             products PTX {
                                 sensors isis-oc;
                                 platforms PTX10008 {

--- a/juniper_official/routing/collect-isis-lsdb-neighbsysid-v1.rule
+++ b/juniper_official/routing/collect-isis-lsdb-neighbsysid-v1.rule
@@ -92,32 +92,32 @@
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX240 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX304 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms VMX {
-                                   releases 22.2R3 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -125,7 +125,7 @@
                             products VMX {
                                 sensors isis-oc;
                                 platforms VMX {
-                                   releases 22.2R3 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -136,12 +136,12 @@
                             products PTX {
                                 sensors isis-oc;
                                 platforms PTX10008 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10016 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/collect-isis-lsdb-neighbsysid-v2.rule
+++ b/juniper_official/routing/collect-isis-lsdb-neighbsysid-v2.rule
@@ -105,27 +105,27 @@
                             products MX {
                                 sensors isis-oc;
                                 platforms MX240 {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX304 {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms VMX {
-                                   releases 23.2R2 {
+                                   releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -133,7 +133,7 @@
                             products VMX {
                                 sensors isis-oc;
                                 platforms VMX {
-                                   releases 23.2R3 {
+                                   releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -144,17 +144,17 @@
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7100-48L {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7509 {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -162,22 +162,22 @@
                             products PTX {
                                 sensors isis-oc;
                                 platforms PTX10001-36MR {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10008 {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10016 {
-                                    releases 23.2R2 {
+                                    releases 22.3R1 {
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/collect-isis-lsdb-neighbsysid-v2.rule
+++ b/juniper_official/routing/collect-isis-lsdb-neighbsysid-v2.rule
@@ -101,6 +101,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors isis-oc;
                             products MX {
                                 sensors isis-oc;
                                 platforms MX240 {
@@ -123,9 +124,23 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors isis-oc;
+                                platforms VMX {
+                                   releases 23.2R3 {
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                         operating-system junosEvolved {
+                            sensors isis-oc;
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {

--- a/juniper_official/routing/collect-isis-lsdb-subtlv.rule
+++ b/juniper_official/routing/collect-isis-lsdb-subtlv.rule
@@ -96,6 +96,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors isis-oc;
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
@@ -123,9 +124,23 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors isis-oc;
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                         operating-system junosEvolved {
+                            sensors isis-oc;
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {

--- a/juniper_official/routing/collect-isis-lsdb-subtlv.rule
+++ b/juniper_official/routing/collect-isis-lsdb-subtlv.rule
@@ -100,32 +100,32 @@
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX240 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX304 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms VMX {
-                                   releases 23.2R2 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -133,7 +133,7 @@
                             products VMX {
                                 sensors isis-oc;
                                 platforms VMX {
-                                   releases 23.2R2 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -144,17 +144,17 @@
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7100-48L {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms ACX7509 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -162,22 +162,22 @@
                             products PTX {
                                 sensors isis-oc;
                                 platforms PTX10001-36MR {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10008 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10016 {
-                                    releases 23.2R2 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/collect-isis-lsdb-tlv.rule
+++ b/juniper_official/routing/collect-isis-lsdb-tlv.rule
@@ -184,6 +184,36 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms MX2008 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2010 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms MX2020 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }			
                                 platforms VMX {
                                    releases 23.4R1 {
                                         sensors isis-oc-junos;
@@ -208,10 +238,129 @@
                                     }
                                 }
                             }
+                            products JNP {
+                                sensors isis-oc-junos;							
+                                platforms JNP10004 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10008 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms JNP10016 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }
+                            products PTX {
+                                sensors isis-oc-junos;							
+                                platforms PTX10008 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products EX {
+                                sensors isis-oc-junos;							
+                                platforms EX4300-48MP {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms EX9204 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }								
+                            }
                         }
                         operating-system junosEvolved {
                             products ACX {
                                 sensors isis-oc-junos;
+                                platforms ACX7020 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }								
+                                }
+                                platforms ACX7020_AC {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms ACX7020_DC {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms ACX7024 {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }								
+                                }
+                                platforms ACX7024X {
+                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
                                 platforms ACX7100-32C {
                                    releases 23.4R1 {
                                         sensors isis-oc-junos;
@@ -224,6 +373,16 @@
                                 }
                                 platforms ACX7100-48L {
                                    releases 23.4R1 {
+                                        sensors isis-oc-junos;
+                                        release-support min-supported-release;
+                                    }
+                                    releases 20.2R1 {
+                                        sensors isis-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms ACX7348 {
+                                    releases 23.4R1 {
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }

--- a/juniper_official/routing/collect-isis-lsdb-tlv.rule
+++ b/juniper_official/routing/collect-isis-lsdb-tlv.rule
@@ -139,7 +139,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -149,7 +149,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -159,7 +159,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -169,7 +169,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -179,7 +179,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -189,7 +189,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -199,7 +199,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -209,7 +209,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -219,7 +219,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -232,7 +232,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -245,7 +245,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -255,7 +255,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -265,7 +265,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -278,7 +278,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -291,7 +291,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -301,7 +301,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -316,7 +316,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }								
@@ -326,7 +326,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -336,7 +336,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -346,7 +346,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }								
@@ -356,7 +356,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -366,7 +366,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -376,7 +376,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -386,7 +386,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -396,7 +396,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -409,7 +409,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -419,7 +419,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -429,7 +429,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }
@@ -439,7 +439,7 @@
                                         sensors isis-oc-junos;
                                         release-support min-supported-release;
                                     }
-                                    releases 20.2R1 {
+                                    releases 20.2R2 {
                                         sensors isis-oc;
                                         release-support min-supported-release;
                                     }

--- a/juniper_official/routing/collect-isis-lsp-retranx-v1.rule
+++ b/juniper_official/routing/collect-isis-lsp-retranx-v1.rule
@@ -61,6 +61,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors isis-oc;
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
@@ -88,9 +89,23 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms VMX {
+                                   releases 22.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors isis-oc;
+                                platforms VMX {
+                                   releases 22.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                         operating-system junosEvolved {
+                            sensors isis-oc;
                             products PTX {
                                 sensors isis-oc;
                                 platforms PTX10008 {

--- a/juniper_official/routing/collect-isis-lsp-retranx-v1.rule
+++ b/juniper_official/routing/collect-isis-lsp-retranx-v1.rule
@@ -65,32 +65,32 @@
                             products MX {
                                 sensors isis-oc;
                                 platforms MX204 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX240 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX304 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms VMX {
-                                   releases 22.2R2 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -98,7 +98,7 @@
                             products VMX {
                                 sensors isis-oc;
                                 platforms VMX {
-                                   releases 22.2R2 {
+                                   releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -109,12 +109,12 @@
                             products PTX {
                                 sensors isis-oc;
                                 platforms PTX10008 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10016 {
-                                    releases 22.2R3 {
+                                    releases 20.2R2 {
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/collect-isis-lsp-retranx-v2.rule
+++ b/juniper_official/routing/collect-isis-lsp-retranx-v2.rule
@@ -74,6 +74,7 @@
                 supported-devices {
                     juniper {
                         operating-system junos {
+                            sensors isis-oc;
                             products MX {
                                 sensors isis-oc;
                                 platforms MX240 {
@@ -96,9 +97,23 @@
                                         release-support min-supported-release;
                                     }
                                 }
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors isis-oc;
+                                platforms VMX {
+                                   releases 23.2R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                         operating-system junosEvolved {
+                            sensors isis-oc;
                             products ACX {
                                 sensors isis-oc;
                                 platforms ACX7100-32C {


### PR DESCRIPTION
- **Default Sensor Addition:**  
  - Added a default sensor for both Junos and JunosEvolved platforms to all single sensor path rules.

- **Multisensor Path Rule Update:**  
  - For the `collect-isis-lsdb-tlv.rule` (a multisensor path rule), added support for several additional platforms along with a default sensor.
