### PR TITLE
 Update collect-sr-color-lsp-stats.rule to support Cisco

### DIFF
--- a/juniper_official/routing/collect-sr-color-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-color-lsp-stats.rule
@@ -2,24 +2,26 @@
  * Collect SR Color LSP traffic statistics for pathfinder dynamic topology.
  *
  * Req 1936: https://paragon-automation.atlassian.net/browse/REQ-1936
- * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
  *
- * Two input control detection
+ * Three input control detection
  *
- *   1) input-to-address, is a regular expression that matches the SR color lsp 
+ *   1) inp-lsp-destination, is a regular expression that matches the SR color lsp 
  *      destination address that must be monitored.  By default it's '.*', which matches
  *      all destination address. Use something like '11.0.0*' to match only destination 
  *      address starting with '11.0.0'.  
  *
- *   2) input-color, is a regular expression that matches the color of SR color lsp 
+ *   2) inp-lsp-color, is a regular expression that matches the color of SR color lsp 
  *      that must be monitored.  By default it's '.*', which matches
  *      all colors. Use something like '10*' to match LSPs starting with color '10'.
+ *
+ *   3) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
+ *      rule deployment based on device.  
  *
  */
 healthbot {
     topic routing.spring {
         rule collect-sr-color-lsp-stats {
-            keys [ lsp-name lsp-cfg-name ];
+            keys [ lsp-name ];
             description "Collects SR color LSP stats periodically";
             sensor jnpr-sr-color-lsp {
                 open-config {
@@ -27,38 +29,19 @@ healthbot {
                     frequency 60s;
                 }
             }
-            sensor cisco-oc-sr-color-lsp {
-                description "Cisco open-config SR Color LSP sensor definition";
-                open-config {
-                    sensor-name /interfaces/interface/state/counters;
-                    frequency 60s;
-                }
-            }
             field lsp-destination {
                 sensor jnpr-sr-color-lsp {
-                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address =~ /{{input-to-address}}/";
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address =~ /{{inp-lsp-destination}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address";
-                } 
-                sensor cisco-oc-sr-color-lsp {
-                    path cisco_lsp_destination_dummy_path;
-                    data-if-missing {
-                        value "cisco_sr_lsp_destination";
-                    }
-                }               
+                }                
                 type string;
                 description "LSP destination in case of SR color LSP and name in case of SR LSP";
             }
             field lsp-color {
                 sensor jnpr-sr-color-lsp {
-                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color =~ /{{input-color}}/";
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color =~ /{{inp-lsp-color}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color";
-                }
-                sensor cisco-oc-sr-color-lsp {
-                    path cisco_lsp_color_dummy_path;
-                    data-if-missing {
-                        value "cisco_sr_lsp_color";
-                    }
-                }                 
+                }                
                 type string;
                 description "Color of the LSP being monitored";
             }
@@ -66,18 +49,12 @@ healthbot {
                 sensor jnpr-sr-color-lsp {
                     path /mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/state/counters/bytes;
                 }
-                sensor cisco-oc-sr-color-lsp {
-                    path /interfaces/interface/state/counters/out-octets;
-                }
                 type integer;
                 description "LSP bytes counter";
             }      
             field lsp-stats-packets {
                 sensor jnpr-sr-color-lsp {
                     path /mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/state/counters/packets;
-                }
-                sensor cisco-oc-sr-color-lsp {
-                    path /interfaces/interface/state/counters/out-pkts;
                 }
                 type integer;
                 description "LSP packet counter";
@@ -89,37 +66,7 @@ healthbot {
                     }
                 }
                 type string;
-                description "LSP computed name";
-            }
-            field lsp-cfg-name {
-                sensor jnpr-sr-color-lsp {
-                    path juniper_interface_name_dummy_path;
-                    data-if-missing {
-                        value "jnpr_sr_lsp";
-                    }
-                }
-                sensor cisco-oc-sr-color-lsp {
-                    where "/interfaces/interface/@name =~ /{{input-cisco-sr-color-lsp-name}}/";
-                    path "/interfaces/interface/@name";
-                }                
-                type string;
-                description "Interface name";
-            }
-            field vendor {
-                sensor jnpr-sr-color-lsp {
-                    path juniper_sr_color_lsp_vendor_dummy_path;
-                    data-if-missing {
-                        value "juniper";
-                    }
-                }
-                sensor cisco-oc-sr-color-lsp {
-                    path cisco_sr_color_lsp_vendor_dummy_path;
-                    data-if-missing {
-                        value "cisco";
-                    }              
-                }
-                type string;                
-                description "Indicates telemetry vendor";
+                description "LSP name";
             }
             field lsp-stats-bps {
                 formula {
@@ -139,20 +86,27 @@ healthbot {
                 }
                 type integer;
                 description "LSP packet rate";
+            }            
+            field device-vendor {
+                constant {
+                    value "{{inp-device-vendor}}";
+                }
+                type string;                
+                description "Indicates device vendor";
             }
-            variable input-to-address {
+            variable inp-lsp-destination {
                 value .*;
                 description "SR color LSP destination address to monitor, regular expression, eg '11.0.0.*|10.52.135.*'";
                 type string;
             }
-            variable input-color {
+            variable inp-lsp-color {
                 value .*;
                 description "SR color LSP colors to monitor, regular expression, eg '100|20*'";
                 type string;
-            }
-            variable input-cisco-sr-color-lsp-name {
-                value srte_c.*;
-                description "Cisco SR Color LSPs are available as srte interfaces, need to prefix srte_c_ to all interface names, eg 'srte_c_3.*|srte_c_300.*'";
+            }            
+            variable inp-device-vendor {
+                value "";
+                description "Contains the name of the device vendor";
                 type string;
             }
             rule-properties {
@@ -164,49 +118,48 @@ healthbot {
                                 sensors jnpr-sr-color-lsp;
                                 platforms MX960 {
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms MX2008 {
+                                platforms MX2008 {                                    
+                                    sensors jnpr-sr-color-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms MX2010 {
+                                platforms MX2010 {                                    
+                                    sensors jnpr-sr-color-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms MX2020  {
+                                platforms MX2020  {                                    
+                                    sensors jnpr-sr-color-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                             }
                             products PTX {
                                 sensors jnpr-sr-color-lsp;
-                                platforms PTX1000 {
+                                platforms PTX1000 {                                    
+                                    sensors jnpr-sr-color-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms PTX10000  {
+                                platforms PTX10000  {                                    
+                                    sensors jnpr-sr-color-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                             }
                             products QFX {
                                 sensors jnpr-sr-color-lsp;
-                                platforms QFX5200 {
+                                platforms QFX5200 {                                    
+                                    sensors jnpr-sr-color-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -216,75 +169,36 @@ healthbot {
                             sensors jnpr-sr-color-lsp;	
                             products PTX {
                                 sensors jnpr-sr-color-lsp;	
-                                platforms PTX10001-36MR {
+                                platforms PTX10001-36MR {                                    
+                                    sensors jnpr-sr-color-lsp;	
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;	
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms PTX10003 {
-                                    releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;	
+                                platforms PTX10003 {                                    
+                                    sensors jnpr-sr-color-lsp;
+                                    releases 22.4R1 {	
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms PTX10004 {
-                                    releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;	
+                                platforms PTX10004 {                                    
+                                    sensors jnpr-sr-color-lsp;
+                                    releases 22.4R1 {	
                                         release-support min-supported-release;
                                     }
                                 }								
-                                platforms PTX10008 {
-                                    releases 22.4R1 {
-                                        sensors jnpr-sr-color-lsp;	
+                                platforms PTX10008 {                                    
+                                    sensors jnpr-sr-color-lsp;
+                                    releases 22.4R1 {	
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms PTX10016  {
-                                    releases 22.1R1 {
-                                        sensors jnpr-sr-color-lsp;	
+                                platforms PTX10016  {                                    
+                                    sensors jnpr-sr-color-lsp;
+                                    releases 22.4R1 {	
                                         release-support min-supported-release;
                                     }
                                 }								
-                            }
-                        }
-                    }
-                    other-vendor cisco {
-                        vendor-name cisco;
-                        operating-systems iosxr {     
-                            products "XRV Appliance" {
-                                platforms "XRV Appliance" {
-                                    sensors cisco-oc-sr-color-lsp;
-                                    releases 7.5.1 {
-                                        sensors cisco-oc-sr-color-lsp;
-                                        release-support min-supported-release;
-                                    }
-                                }
-                            }                            
-                            products "XRv" {
-                                platforms "XRv 9000" {
-                                    sensors cisco-oc-sr-color-lsp;
-                                    releases 7.5.1 {
-                                        sensors cisco-oc-sr-color-lsp;
-                                        release-support min-supported-release;
-                                    }
-                                }
-                            }                            
-                            products "NCS" {
-                                platforms "NCS-5504" {
-                                    sensors cisco-oc-sr-color-lsp;
-                                    releases 7.5.1 {
-                                        sensors cisco-oc-sr-color-lsp;
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms "NCS-5508" {
-                                    sensors cisco-oc-sr-color-lsp;
-                                    releases 7.5.1 {
-                                        sensors cisco-oc-sr-color-lsp;
-                                        release-support min-supported-release;
-                                    }
-                                }
                             }
                         }
                     }

--- a/juniper_official/routing/collect-sr-color-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-color-lsp-stats.rule
@@ -3,19 +3,16 @@
  *
  * Req 1936: https://paragon-automation.atlassian.net/browse/REQ-1936
  *
- * Three input control detection
+ * Two input control detection
  *
- *   1) inp-lsp-destination, is a regular expression that matches the SR color lsp 
+ *   1) input-to-address, is a regular expression that matches the SR color lsp 
  *      destination address that must be monitored.  By default it's '.*', which matches
  *      all destination address. Use something like '11.0.0*' to match only destination 
  *      address starting with '11.0.0'.  
  *
- *   2) inp-lsp-color, is a regular expression that matches the color of SR color lsp 
+ *   2) input-color, is a regular expression that matches the color of SR color lsp 
  *      that must be monitored.  By default it's '.*', which matches
  *      all colors. Use something like '10*' to match LSPs starting with color '10'.
- *
- *   3) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
- *      rule deployment based on device.  
  *
  */
 healthbot {
@@ -31,7 +28,7 @@ healthbot {
             }
             field lsp-destination {
                 sensor jnpr-sr-color-lsp {
-                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address =~ /{{inp-lsp-destination}}/";
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address =~ /{{input-to-address}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address";
                 }                
                 type string;
@@ -39,7 +36,7 @@ healthbot {
             }
             field lsp-color {
                 sensor jnpr-sr-color-lsp {
-                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color =~ /{{inp-lsp-color}}/";
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color =~ /{{input-color}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color";
                 }                
                 type string;
@@ -86,27 +83,15 @@ healthbot {
                 }
                 type integer;
                 description "LSP packet rate";
-            }            
-            field device-vendor {
-                constant {
-                    value "{{inp-device-vendor}}";
-                }
-                type string;                
-                description "Indicates device vendor";
             }
-            variable inp-lsp-destination {
+            variable input-to-address {
                 value .*;
                 description "SR color LSP destination address to monitor, regular expression, eg '11.0.0.*|10.52.135.*'";
                 type string;
             }
-            variable inp-lsp-color {
+            variable input-color {
                 value .*;
                 description "SR color LSP colors to monitor, regular expression, eg '100|20*'";
-                type string;
-            }            
-            variable inp-device-vendor {
-                value "";
-                description "Contains the name of the device vendor";
                 type string;
             }
             rule-properties {
@@ -117,25 +102,25 @@ healthbot {
                             products MX {
                                 sensors jnpr-sr-color-lsp;
                                 platforms MX960 {
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2008 {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2010 {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020  {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -144,13 +129,13 @@ healthbot {
                                 sensors jnpr-sr-color-lsp;
                                 platforms PTX1000 {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10000  {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -159,7 +144,7 @@ healthbot {
                                 sensors jnpr-sr-color-lsp;
                                 platforms QFX5200 {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -171,31 +156,31 @@ healthbot {
                                 sensors jnpr-sr-color-lsp;	
                                 platforms PTX10001-36MR {                                    
                                     sensors jnpr-sr-color-lsp;	
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10003 {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {	
+                                    releases 22.1R1 {	
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {	
+                                    releases 22.1R1 {	
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10008 {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {	
+                                    releases 22.1R1 {	
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10016  {                                    
                                     sensors jnpr-sr-color-lsp;
-                                    releases 22.4R1 {	
+                                    releases 22.1R1 {	
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/collect-sr-color-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-color-lsp-stats.rule
@@ -1,7 +1,8 @@
 /*
  * Collect SR Color LSP traffic statistics for pathfinder dynamic topology.
  *
- * Req TBD: TBD
+ * Req 1936: https://paragon-automation.atlassian.net/browse/REQ-1936
+ * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
  *
  * Two input control detection
  *
@@ -18,7 +19,7 @@
 healthbot {
     topic routing.spring {
         rule collect-sr-color-lsp-stats {
-            keys [ lsp-name ];
+            keys [ lsp-name lsp-cfg-name ];
             description "Collects SR color LSP stats periodically";
             sensor jnpr-sr-color-lsp {
                 open-config {
@@ -26,11 +27,24 @@ healthbot {
                     frequency 60s;
                 }
             }
+            sensor cisco-oc-sr-color-lsp {
+                description "Cisco open-config SR Color LSP sensor definition";
+                open-config {
+                    sensor-name /interfaces/interface/state/counters;
+                    frequency 60s;
+                }
+            }
             field lsp-destination {
                 sensor jnpr-sr-color-lsp {
                     where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address =~ /{{input-to-address}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@to-address";
-                }                
+                } 
+                sensor cisco-oc-sr-color-lsp {
+                    path cisco_lsp_destination_dummy_path;
+                    data-if-missing {
+                        value "cisco_sr_lsp_destination";
+                    }
+                }               
                 type string;
                 description "LSP destination in case of SR color LSP and name in case of SR LSP";
             }
@@ -38,7 +52,13 @@ healthbot {
                 sensor jnpr-sr-color-lsp {
                     where "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color =~ /{{input-color}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/@color";
-                }                
+                }
+                sensor cisco-oc-sr-color-lsp {
+                    path cisco_lsp_color_dummy_path;
+                    data-if-missing {
+                        value "cisco_sr_lsp_color";
+                    }
+                }                 
                 type string;
                 description "Color of the LSP being monitored";
             }
@@ -46,12 +66,18 @@ healthbot {
                 sensor jnpr-sr-color-lsp {
                     path /mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/state/counters/bytes;
                 }
+                sensor cisco-oc-sr-color-lsp {
+                    path /interfaces/interface/state/counters/out-octets;
+                }
                 type integer;
                 description "LSP bytes counter";
             }      
             field lsp-stats-packets {
                 sensor jnpr-sr-color-lsp {
                     path /mpls/signaling-protocols/segment-routing/sr-te-ip-policies/sr-te-ip-policy/state/counters/packets;
+                }
+                sensor cisco-oc-sr-color-lsp {
+                    path /interfaces/interface/state/counters/out-pkts;
                 }
                 type integer;
                 description "LSP packet counter";
@@ -63,7 +89,37 @@ healthbot {
                     }
                 }
                 type string;
-                description "LSP name";
+                description "LSP computed name";
+            }
+            field lsp-cfg-name {
+                sensor jnpr-sr-color-lsp {
+                    path juniper_interface_name_dummy_path;
+                    data-if-missing {
+                        value "jnpr_sr_lsp";
+                    }
+                }
+                sensor cisco-oc-sr-color-lsp {
+                    where "/interfaces/interface/@name =~ /{{input-cisco-sr-color-lsp-name}}/";
+                    path "/interfaces/interface/@name";
+                }                
+                type string;
+                description "Interface name";
+            }
+            field vendor {
+                sensor jnpr-sr-color-lsp {
+                    path juniper_sr_color_lsp_vendor_dummy_path;
+                    data-if-missing {
+                        value "juniper";
+                    }
+                }
+                sensor cisco-oc-sr-color-lsp {
+                    path cisco_sr_color_lsp_vendor_dummy_path;
+                    data-if-missing {
+                        value "cisco";
+                    }              
+                }
+                type string;                
+                description "Indicates telemetry vendor";
             }
             field lsp-stats-bps {
                 formula {
@@ -94,6 +150,11 @@ healthbot {
                 description "SR color LSP colors to monitor, regular expression, eg '100|20*'";
                 type string;
             }
+            variable input-cisco-sr-color-lsp-name {
+                value srte_c.*;
+                description "Cisco SR Color LSPs are available as srte interfaces, need to prefix srte_c_ to all interface names, eg 'srte_c_3.*|srte_c_300.*'";
+                type string;
+            }
             rule-properties {
                 supported-devices {
                     juniper {
@@ -102,25 +163,25 @@ healthbot {
                             products MX {
                                 sensors jnpr-sr-color-lsp;
                                 platforms MX960 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2008 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2010 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020  {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
@@ -129,13 +190,13 @@ healthbot {
                             products PTX {
                                 sensors jnpr-sr-color-lsp;
                                 platforms PTX1000 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10000  {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
@@ -144,7 +205,7 @@ healthbot {
                             products QFX {
                                 sensors jnpr-sr-color-lsp;
                                 platforms QFX5200 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;
                                         release-support min-supported-release;
                                     }
@@ -156,25 +217,25 @@ healthbot {
                             products PTX {
                                 sensors jnpr-sr-color-lsp;	
                                 platforms PTX10001-36MR {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;	
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10003 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;	
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;	
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10008 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-color-lsp;	
                                         release-support min-supported-release;
                                     }
@@ -185,6 +246,45 @@ healthbot {
                                         release-support min-supported-release;
                                     }
                                 }								
+                            }
+                        }
+                    }
+                    other-vendor cisco {
+                        vendor-name cisco;
+                        operating-systems iosxr {     
+                            products "XRV Appliance" {
+                                platforms "XRV Appliance" {
+                                    sensors cisco-oc-sr-color-lsp;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }                            
+                            products "XRv" {
+                                platforms "XRv 9000" {
+                                    sensors cisco-oc-sr-color-lsp;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }                            
+                            products "NCS" {
+                                platforms "NCS-5504" {
+                                    sensors cisco-oc-sr-color-lsp;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-5508" {
+                                    sensors cisco-oc-sr-color-lsp;
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-sr-color-lsp;
+                                        release-support min-supported-release;
+                                    }
+                                }
                             }
                         }
                     }

--- a/juniper_official/routing/collect-srte-interface-stats.rule
+++ b/juniper_official/routing/collect-srte-interface-stats.rule
@@ -3,14 +3,11 @@
  *
  * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
  *
- * Two input control detection
+ * One input control detection
  *
- *   1) inp-lsp-name, is a regular expression that matches the srte interface name
+ *   1) input-lsp-name, is a regular expression that matches the srte interface name
  *      that must be monitored.  By default it's 'srte_c.*', which matches
  *      all Cisco SR Color LSPs.
- *
- *   2) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
- *      rule deployment based on device.  
  *
  */
 healthbot {
@@ -41,7 +38,7 @@ healthbot {
             }
             field lsp-name {
                 sensor srte-interface-oc {
-                    where "/interfaces/interface/@name =~ /{{inp-lsp-name}}/";
+                    where "/interfaces/interface/@name =~ /{{input-lsp-name}}/";
                     path "/interfaces/interface/@name";
                 }                
                 type string;
@@ -65,22 +62,10 @@ healthbot {
                 }
                 type integer;
                 description "LSP packet rate";
-            }           
-            field device-vendor {
-                constant {
-                    value "{{inp-device-vendor}}";
-                }
-                type string;                
-                description "Indicates device vendor";
             }
-            variable inp-lsp-name {
+            variable input-lsp-name {
                 value srte_c.*;
                 description "Cisco SR Color LSPs are available as srte interfaces, need to prefix srte_c_ to all interface names, eg 'srte_c_3.*|srte_c_300.*'";
-                type string;
-            }            
-            variable inp-device-vendor {
-                value "";
-                description "Contains the name of the device vendor";
                 type string;
             }
             rule-properties {

--- a/juniper_official/routing/collect-srte-interface-stats.rule
+++ b/juniper_official/routing/collect-srte-interface-stats.rule
@@ -1,0 +1,127 @@
+/*
+ * Collect SRTE Interface statistics for pathfinder dynamic topology.
+ *
+ * Req 1351: https://paragon-automation.atlassian.net/browse/REQ-1351
+ *
+ * Two input control detection
+ *
+ *   1) inp-lsp-name, is a regular expression that matches the srte interface name
+ *      that must be monitored.  By default it's 'srte_c.*', which matches
+ *      all Cisco SR Color LSPs.
+ *
+ *   2) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
+ *      rule deployment based on device.  
+ *
+ */
+healthbot {
+    topic routing.spring {
+        rule collect-srte-interface-stats {
+            keys [ lsp-name ];
+            description "Collects SRTE Interface based stats periodically";
+            sensor srte-interface-oc {
+                description "open-config Interface sensor definition";
+                open-config {
+                    sensor-name /interfaces/interface/state/counters;
+                    frequency 60s;
+                }
+            }
+            field lsp-stats-bytes {
+                sensor srte-interface-oc {
+                    path /interfaces/interface/state/counters/out-octets;
+                }
+                type integer;
+                description "LSP bytes counter";
+            }      
+            field lsp-stats-packets {
+                sensor srte-interface-oc {
+                    path /interfaces/interface/state/counters/out-pkts;
+                }
+                type integer;
+                description "LSP packet counter";
+            }
+            field lsp-name {
+                sensor srte-interface-oc {
+                    where "/interfaces/interface/@name =~ /{{inp-lsp-name}}/";
+                    path "/interfaces/interface/@name";
+                }                
+                type string;
+                description "Interface name";
+            }
+            field lsp-stats-bps {
+                formula {
+                    rate-of-change {
+                        field-name "$lsp-stats-bytes";
+                        multiplication-factor 8;
+                    }
+                }
+                type integer;
+                description "LSP bit rate";
+            }            
+            field lsp-stats-pps {
+                formula {
+                    rate-of-change {
+                        field-name "$lsp-stats-packets";
+                    }
+                }
+                type integer;
+                description "LSP packet rate";
+            }           
+            field device-vendor {
+                constant {
+                    value "{{inp-device-vendor}}";
+                }
+                type string;                
+                description "Indicates device vendor";
+            }
+            variable inp-lsp-name {
+                value srte_c.*;
+                description "Cisco SR Color LSPs are available as srte interfaces, need to prefix srte_c_ to all interface names, eg 'srte_c_3.*|srte_c_300.*'";
+                type string;
+            }            
+            variable inp-device-vendor {
+                value "";
+                description "Contains the name of the device vendor";
+                type string;
+            }
+            rule-properties {
+                supported-devices {
+                    other-vendor cisco {
+                        vendor-name cisco;
+                        operating-systems iosxr {     
+                            products "XRV Appliance" {
+                                platforms "XRV Appliance" {                                    
+                                    sensors srte-interface-oc;
+                                    releases 7.5.1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }                            
+                            products "XRv" {
+                                platforms "XRv 9000" {                                    
+                                    sensors srte-interface-oc;
+                                    releases 7.5.1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }                            
+                            products "NCS" {
+                                platforms "NCS-5504" {
+                                    sensors srte-interface-oc;
+                                    releases 7.5.1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-5508" {                                    
+                                    sensors srte-interface-oc;
+                                    releases 7.5.1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The requirement is to collect the SR Color LSP traffic statistics from Cisco devices, for which the existing rule "collect-sr-color-lsp-stats.rule" has been updated with Cisco specific openconfig sensor and platform/models.
The name of the Juniper SR LSP is computed using two fields, where as the name for Cisco is received in a single field hence a new field has been added to the key which contains the Cisco SR LSP name.

Note:

- Testing is done on virtual machine having the IOS-XR 7.5.1, 7.8.1 and 24.3.1
- The rule has both "XRV Appliance" and "XRv" because EMS has issues supporting "XRv"
