### PR TITLE
feat: default trigger to store ts-input-packets-pps ts-output-packets-pps to tsdb

### DIFF
--- a/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
@@ -32,6 +32,15 @@ healthbot {
                 type unsigned-integer;
                 description "PFE output stats";
             }
+            field ts-drop-packets-pps {
+                formula {
+                    eval {
+                        expression "max(($ts-input-packets-pps - $ts-output-packets-pps), 0)";
+                    }
+                }
+                type unsigned-integer;
+                description "PFE drop stats";				
+            }
             field fpc {
                 sensor pfestats {
                     path "/components/component/@name";

--- a/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
@@ -32,15 +32,6 @@ healthbot {
                 type unsigned-integer;
                 description "PFE output stats";
             }
-            field ts-drop-packets-pps {
-                formula {
-                    eval {
-                        expression "($ts-input-packets-pps - $ts-output-packets-pps) * (($ts-input-packets-pps - $ts-output-packets-pps) > 0)";
-                    }
-                }
-                type unsigned-integer;
-                description "PFE drop stats";				
-            }
             field fpc {
                 sensor pfestats {
                     path "/components/component/@name";
@@ -56,7 +47,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$ts-input-packets-pps $ts-output-packets-pps $ts-drop-packets-pps";
+                            message "$ts-input-packets-pps $ts-output-packets-pps";
                         }
                     }
                 }

--- a/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
@@ -56,7 +56,7 @@ healthbot {
                     then {
                         stats {
                             color green;
-                            message "$ts-input-packets-pps $ts-output-packets-pps";
+                            message "$ts-input-packets-pps $ts-output-packets-pps $ts-drop-packets-pps";
                         }
                     }
                 }

--- a/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
@@ -54,7 +54,7 @@ healthbot {
                 frequency 1offset;
                 term ts-input-output-packets-pps {
                     then {
-                        stats {
+                        status {
                             color green;
                             message "$ts-input-packets-pps $ts-output-packets-pps $ts-drop-packets-pps";
                         }

--- a/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
@@ -39,6 +39,19 @@ healthbot {
                 type string;
                 description "FPC name";
             }
+            trigger pfe-input-output-stats {
+                synopsis "PFE input output stats KPI";
+                description "Default trigger to move pfe-stats KPI to tsdb";
+                frequency 1offset;
+                term ts-input-output-packets-pps {
+                    then {
+                        stats {
+                            color green;
+                            message "$ts-input-packets-pps $ts-output-packets-pps";
+                        }
+                    }
+                }
+            }
 	    rule-properties {
               version 1;
               contributor juniper;

--- a/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
+++ b/juniper_official/Solutions/Traffic-Blackhole/pfe-stats.rule
@@ -35,7 +35,7 @@ healthbot {
             field ts-drop-packets-pps {
                 formula {
                     eval {
-                        expression "max(($ts-input-packets-pps - $ts-output-packets-pps), 0)";
+                        expression "($ts-input-packets-pps - $ts-output-packets-pps) * (($ts-input-packets-pps - $ts-output-packets-pps) > 0)";
                     }
                 }
                 type unsigned-integer;


### PR DESCRIPTION
Added a default trigger to store ts-input-packets-pps, ts-output-packets-pps and ts-drop-packets-pps in TSDB