### PR TITLE
 Update collect-rsvp-stats.rule to support Cisco

### DIFF
--- a/juniper_official/routing/collect-rsvp-cfg.rule
+++ b/juniper_official/routing/collect-rsvp-cfg.rule
@@ -3,23 +3,29 @@
  *
  * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
  *
- * Two input control detection
+ * Four input control detection
  *
- *   1) input-lsp-name, is a regular expression that matches the lsp name
+ *   1) inp-lsp-signaled-name, is a regular expression that matches the lsp signaled name
  *      that you would like to monitor.  By default it's '.*', which matches
  *      all lsps. Use something like 'Silver*' to match only lsp names starting
  *      with 'Silver'. 
- *   2) input-cisco-tunnel-te-name, is a regular expression that matches the 
+ *   2) inp-lsp-name, is a regular expression that matches the 
  *      Cisco RSVP LSP tunnel-te interface name. By default it's 'tunnel-te.*', which matches
  *      all Cisco RSVP LSP/interfaces. Use something like 'tunnel-te1*' to match only lsp names starting
- *      with 'tunnel-te1'. 
+ *      with 'tunnel-te1'.
+ *
+ *   3) inp-rule-type, indicates the type of rule, either it is a normal traffic stats collection rule
+ *      in which case nothing is set or it is reference rule, by default the value is set to "reference".
+ *
+ *   4) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
+ *      rule deployment based on device. 
  *
  */
  healthbot {
     topic routing.mpls {
         rule collect-rsvp-cfg {
             keys [ lsp-name ];
-            description "Collects LSP name periodically";
+            description "Collects LSP config values periodically";
             sensor cisco-oc-lsp-cfg {
                 description "Cisco open-config LSP sensor definition";
                 open-config {
@@ -29,7 +35,7 @@
             }
             field lsp-name {
                 sensor cisco-oc-lsp-cfg {
-                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/@tunnel-name =~ /{{input-cisco-tunnel-te-name}}/";
+                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/@tunnel-name =~ /{{inp-lsp-name}}/";
                     path "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/@tunnel-name";
                 }
                 type string;
@@ -37,30 +43,44 @@
             }
             field lsp-signaled-name {
                 sensor cisco-oc-lsp-cfg {
-                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/signaled-name =~ /{{input-lsp-name}}/";
+                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/signaled-name =~ /{{inp-lsp-signaled-name}}/";
                     path "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/signaled-name";
                 }
                 type string;
                 description "LSP signaled name to be monitored";
             }
             field rule-type {
-                sensor cisco-oc-lsp-cfg {
-                    path cisco_rsvp_cfg_reference_rule_type_dummy_path;
-                    data-if-missing {
-                        value "reference";
-                    }
+                constant {
+                    value "{{inp-rule-type}}";
                 }
                 type string;
                 description "Type of the rule";
-            }
-            variable input-lsp-name {
+            }             
+            field device-vendor {
+                constant {
+                    value "{{inp-device-vendor}}";
+                }
+                type string;                
+                description "Indicates device vendor";
+            }            
+            variable inp-lsp-signaled-name {
                 value .*;
                 description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
                 type string;
             }
-            variable input-cisco-tunnel-te-name {
+            variable inp-lsp-name {
                 value tunnel-te.*;
                 description "Cisco RSVP LSPs are available as tunnel-te interfaces, need to prefix tunnel-te to all interface/tunnel name fields, eg 'tunnel-te10.*|tunnel-te300.*'";
+                type string;
+            }
+            variable inp-rule-type {
+                value reference;
+                description "Contains the value of the rule type";
+                type string;
+            }
+            variable inp-device-vendor {
+                value "";
+                description "Contains the name of the device vendor";
                 type string;
             }
             rule-properties {
@@ -79,7 +99,6 @@
                                 platforms "XRV Appliance" {
                                     sensors cisco-oc-lsp-cfg;
                                     releases 7.5.1 {
-                                        sensors cisco-oc-lsp-cfg;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -88,7 +107,6 @@
                                 platforms "XRv 9000" {
                                     sensors cisco-oc-lsp-cfg;
                                     releases 7.5.1 {
-                                        sensors cisco-oc-lsp-cfg;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -97,14 +115,12 @@
                                 platforms "NCS-5504" {
                                     sensors cisco-oc-lsp-cfg;
                                     releases 7.5.1 {
-                                        sensors cisco-oc-lsp-cfg;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms "NCS-5508" {
                                     sensors cisco-oc-lsp-cfg;
                                     releases 7.5.1 {
-                                        sensors cisco-oc-lsp-cfg;
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/routing/collect-rsvp-cfg.rule
+++ b/juniper_official/routing/collect-rsvp-cfg.rule
@@ -1,0 +1,118 @@
+/*
+ * Collect RSVP LSP name for pathfinder dynamic topology.
+ *
+ * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
+ *
+ * Two input control detection
+ *
+ *   1) input-lsp-name, is a regular expression that matches the lsp name
+ *      that you would like to monitor.  By default it's '.*', which matches
+ *      all lsps. Use something like 'Silver*' to match only lsp names starting
+ *      with 'Silver'. 
+ *   2) input-cisco-tunnel-te-name, is a regular expression that matches the 
+ *      Cisco RSVP LSP tunnel-te interface name. By default it's 'tunnel-te.*', which matches
+ *      all Cisco RSVP LSP/interfaces. Use something like 'tunnel-te1*' to match only lsp names starting
+ *      with 'tunnel-te1'. 
+ *
+ */
+ healthbot {
+    topic routing.mpls {
+        rule collect-rsvp-cfg {
+            keys [ lsp-name ];
+            description "Collects LSP name periodically";
+            sensor cisco-oc-lsp-cfg {
+                description "Cisco open-config LSP sensor definition";
+                open-config {
+                    sensor-name "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head";
+                    frequency 60s;
+                }
+            }
+            field lsp-name {
+                sensor cisco-oc-lsp-cfg {
+                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/@tunnel-name =~ /{{input-cisco-tunnel-te-name}}/";
+                    path "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/@tunnel-name";
+                }
+                type string;
+                description "LSP name to be monitored";
+            }
+            field lsp-signaled-name {
+                sensor cisco-oc-lsp-cfg {
+                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/signaled-name =~ /{{input-lsp-name}}/";
+                    path "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/signaled-name";
+                }
+                type string;
+                description "LSP signaled name to be monitored";
+            }
+            field rule-type {
+                sensor cisco-oc-lsp-cfg {
+                    path cisco_rsvp_cfg_reference_rule_type_dummy_path;
+                    data-if-missing {
+                        value "reference";
+                    }
+                }
+                type string;
+                description "Type of the rule";
+            }
+            variable input-lsp-name {
+                value .*;
+                description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
+                type string;
+            }
+            variable input-cisco-tunnel-te-name {
+                value tunnel-te.*;
+                description "Cisco RSVP LSPs are available as tunnel-te interfaces, need to prefix tunnel-te to all interface/tunnel name fields, eg 'tunnel-te10.*|tunnel-te300.*'";
+                type string;
+            }
+            rule-properties {
+                version 1;
+                contributor juniper;
+                category basic;
+                is-scaling-rule {
+                    description "Fields:lsp-name ; Directly impacted by number of lsp's running in each network device";
+                }
+                supported-healthbot-version 2.1.0;
+                supported-devices {  
+                    other-vendor cisco {
+                        vendor-name cisco;
+                        operating-systems iosxr {  
+                            products "XRV Appliance" {
+                                platforms "XRV Appliance" {
+                                    sensors cisco-oc-lsp-cfg;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }                           
+                            products "XRv" {
+                                platforms "XRv 9000" {
+                                    sensors cisco-oc-lsp-cfg;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }                            
+                            products "NCS" {
+                                platforms "NCS-5504" {
+                                    sensors cisco-oc-lsp-cfg;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-5508" {
+                                    sensors cisco-oc-lsp-cfg;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }                    
+                }
+            }
+        }
+    }
+}

--- a/juniper_official/routing/collect-rsvp-cfg.rule
+++ b/juniper_official/routing/collect-rsvp-cfg.rule
@@ -3,22 +3,16 @@
  *
  * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
  *
- * Four input control detection
+ * Two input control detection
  *
- *   1) inp-lsp-signaled-name, is a regular expression that matches the lsp signaled name
+ *   1) input-lsp-signaled-name, is a regular expression that matches the lsp signaled name
  *      that you would like to monitor.  By default it's '.*', which matches
  *      all lsps. Use something like 'Silver*' to match only lsp names starting
  *      with 'Silver'. 
- *   2) inp-lsp-name, is a regular expression that matches the 
+ *   2) input-lsp-name, is a regular expression that matches the 
  *      Cisco RSVP LSP tunnel-te interface name. By default it's 'tunnel-te.*', which matches
  *      all Cisco RSVP LSP/interfaces. Use something like 'tunnel-te1*' to match only lsp names starting
  *      with 'tunnel-te1'.
- *
- *   3) inp-rule-type, indicates the type of rule, either it is a normal traffic stats collection rule
- *      in which case nothing is set or it is reference rule, by default the value is set to "reference".
- *
- *   4) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
- *      rule deployment based on device. 
  *
  */
  healthbot {
@@ -35,7 +29,7 @@
             }
             field lsp-name {
                 sensor cisco-oc-lsp-cfg {
-                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/@tunnel-name =~ /{{inp-lsp-name}}/";
+                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/@tunnel-name =~ /{{input-lsp-name}}/";
                     path "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/@tunnel-name";
                 }
                 type string;
@@ -43,54 +37,23 @@
             }
             field lsp-signaled-name {
                 sensor cisco-oc-lsp-cfg {
-                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/signaled-name =~ /{{inp-lsp-signaled-name}}/";
+                    where "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/signaled-name =~ /{{input-lsp-signaled-name}}/";
                     path "Cisco-IOS-XR-mpls-te-oper:/mpls-te/p2p-p2mp-tunnel/tunnel-heads/tunnel-head/signaled-name";
                 }
                 type string;
                 description "LSP signaled name to be monitored";
-            }
-            field rule-type {
-                constant {
-                    value "{{inp-rule-type}}";
-                }
-                type string;
-                description "Type of the rule";
-            }             
-            field device-vendor {
-                constant {
-                    value "{{inp-device-vendor}}";
-                }
-                type string;                
-                description "Indicates device vendor";
             }            
-            variable inp-lsp-signaled-name {
+            variable input-lsp-signaled-name {
                 value .*;
                 description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
                 type string;
             }
-            variable inp-lsp-name {
+            variable input-lsp-name {
                 value tunnel-te.*;
                 description "Cisco RSVP LSPs are available as tunnel-te interfaces, need to prefix tunnel-te to all interface/tunnel name fields, eg 'tunnel-te10.*|tunnel-te300.*'";
                 type string;
             }
-            variable inp-rule-type {
-                value reference;
-                description "Contains the value of the rule type";
-                type string;
-            }
-            variable inp-device-vendor {
-                value "";
-                description "Contains the name of the device vendor";
-                type string;
-            }
             rule-properties {
-                version 1;
-                contributor juniper;
-                category basic;
-                is-scaling-rule {
-                    description "Fields:lsp-name ; Directly impacted by number of lsp's running in each network device";
-                }
-                supported-healthbot-version 2.1.0;
                 supported-devices {  
                     other-vendor cisco {
                         vendor-name cisco;

--- a/juniper_official/routing/collect-rsvp-stats.rule
+++ b/juniper_official/routing/collect-rsvp-stats.rule
@@ -4,16 +4,20 @@
  * Req 60: https://paragon-automation.atlassian.net/browse/REQ-60
  * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
  *
- * Two input control detection
+ * Four input control detection
  *
- *   1) input-lsp-name, is a regular expression that matches the lsp name
+ *   1) inp-lsp-name, is a regular expression that matches the lsp name
  *      that you would like to monitor.  By default it's '.*', which matches
  *      all lsps. Use something like 'Silver*' to match only lsp names starting
  *      with 'Silver'. 
- *   2) input-cisco-tunnel-te-name, is a regular expression that matches the 
- *      Cisco RSVP LSP traffic and signalling entries. By default it's 'tunnel-te.*', which matches
- *      all Cisco RSVP LSP/interfaces. Use something like 'tunnel-te1*' to match only lsp names starting
- *      with 'tunnel-te1'. 
+ *   2) inp-referenced-rules, must be strings that contain the names of the rules to
+ *      to be referred to evaluate the reference data.
+ *
+ *   3) inp-reference-rule-expression-name, is a string having the golang Common Expression Language 
+ *      compatible expression based on the rule and their fields to be used for reference field value evaluation.
+ *
+ *   4) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
+ *      rule deployment based on device.  
  *
  */
  healthbot {
@@ -37,63 +41,36 @@
             }
             field lsp-name {
                 sensor lsp {
-                    where "/mpls/lsps/constrained-path/tunnels/tunnel/@name =~ /{{input-lsp-name}}/";
+                    where "/mpls/lsps/constrained-path/tunnels/tunnel/@name =~ /{{inp-lsp-name}}/";
                     path "/mpls/lsps/constrained-path/tunnels/tunnel/@name";
                 }
                 sensor cisco-oc-lsp-traffic {
-                    where "/interfaces/interface/@name =~ /{{input-cisco-tunnel-te-name}}/";
+                    where "/interfaces/interface/@name =~ /{{inp-lsp-name}}/";
                     path "/interfaces/interface/@name";
                 }
                 type string;
                 description "LSP name to be monitored";
-            }
-            field vendor {
-                sensor lsp {
-                    path juniper_rsvp_lsp_vendor_dummy_path;
-                    data-if-missing {
-                        value "juniper";
-                    }
-                }
-                sensor cisco-oc-lsp-traffic {
-                    path cisco_traffic_vendor_dummy_path;
-                    data-if-missing {
-                        value "cisco";
-                    }              
-                }
-                type string;                
-                description "Indicates telemetry vendor";
             }     
             field referenced-rules {
-                sensor lsp {
-                    path juniper_rsvp_lsp_reference_rule_path;
-                    data-if-missing {
-                        value "none";
-                    }
-                }
-                sensor cisco-oc-lsp-traffic {
-                    path cisco_traffic_referenced_rules_dummy_path;
-                    data-if-missing {
-                        value "collect-rsvp-cfg";
-                    }              
-                }                
+                constant {
+                    value "{{inp-referenced-rules}}";
+                }              
                 type string;                
                 description "Indicates rules to be referenced to computed the data set for this rule";
             } 
-            field reference-rule-expression {
-                sensor lsp {
-                    path juniper_rsvp_lsp_reference_rule_expression_dummy_path;
-                    data-if-missing {
-                        value "none";
-                    }
-                }
-                sensor cisco-oc-lsp-traffic {
-                    path cisco_rsvp_lsp_reference_rule_expression_dummy_path;
-                    data-if-missing {
-                        value "collect-rsvp-stats.vendor == \"cisco\" && collect-rsvp-stats.lsp-name == collect-rsvp-cfg.lsp-name && abs(collect-rsvp-stats.__device_timestamp__ - collect-rsvp-cfg.__device_timestamp__) < env_cfg[\"ACTIVE_DEVICE_CFG_INTERVAL\"] ? {\"lsp-name\": collect-rsvp-cfg.lsp-signaled-name}:null";
-                    }
+            field reference-rule-expression-name {
+                constant {
+                    value "{{inp-reference-rule-expression-name}}";
                 }
                 type string;                
                 description "Indicates the expression to be used to compute the data set for this rule";
+            }             
+            field device-vendor {
+                constant {
+                    value "{{inp-device-vendor}}";
+                }
+                type string;                
+                description "Indicates device vendor";
             }
             field lsp-stats-bps {
                 formula {
@@ -132,14 +109,24 @@
                 }
                 type integer;
             }
-            variable input-lsp-name {
+            variable inp-lsp-name {
                 value .*;
                 description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
                 type string;
             }
-            variable input-cisco-tunnel-te-name {
-                value tunnel-te.*;
-                description "Cisco RSVP LSPs are available as tunnel-te interfaces, need to prefix tunnel-te to all interface/tunnel name fields, eg 'tunnel-te10.*|tunnel-te300.*'";
+            variable inp-referenced-rules {
+                value none;
+                description "Contains the list of rules which will be referred to construct the value for some fields at the client/consumer side, must be a rule name and accepts multple rule name in a comma seperted list, eg 'collect-rsvp-cfg,collect-sr-sp-stats'";
+                type string;
+            }
+            variable inp-reference-rule-expression-name {
+                value none;
+                description "Contains the expression to be used to evaluate and extract the necessary data from the referenced rules";
+                type string;
+            }            
+            variable inp-device-vendor {
+                value "";
+                description "Contains the name of the device vendor";
                 type string;
             }
             rule-properties {
@@ -157,56 +144,48 @@
                                 platforms MX2010 {
                                     sensors lsp;
                                     releases 22.4R1 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020 {
                                     sensors lsp;
                                     releases 22.4R1 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10004 {
                                     sensors lsp;
                                     releases 22.3R1 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
                                     sensors lsp;
                                     releases 22.3R1 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
                                     sensors lsp;
                                     releases 22.3R1 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX240 {
                                     sensors lsp;
                                     releases 22.4R1 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
                                     sensors lsp;
                                     releases 22.4R1 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
                                     sensors lsp;
                                     releases 22.4R1 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -217,28 +196,24 @@
                                 platforms PTX10001 {
                                     sensors lsp;
                                     releases 22.2R3 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
                                     sensors lsp;
                                     releases 22.2R3 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10008 {
                                     sensors lsp;
                                     releases 22.2R3 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10016 {
                                     sensors lsp;
                                     releases 22.2R3 {
-                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }								
@@ -252,7 +227,6 @@
                                 platforms "XRV Appliance" {
                                     sensors cisco-oc-lsp-traffic;
                                     releases 7.5.1 {
-                                        sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -261,7 +235,6 @@
                                 platforms "XRv 9000" {
                                     sensors cisco-oc-lsp-traffic;
                                     releases 7.5.1 {
-                                        sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -270,14 +243,12 @@
                                 platforms "NCS-5504" {
                                     sensors cisco-oc-lsp-traffic;
                                     releases 7.5.1 {
-                                        sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms "NCS-5508" {
                                     sensors cisco-oc-lsp-traffic;
                                     releases 7.5.1 {
-                                        sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/routing/collect-rsvp-stats.rule
+++ b/juniper_official/routing/collect-rsvp-stats.rule
@@ -2,13 +2,18 @@
  * Collect RSVP LSP traffic statistics for pathfinder dynamic topology.
  *
  * Req 60: https://paragon-automation.atlassian.net/browse/REQ-60
+ * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
  *
- * One input control detection
+ * Two input control detection
  *
  *   1) input-lsp-name, is a regular expression that matches the lsp name
  *      that you would like to monitor.  By default it's '.*', which matches
  *      all lsps. Use something like 'Silver*' to match only lsp names starting
  *      with 'Silver'. 
+ *   2) input-cisco-tunnel-te-name, is a regular expression that matches the 
+ *      Cisco RSVP LSP traffic and signalling entries. By default it's 'tunnel-te.*', which matches
+ *      all Cisco RSVP LSP/interfaces. Use something like 'tunnel-te1*' to match only lsp names starting
+ *      with 'tunnel-te1'. 
  *
  */
  healthbot {
@@ -17,8 +22,16 @@
             keys [ lsp-name ];
             description "Collects LSP stats periodically";
             sensor lsp {
+                description "Juniper native open-config LSP sensor definition";                
                 open-config {
                     sensor-name /junos/services/label-switched-path/usage/;
+                    frequency 60s;
+                }
+            }
+            sensor cisco-oc-lsp-traffic {
+                description "Cisco open-config LSP sensor definition";
+                open-config {
+                    sensor-name /interfaces/interface/state/counters;
                     frequency 60s;
                 }
             }
@@ -27,8 +40,60 @@
                     where "/mpls/lsps/constrained-path/tunnels/tunnel/@name =~ /{{input-lsp-name}}/";
                     path "/mpls/lsps/constrained-path/tunnels/tunnel/@name";
                 }
+                sensor cisco-oc-lsp-traffic {
+                    where "/interfaces/interface/@name =~ /{{input-cisco-tunnel-te-name}}/";
+                    path "/interfaces/interface/@name";
+                }
                 type string;
                 description "LSP name to be monitored";
+            }
+            field vendor {
+                sensor lsp {
+                    path juniper_rsvp_lsp_vendor_dummy_path;
+                    data-if-missing {
+                        value "juniper";
+                    }
+                }
+                sensor cisco-oc-lsp-traffic {
+                    path cisco_traffic_vendor_dummy_path;
+                    data-if-missing {
+                        value "cisco";
+                    }              
+                }
+                type string;                
+                description "Indicates telemetry vendor";
+            }     
+            field referenced-rules {
+                sensor lsp {
+                    path juniper_rsvp_lsp_reference_rule_path;
+                    data-if-missing {
+                        value "none";
+                    }
+                }
+                sensor cisco-oc-lsp-traffic {
+                    path cisco_traffic_referenced_rules_dummy_path;
+                    data-if-missing {
+                        value "collect-rsvp-cfg";
+                    }              
+                }                
+                type string;                
+                description "Indicates rules to be referenced to computed the data set for this rule";
+            } 
+            field reference-rule-expression {
+                sensor lsp {
+                    path juniper_rsvp_lsp_reference_rule_expression_dummy_path;
+                    data-if-missing {
+                        value "none";
+                    }
+                }
+                sensor cisco-oc-lsp-traffic {
+                    path cisco_rsvp_lsp_reference_rule_expression_dummy_path;
+                    data-if-missing {
+                        value "collect-rsvp-stats.vendor == \"cisco\" && collect-rsvp-stats.lsp-name == collect-rsvp-cfg.lsp-name && abs(collect-rsvp-stats.__device_timestamp__ - collect-rsvp-cfg.__device_timestamp__) < env_cfg[\"ACTIVE_DEVICE_CFG_INTERVAL\"] ? {\"lsp-name\": collect-rsvp-cfg.lsp-signaled-name}:null";
+                    }
+                }
+                type string;                
+                description "Indicates the expression to be used to compute the data set for this rule";
             }
             field lsp-stats-bps {
                 formula {
@@ -43,12 +108,18 @@
                 sensor lsp {
                     path /mpls/lsps/constrained-path/tunnels/tunnel/state/counters/bytes;
                 }
+                sensor cisco-oc-lsp-traffic {
+                    path /interfaces/interface/state/counters/out-octets;
+                }
                 type integer;
                 description "LSP bytes counter";
             }
             field lsp-stats-packets {
                 sensor lsp {
                     path /mpls/lsps/constrained-path/tunnels/tunnel/state/counters/packets;
+                }
+                sensor cisco-oc-lsp-traffic {
+                    path /interfaces/interface/state/counters/out-pkts;
                 }
                 type integer;
                 description "LSP packet counter";
@@ -66,6 +137,11 @@
                 description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
                 type string;
             }
+            variable input-cisco-tunnel-te-name {
+                value tunnel-te.*;
+                description "Cisco RSVP LSPs are available as tunnel-te interfaces, need to prefix tunnel-te to all interface/tunnel name fields, eg 'tunnel-te10.*|tunnel-te300.*'";
+                type string;
+            }
             rule-properties {
                 version 1;
                 contributor juniper;
@@ -79,42 +155,58 @@
                         operating-system junos {
                             products MX {
                                 platforms MX2010 {
-                                    releases 19.2R1 {
+                                    sensors lsp;
+                                    releases 22.4R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020 {
-                                    releases 19.2R1 {
+                                    sensors lsp;
+                                    releases 22.4R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10004 {
+                                    sensors lsp;
                                     releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10008 {
+                                    sensors lsp;
                                     releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX10016 {
+                                    sensors lsp;
                                     releases 22.3R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX240 {
-                                    releases 19.2R1 {
+                                    sensors lsp;
+                                    releases 22.4R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
-                                    releases 19.2R1 {
+                                    sensors lsp;
+                                    releases 22.4R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
-                                    releases 19.2R1 {
+                                    sensors lsp;
+                                    releases 22.4R1 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -123,25 +215,72 @@
                         operating-system junosEvolved {
                             products PTX {
                                 platforms PTX10001 {
+                                    sensors lsp;
                                     releases 22.2R3 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
+                                    sensors lsp;
                                     releases 22.2R3 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10008 {
+                                    sensors lsp;
                                     releases 22.2R3 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10016 {
+                                    sensors lsp;
                                     releases 22.2R3 {
+                                        sensors lsp;
                                         release-support min-supported-release;
                                     }
                                 }								
+                            }
+                        }
+                    }                    
+                    other-vendor cisco {
+                        vendor-name cisco;
+                        operating-systems iosxr {     
+                            products "XRV Appliance" {
+                                platforms "XRV Appliance" {
+                                    sensors cisco-oc-lsp-traffic;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }                             
+                            products "XRv" {
+                                platforms "XRv 9000" {
+                                    sensors cisco-oc-lsp-traffic;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }                             
+                            products "NCS" {
+                                platforms "NCS-5504" {
+                                    sensors cisco-oc-lsp-traffic;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-5508" {
+                                    sensors cisco-oc-lsp-traffic;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                     }

--- a/juniper_official/routing/collect-rsvp-stats.rule
+++ b/juniper_official/routing/collect-rsvp-stats.rule
@@ -4,20 +4,12 @@
  * Req 60: https://paragon-automation.atlassian.net/browse/REQ-60
  * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
  *
- * Four input control detection
+ * One input control detection
  *
- *   1) inp-lsp-name, is a regular expression that matches the lsp name
+ *   1) input-lsp-name, is a regular expression that matches the lsp name
  *      that you would like to monitor.  By default it's '.*', which matches
  *      all lsps. Use something like 'Silver*' to match only lsp names starting
  *      with 'Silver'. 
- *   2) inp-referenced-rules, must be strings that contain the names of the rules to
- *      to be referred to evaluate the reference data.
- *
- *   3) inp-reference-rule-expression-name, is a string having the golang Common Expression Language 
- *      compatible expression based on the rule and their fields to be used for reference field value evaluation.
- *
- *   4) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
- *      rule deployment based on device.  
  *
  */
  healthbot {
@@ -41,36 +33,15 @@
             }
             field lsp-name {
                 sensor lsp {
-                    where "/mpls/lsps/constrained-path/tunnels/tunnel/@name =~ /{{inp-lsp-name}}/";
+                    where "/mpls/lsps/constrained-path/tunnels/tunnel/@name =~ /{{input-lsp-name}}/";
                     path "/mpls/lsps/constrained-path/tunnels/tunnel/@name";
                 }
                 sensor cisco-oc-lsp-traffic {
-                    where "/interfaces/interface/@name =~ /{{inp-lsp-name}}/";
+                    where "/interfaces/interface/@name =~ /{{input-lsp-name}}/";
                     path "/interfaces/interface/@name";
                 }
                 type string;
                 description "LSP name to be monitored";
-            }     
-            field referenced-rules {
-                constant {
-                    value "{{inp-referenced-rules}}";
-                }              
-                type string;                
-                description "Indicates rules to be referenced to computed the data set for this rule";
-            } 
-            field reference-rule-expression-name {
-                constant {
-                    value "{{inp-reference-rule-expression-name}}";
-                }
-                type string;                
-                description "Indicates the expression to be used to compute the data set for this rule";
-            }             
-            field device-vendor {
-                constant {
-                    value "{{inp-device-vendor}}";
-                }
-                type string;                
-                description "Indicates device vendor";
             }
             field lsp-stats-bps {
                 formula {
@@ -109,24 +80,9 @@
                 }
                 type integer;
             }
-            variable inp-lsp-name {
+            variable input-lsp-name {
                 value .*;
                 description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
-                type string;
-            }
-            variable inp-referenced-rules {
-                value none;
-                description "Contains the list of rules which will be referred to construct the value for some fields at the client/consumer side, must be a rule name and accepts multple rule name in a comma seperted list, eg 'collect-rsvp-cfg,collect-sr-sp-stats'";
-                type string;
-            }
-            variable inp-reference-rule-expression-name {
-                value none;
-                description "Contains the expression to be used to evaluate and extract the necessary data from the referenced rules";
-                type string;
-            }            
-            variable inp-device-vendor {
-                value "";
-                description "Contains the name of the device vendor";
                 type string;
             }
             rule-properties {
@@ -143,13 +99,13 @@
                             products MX {
                                 platforms MX2010 {
                                     sensors lsp;
-                                    releases 22.4R1 {
+                                    releases 19.2R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020 {
                                     sensors lsp;
-                                    releases 22.4R1 {
+                                    releases 19.2R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -173,19 +129,19 @@
                                 }
                                 platforms MX240 {
                                     sensors lsp;
-                                    releases 22.4R1 {
+                                    releases 19.2R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX480 {
                                     sensors lsp;
-                                    releases 22.4R1 {
+                                    releases 19.2R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX960 {
                                     sensors lsp;
-                                    releases 22.4R1 {
+                                    releases 19.2R1 {
                                         release-support min-supported-release;
                                     }
                                 }


### PR DESCRIPTION
The requirement is to collect the RSVP LSP traffic statistics from Cisco devices, for which the existing rule "collect-rsvp-stats.rule" has been updated with Cisco specific openconfig sensor and platform/models

The Cisco RSVP LSP traffic is received with the interface name and not the actual name of the LSP, this data is available as signaled name in a different sensor, hence a new rule "collect-rsv-cfg.rule" has been added.
The data from both the rule have to be correlated in the traffic stats consumer application, hence the rule has some fields with dummy paths to allow for the application to be able to correlate the data from the two sensors.

Note:

- Testing is done on virtual machine having the IOS-XR 7.5.1, 7.8.1 and 24.3.1
- The rule has both "XRV Appliance" and "XRv" because EMS has issues supporting "XRv"