### PR TITLE
Added neighbor-id field and variable to ospf network rules

### DIFF
--- a/juniper_official/vpn/l3vpn/l3vpn-proto-ospf-nw.rule
+++ b/juniper_official/vpn/l3vpn/l3vpn-proto-ospf-nw.rule
@@ -52,6 +52,13 @@ healthbot {
                 type string;
                 description "Protocol neighbor address";
             }
+            field neighbor-id {
+                constant {
+                    value "{{neighbor-id}}";
+                }
+                type string;
+                description "Protocol neighbor id";
+            }			
             field pe-router-name {
                 constant {
                     value "{{pe-device-name}}";
@@ -68,7 +75,7 @@ healthbot {
             }
             field vpn-state {
                 reference {
-                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='routing.ospf']/rule[rule-name=check-ospf-neighbor-state]/field[neighbor-address='{{customer-neighbor-address}}']/ospf-neighbor-state";
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='routing.ospf']/rule[rule-name=check-ospf-neighbor-state]/field[neighbor-address='{{customer-neighbor-address}}' and instance-name='{{customer-vpn-name}}' and interface-name='{{pe-interface-name}}.{{pe-ifl-number}}' and neighbor-id='{{neighbor-id}}']/ospf-neighbor-state";
                     data-if-missing {
                         value DOWN;
                     }
@@ -134,7 +141,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session is UP";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session neighbor-id:$neighbor-id is UP";
                         }
                     }
                 }
@@ -147,7 +154,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session is DOWN";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session neighbor-id:$neighbor-id is DOWN";
                         }
                     }
                 }
@@ -156,6 +163,10 @@ healthbot {
                 description "OSPF neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
                 type string;
             }
+            variable neighbor-id {
+                description "OSPF neighbor id to monitor, regular expression, e.g. '172.16.*'";
+                type string;
+            }			
             variable customer-vpn-name {
                 description "VRF name to monitor, regular expression, e.g. 'customer*'";
                 type string;

--- a/juniper_official/vpn/l3vpn/l3vpn-proto-ospf3-nw.rule
+++ b/juniper_official/vpn/l3vpn/l3vpn-proto-ospf3-nw.rule
@@ -53,6 +53,13 @@ healthbot {
                 type string;
                 description "Protocol neighbor address";
             }
+            field neighbor-id {
+                constant {
+                    value "{{neighbor-id}}";
+                }
+                type string;
+                description "Protocol neighbor id";
+            }			
             field pe-router-name {
                 constant {
                     value "{{pe-device-name}}";
@@ -69,7 +76,7 @@ healthbot {
             }
             field vpn-state {
                 reference {
-                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='routing.ospf']/rule[rule-name=check-ospf3-neighbor-state]/field[neighbor-address='{{customer-neighbor-address}}']/ospf-neighbor-state";
+                    path "/device-group[device-group-name={{pe-device-group}}]/device[device-id={{pe-device-name}}]/topic[topic-name='routing.ospf']/rule[rule-name=check-ospf3-neighbor-state]/field[neighbor-address='{{customer-neighbor-address}}' and instance-name='{{customer-vpn-name}}' and interface-name='{{pe-interface-name}}.{{pe-ifl-number}}' and neighbor-id='{{neighbor-id}}']/ospf-neighbor-state";
                     data-if-missing {
                         value DOWN;
                     }
@@ -135,7 +142,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session is UP";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session neighbor-id:$neighbor-id is UP";
                         }
                     }
                 }
@@ -148,7 +155,7 @@ healthbot {
                     then {
                         status {
                             color red;
-                            message "L3VPN:$vpn-name neighbor:$neighbor-session is DOWN";
+                            message "L3VPN:$vpn-name neighbor:$neighbor-session neighbor-id:$neighbor-id is DOWN";
                         }
                     }
                 }
@@ -157,6 +164,10 @@ healthbot {
                 description "OSPF3 IPv6 neighbor addresses to monitor, regular expression, e.g. '172.16.*'";
                 type string;
             }
+            variable neighbor-id {
+                description "OSPF neighbor id to monitor, regular expression, e.g. '172.16.*'";
+                type string;
+            }			
             variable customer-vpn-name {
                 description "VRF name to monitor, regular expression, e.g. 'customer*'";
                 type string;


### PR DESCRIPTION
Added neighbor-id as field and variable in the OSPF Network Rules and updated reference paths.

 check-l3vpn-ospf-state
 check-l3vpn-ospf3-state