### PR TITLE
Update REQ and supported versions in collect-sr-lsp-stats.rule

### DIFF
--- a/juniper_official/routing/collect-sr-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-lsp-stats.rule
@@ -1,7 +1,7 @@
 /*
  * Collect SR LSP traffic statistics for pathfinder dynamic topology.
  *
- * Req <TBD>: TBD 
+ * Req 1936: https://paragon-automation.atlassian.net/browse/REQ-1936 
  *
  * One input control detection
  *
@@ -76,25 +76,25 @@ healthbot {
                             products MX {
                                 sensors jnpr-sr-lsp;
                                 platforms MX960 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2008 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2010 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020  {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
@@ -103,13 +103,13 @@ healthbot {
                             products PTX {
                                 sensors jnpr-sr-lsp;
                                 platforms PTX1000 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10000  {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
@@ -118,7 +118,7 @@ healthbot {
                             products QFX {
                                 sensors jnpr-sr-lsp;
                                 platforms QFX5200 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
@@ -130,31 +130,31 @@ healthbot {
                             products PTX {
                                 sensors jnpr-sr-lsp;
                                 platforms PTX10001-36MR {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10003 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10008 {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10016  {
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }

--- a/juniper_official/routing/collect-sr-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-lsp-stats.rule
@@ -3,12 +3,15 @@
  *
  * Req 1936: https://paragon-automation.atlassian.net/browse/REQ-1936 
  *
- * One input control detection
+ * Two input control detection
  *
- *   1) input-lsp-name, is a regular expression that matches the SR lsp name
+ *   1) inp-lsp-name, is a regular expression that matches the SR lsp name
  *      that must be monitored.  By default it's '.*', which matches
  *      all lsps. Use something like 'Silver*' to match only lsp names starting
  *      with 'Silver'.
+ *
+ *   2) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
+ *      rule deployment based on device.  
  *
  */
 healthbot {
@@ -24,7 +27,7 @@ healthbot {
             }
             field lsp-name {
                 sensor jnpr-sr-lsp {
-                    where "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name =~ /{{input-lsp-name}}/";
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name =~ /{{inp-lsp-name}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name";
                 }              
                 type string;
@@ -62,10 +65,22 @@ healthbot {
                 }
                 type integer;
                 description "LSP packet rate";
+            }           
+            field device-vendor {
+                constant {
+                    value "{{inp-device-vendor}}";
+                }
+                type string;                
+                description "Indicates device vendor";
             }
-            variable input-lsp-name {
+            variable inp-lsp-name {
                 value .*;
                 description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
+                type string;
+            }            
+            variable inp-device-vendor {
+                value "";
+                description "Contains the name of the device vendor";
                 type string;
             }
             rule-properties {
@@ -76,26 +91,26 @@ healthbot {
                             products MX {
                                 sensors jnpr-sr-lsp;
                                 platforms MX960 {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2008 {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2010 {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020  {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -103,14 +118,14 @@ healthbot {
                             products PTX {
                                 sensors jnpr-sr-lsp;
                                 platforms PTX1000 {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10000  {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -118,8 +133,8 @@ healthbot {
                             products QFX {
                                 sensors jnpr-sr-lsp;
                                 platforms QFX5200 {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
@@ -130,32 +145,32 @@ healthbot {
                             products PTX {
                                 sensors jnpr-sr-lsp;
                                 platforms PTX10001-36MR {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10003 {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10008 {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10016  {
+                                    sensors jnpr-sr-lsp;
                                     releases 22.4R1 {
-                                        sensors jnpr-sr-lsp;
                                         release-support min-supported-release;
                                     }
                                 }								

--- a/juniper_official/routing/collect-sr-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-lsp-stats.rule
@@ -3,15 +3,12 @@
  *
  * Req 1936: https://paragon-automation.atlassian.net/browse/REQ-1936 
  *
- * Two input control detection
+ * One input control detection
  *
- *   1) inp-lsp-name, is a regular expression that matches the SR lsp name
+ *   1) input-lsp-name, is a regular expression that matches the SR lsp name
  *      that must be monitored.  By default it's '.*', which matches
  *      all lsps. Use something like 'Silver*' to match only lsp names starting
  *      with 'Silver'.
- *
- *   2) inp-device-vendor, indicates the device vendor is empty by default and needs to be filled during
- *      rule deployment based on device.  
  *
  */
 healthbot {
@@ -27,7 +24,7 @@ healthbot {
             }
             field lsp-name {
                 sensor jnpr-sr-lsp {
-                    where "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name =~ /{{inp-lsp-name}}/";
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name =~ /{{input-lsp-name}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name";
                 }              
                 type string;
@@ -65,22 +62,10 @@ healthbot {
                 }
                 type integer;
                 description "LSP packet rate";
-            }           
-            field device-vendor {
-                constant {
-                    value "{{inp-device-vendor}}";
-                }
-                type string;                
-                description "Indicates device vendor";
             }
-            variable inp-lsp-name {
+            variable input-lsp-name {
                 value .*;
                 description "LSP names to monitor, regular expression, eg 'LSP-1.*|LSP-A.*'";
-                type string;
-            }            
-            variable inp-device-vendor {
-                value "";
-                description "Contains the name of the device vendor";
                 type string;
             }
             rule-properties {
@@ -92,25 +77,25 @@ healthbot {
                                 sensors jnpr-sr-lsp;
                                 platforms MX960 {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2008 {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2010 {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms MX2020  {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -119,13 +104,13 @@ healthbot {
                                 sensors jnpr-sr-lsp;
                                 platforms PTX1000 {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10000  {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -134,7 +119,7 @@ healthbot {
                                 sensors jnpr-sr-lsp;
                                 platforms QFX5200 {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -146,31 +131,31 @@ healthbot {
                                 sensors jnpr-sr-lsp;
                                 platforms PTX10001-36MR {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10003 {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10004 {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }								
                                 platforms PTX10008 {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms PTX10016  {
                                     sensors jnpr-sr-lsp;
-                                    releases 22.4R1 {
+                                    releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }								


### PR DESCRIPTION
The rule "collect-sr-lsp-stats.rule" was missing the REQ number, the same has been added, also the minimum supported version has been changed to the version where junos supports openconfig fully.
