### PR TITLE
Removed router name from trigger messages for vpn rules

### DIFF
--- a/juniper_official/vpn/l3vpn/l3vpn-proto-bgp-nw.rule
+++ b/juniper_official/vpn/l3vpn/l3vpn-proto-bgp-nw.rule
@@ -99,7 +99,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is UP";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name is UP";
                         }
                     }
                 }
@@ -112,7 +112,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is $instance-interface-status";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name is $instance-interface-status";
                         }
                     }
                 }
@@ -131,7 +131,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is UP";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session is UP";
                         }
                     }
                 }
@@ -144,7 +144,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is DOWN";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session is DOWN";
                         }
                     }
                 }

--- a/juniper_official/vpn/l3vpn/l3vpn-proto-ospf-nw.rule
+++ b/juniper_official/vpn/l3vpn/l3vpn-proto-ospf-nw.rule
@@ -102,7 +102,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is UP";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name is UP";
                         }
                     }
                 }
@@ -115,7 +115,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is $instance-interface-status";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name is $instance-interface-status";
                         }
                     }
                 }
@@ -134,7 +134,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is UP";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session is UP";
                         }
                     }
                 }
@@ -147,7 +147,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is DOWN";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session is DOWN";
                         }
                     }
                 }

--- a/juniper_official/vpn/l3vpn/l3vpn-proto-ospf3-nw.rule
+++ b/juniper_official/vpn/l3vpn/l3vpn-proto-ospf3-nw.rule
@@ -103,7 +103,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is UP";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name is UP";
                         }
                     }
                 }
@@ -116,7 +116,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is $instance-interface-status";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name is $instance-interface-status";
                         }
                     }
                 }
@@ -135,7 +135,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is UP";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session is UP";
                         }
                     }
                 }
@@ -148,7 +148,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session of $pe-router-name is DOWN";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session is DOWN";
                         }
                     }
                 }

--- a/juniper_official/vpn/l3vpn/l3vpn-proto-static-nw.rule
+++ b/juniper_official/vpn/l3vpn/l3vpn-proto-static-nw.rule
@@ -81,7 +81,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is UP";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name is UP";
                         }
                     }
                 }
@@ -94,7 +94,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name on router $pe-router-name is $instance-interface-status";
+                            message "PE interface $instance-interface-name.$instance-ifl-no of VPN:$vpn-name is $instance-interface-status";
                         }
                     }
                 }


### PR DESCRIPTION
router name removed from trigger messages for below L3VPN rules : 
l3vpn-proto-bgp-nw
l3vpn-proto-ospf-nw
l3vpn-proto-ospf3-nw
l3vpn-proto-static-nw