### PR TITLE
Removed thresholds for interface and pfe rules

### DIFF
--- a/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
+++ b/juniper_official/interface/check-interface-fec-crc-framing-errors.rule
@@ -53,10 +53,6 @@ healthbot {
                 plots fec-uncorrected-plot {
                     unit count;
                     triggers fec-uncorrected-errors;
-                    thresholds threshold-value {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field framing-errors {
@@ -68,10 +64,6 @@ healthbot {
                 plots framing-errors-plot {
                     unit count;
                     triggers framing-errors;
-                    thresholds threshold-value {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field optical-fec-corrected {
@@ -91,10 +83,6 @@ healthbot {
                 plots input-crc-errors-plot {
                     unit count;
                     triggers input-crc-errors;
-                    thresholds threshold-value {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field interface-name {
@@ -114,10 +102,6 @@ healthbot {
                 plots output-crc-errors-plot {
                     unit count;
                     triggers output-crc-errors;
-                    thresholds threshold-value {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             /*

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -107,10 +107,6 @@ healthbot {
                 plots in-error-plots {
                     unit count;
                     triggers interface-input-errors;
-                    thresholds in-errors-threshold {
-                        field-name "$in-errors-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field in-errors-threshold {
@@ -204,10 +200,6 @@ healthbot {
                 plots out-error-plots {
                     unit count;
                     triggers interface-output-errors;
-                    thresholds out-errors-threshold {
-                        field-name "$out-errors-threshold";
-                        severity critical;
-                    }
                 }
             }
             field out-errors-threshold {

--- a/juniper_official/linecard/check-pfe-discards.rule
+++ b/juniper_official/linecard/check-pfe-discards.rule
@@ -40,10 +40,6 @@ healthbot {
                 plots bad-route-discard-plot {
                     unit count;
                     triggers pfe-bad-route-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field bits-to-test-discard {
@@ -55,10 +51,6 @@ healthbot {
                 plots bits-to-test-discard-plot {
                     unit count;
                     triggers pfe-bits-to-test-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field data-error-discard {
@@ -70,10 +62,6 @@ healthbot {
                 plots data-error-discard-plot {
                     unit count;
                     triggers pfe-data-error-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field drop-threshold {
@@ -92,10 +80,6 @@ healthbot {
                 plots fabric-discards-plot {
                     unit count;
                     triggers pfe-fabric-discards;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field info-cell-discard {
@@ -107,10 +91,6 @@ healthbot {
                 plots info-cell-discard-plot {
                     unit count;
                     triggers pfe-info-cell-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field invalid-iif-discard {
@@ -122,10 +102,6 @@ healthbot {
                 plots invalid-iif-discard-plot {
                     unit count;
                     triggers pfe-invalid-iif-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field nexthop-discard {
@@ -137,10 +113,6 @@ healthbot {
                 plots nexthop-discard-plot {
                     unit count;
                     triggers pfe-nexthop-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field stack-overflow-discard {
@@ -152,10 +124,6 @@ healthbot {
                 plots stack-overflow-discard-plot {
                     unit count;
                     triggers pfe-stack-overflow-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field stack-underflow-discard {
@@ -167,10 +135,6 @@ healthbot {
                 plots stack-underflow-discard-plot {
                     unit count;
                     triggers pfe-stack-underflow-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field tcp-header-error-discard {
@@ -182,10 +146,6 @@ healthbot {
                 plots tcp-header-error-discard-plot {
                     unit count;
                     triggers pfe-tcp-header-error-discard;
-                    thresholds drop-threshold {
-                        field-name "$drop-threshold";
-                        severity critical;
-                    }
                 }				
             }
             field bad-route-discard-rate {


### PR DESCRIPTION
check-interface-in-out-errors-traffic-state-flaps : removed threshold from plots for in-errors-count and out-errors-count fields

check-interface-fec-crc-framing-errors : removed threshold from plots for fec-uncorrected,framing-errors,input-crc-error and output-crc-error fields

check-pfe-discards