### PR TITLE
Removed router name from trigger messages for evpn rule

### DIFF
--- a/juniper_official/vpn/evpn/evpn-view-nw.rule
+++ b/juniper_official/vpn/evpn/evpn-view-nw.rule
@@ -85,7 +85,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$pe-router-name, VPN: $vpn-name, Interface: $instance-interface-name.$instance-ifl-no, Interface-state: $instance-interface-status";
+                            message "VPN: $vpn-name, Interface: $instance-interface-name.$instance-ifl-no, Interface-state: $instance-interface-status";
                         }
                     }
                 }
@@ -98,7 +98,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$pe-router-name, VPN: $vpn-name, Interface: $instance-interface-name.$instance-ifl-no, Interface-state: $instance-interface-status";
+                            message "VPN: $vpn-name, Interface: $instance-interface-name.$instance-ifl-no, Interface-state: $instance-interface-status";
                         }
                     }
                 }
@@ -115,7 +115,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$pe-router-name, VPN: $vpn-name, Neighbor-state: up";
+                            message "VPN: $vpn-name, Neighbor-state: up";
                         }
                     }
                 }
@@ -126,7 +126,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "$pe-router-name, VPN: $vpn-name, Neighbor-state: down";
+                            message "VPN: $vpn-name, Neighbor-state: down";
                         }
                     }
                 }


### PR DESCRIPTION
Router name removed from trigger messages for eVPN rule "evpn-view-nw".
