### PR TITLE
fix: PPF-2110: Add vmx and mx304 special handling for SR LSP

### DIFF
--- a/juniper_official/interface/collect-logical-interface-stats.rule
+++ b/juniper_official/interface/collect-logical-interface-stats.rule
@@ -261,6 +261,15 @@
                                     }
                                 }
                             }
+                            products VMX {
+                                sensors interfaces-oc;
+                                platforms VMX {                                    
+                                    sensors interfaces-oc;
+                                    releases 22.4R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
                         }
                     }                    
                     other-vendor cisco {

--- a/juniper_official/interface/collect-physical-interface-stats.rule
+++ b/juniper_official/interface/collect-physical-interface-stats.rule
@@ -243,6 +243,15 @@
                                     }
                                 }
                             }
+                            products VMX {
+                                sensors interfaces-oc;
+                                platforms VMX {                                    
+                                    sensors interfaces-oc;
+                                    releases 22.4R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
                         }
                     }
                     other-vendor cisco {

--- a/juniper_official/routing/collect-rsvp-stats.rule
+++ b/juniper_official/routing/collect-rsvp-stats.rule
@@ -148,6 +148,15 @@
                                     }
                                 }
                             }
+                            products VMX {
+                                sensors lsp;
+                                platforms VMX {                                    
+                                    sensors lsp;
+                                    releases 22.4R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
                         }
                         operating-system junosEvolved {
                             sensors lsp;

--- a/juniper_official/routing/collect-sr-color-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-color-lsp-stats.rule
@@ -101,6 +101,12 @@ healthbot {
                             sensors jnpr-sr-color-lsp;
                             products MX {
                                 sensors jnpr-sr-color-lsp;
+                                platforms MX304 {
+                                    sensors jnpr-sr-color-lsp;
+                                    releases 23.4R2 {
+                                        release-support min-supported-release;
+                                    }
+                                }
                                 platforms MX960 {
                                     sensors jnpr-sr-color-lsp;
                                     releases 22.1R1 {
@@ -126,50 +132,20 @@ healthbot {
                                     }
                                 }
                             }
-                            products PTX {
-                                sensors jnpr-sr-color-lsp;
-                                platforms PTX1000 {                                    
-                                    sensors jnpr-sr-color-lsp;
-                                    releases 22.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms PTX5000 {                                    
-                                    sensors jnpr-sr-color-lsp;
-                                    releases 22.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms PTX10000  {                                    
-                                    sensors jnpr-sr-color-lsp;
-                                    releases 22.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }                                								
-                                platforms PTX10002-60C {                                    
-                                    sensors jnpr-sr-color-lsp;
-                                    releases 22.1R1 {	
-                                        release-support min-supported-release;
-                                    }
-                                }								
-                                platforms PTX10008 {                                    
-                                    sensors jnpr-sr-color-lsp;
-                                    releases 22.1R1 {	
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms PTX10016  {                                    
-                                    sensors jnpr-sr-color-lsp;
-                                    releases 22.1R1 {	
-                                        release-support min-supported-release;
-                                    }
-                                }
-                            }
                             products QFX {
                                 sensors jnpr-sr-color-lsp;
                                 platforms QFX5200 {                                    
                                     sensors jnpr-sr-color-lsp;
                                     releases 22.1R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products VMX {
+                                sensors jnpr-sr-color-lsp;
+                                platforms VMX {                                    
+                                    sensors jnpr-sr-color-lsp;
+                                    releases 22.4R1 {
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/routing/collect-sr-lsp-stats.rule
+++ b/juniper_official/routing/collect-sr-lsp-stats.rule
@@ -22,11 +22,21 @@ healthbot {
                     frequency 60s;
                 }
             }
+            sensor jnpr-sr-lsp-tunnelName {
+                open-config {
+                    sensor-name /junos/services/segment-routing/traffic-engineering/tunnel/ingress/usage/;
+                    frequency 60s;
+                }
+            }
             field lsp-name {
                 sensor jnpr-sr-lsp {
                     where "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name =~ /{{input-lsp-name}}/";
                     path "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnel-name";
-                }              
+                }   
+                sensor jnpr-sr-lsp-tunnelName {
+                    where "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnelName =~ /{{input-lsp-name}}/";
+                    path "/mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/@tunnelName";
+                }           
                 type string;
                 description "LSP destination in case of SR color LSP and name in case of SR LSP";
             }
@@ -34,11 +44,17 @@ healthbot {
                 sensor jnpr-sr-lsp {
                     path /mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/state/counters/bytes;
                 }
+                sensor jnpr-sr-lsp-tunnelName {
+                    path /mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/state/counters/bytes;
+                }
                 type integer;
                 description "LSP bytes counter";
             }      
             field lsp-stats-packets {
                 sensor jnpr-sr-lsp {
+                    path /mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/state/counters/packets;
+                }
+                sensor jnpr-sr-lsp-tunnelName {
                     path /mpls/signaling-protocols/segment-routing/sr-te-ingress-tunnel-policies/sr-te-ingress-tunnel-policy/state/counters/packets;
                 }
                 type integer;
@@ -72,9 +88,16 @@ healthbot {
                 supported-devices {
                     juniper {
                         operating-system junos {
-                            sensors jnpr-sr-lsp;	
+                            sensors jnpr-sr-lsp;
                             products MX {
                                 sensors jnpr-sr-lsp;
+                                platforms MX304 {
+                                    sensors jnpr-sr-lsp-tunnelName;
+                                    releases 23.4R2 {
+                                        sensors jnpr-sr-lsp-tunnelName;
+                                        release-support min-supported-release;
+                                    }
+                                }
                                 platforms MX960 {
                                     sensors jnpr-sr-lsp;
                                     releases 22.1R1 {
@@ -100,26 +123,20 @@ healthbot {
                                     }
                                 }
                             }
-                            products PTX {
+                            products QFX {
                                 sensors jnpr-sr-lsp;
-                                platforms PTX1000 {
-                                    sensors jnpr-sr-lsp;
-                                    releases 22.1R1 {
-                                        release-support min-supported-release;
-                                    }
-                                }
-                                platforms PTX10000  {
+                                platforms QFX5200 {
                                     sensors jnpr-sr-lsp;
                                     releases 22.1R1 {
                                         release-support min-supported-release;
                                     }
                                 }
                             }
-                            products QFX {
+                            products VMX {
                                 sensors jnpr-sr-lsp;
-                                platforms QFX5200 {
+                                platforms VMX {                                    
                                     sensors jnpr-sr-lsp;
-                                    releases 22.1R1 {
+                                    releases 22.4R1 {
                                         release-support min-supported-release;
                                     }
                                 }
@@ -159,6 +176,15 @@ healthbot {
                                         release-support min-supported-release;
                                     }
                                 }								
+                            }
+                            products ACX {
+                                sensors jnpr-sr-lsp;
+                                platforms ACX7024 {
+                                sensors jnpr-sr-lsp;
+                                    releases 23.4R1 {
+                                        release-support min-supported-release;
+                                    }
+                                }						
                             }
                         }
                     }


### PR DESCRIPTION
The change included in this MR are,
1. Update Juniper specific rules to support the Juniper VMX device properties 
2. In the Juniper MX304 device the SR LSP sensor has a bug , that is, the field that should contain the tunnel name is sent in the field named "tunnelName" instead of "tunnel-name", this MR contains the changes to handle this case.

Note: The testing is done only for VMX changes, the testing for MX304 special handling cannot be done by development team as we do not have access to MX304, this SR LSP changes will be tested by QA team.

refs: PPF-2110, PPF-2108