### PR TITLE
Removed flaps thresholds in plots for interface rule

### DIFF
--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -81,10 +81,6 @@ healthbot {
                 plots flaps-plot {
                     unit count;
                     triggers interface-link-flaps;
-                    thresholds flaps-threshold {
-                        field-name "$flaps-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field flaps-threshold {


### PR DESCRIPTION
Removed flaps thresholds in plots in check-interface-in-out-errors-traffic-state-flaps rule.