### PR TITLE
feat: PPF-2346: Update the Cisco product support list

### DIFF
--- a/juniper_official/interface/collect-logical-interface-stats.rule
+++ b/juniper_official/interface/collect-logical-interface-stats.rule
@@ -274,33 +274,97 @@
                     }                    
                     other-vendor cisco {
                         vendor-name cisco;
-                        operating-systems iosxr {  
+                        operating-systems iosxr {
                             products "XRV Appliance" {
                                 platforms "XRV Appliance" {
-                                    sensors interfaces-oc;
                                     releases 7.5.1 {
+                                        sensors interfaces-oc;
                                         release-support min-supported-release;
                                     }
                                 }
                             }                             
                             products "XRv" {
                                 platforms "XRv 9000" {
-                                    sensors interfaces-oc;
                                     releases 7.5.1 {
+                                        sensors interfaces-oc;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                            
+                            }
                             products "NCS" {
                                 platforms "NCS-5504" {
-                                    sensors interfaces-oc;
                                     releases 7.5.1 {
+                                        sensors interfaces-oc;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms "NCS-5508" {
-                                    sensors interfaces-oc;
                                     releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-57C3-MOD-SYS" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8201" {
+                                platforms "8201" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8202" {
+                                platforms "8202-32" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8804" {
+                                platforms "8804" {
+                                    releases 7.5.1 {                                        
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8808" {
+                                platforms "8808" {
+                                    releases 7.5.1 {                                        
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "ASR" {
+                                platforms "ASR-9010" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9901" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9902" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9910" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/interface/collect-physical-interface-stats.rule
+++ b/juniper_official/interface/collect-physical-interface-stats.rule
@@ -256,34 +256,97 @@
                     }
                     other-vendor cisco {
                         vendor-name cisco;
-                        operating-systems iosxr {  
+                        operating-systems iosxr {
                             products "XRV Appliance" {
                                 platforms "XRV Appliance" {
-                                    sensors interfaces-oc;
                                     releases 7.5.1 {
+                                        sensors interfaces-oc;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                            
+                            }
                             products "XRv" {
                                 platforms "XRv 9000" {
-                                    sensors interfaces-oc;
                                     releases 7.5.1 {
+                                        sensors interfaces-oc;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                         
+                            }
                             products "NCS" {
                                 platforms "NCS-5504" {
-                                    sensors interfaces-oc;
                                     releases 7.5.1 {
-                                    sensors interfaces-oc;
+                                        sensors interfaces-oc;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms "NCS-5508" {
-                                    sensors interfaces-oc;
                                     releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-57C3-MOD-SYS" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8201" {
+                                platforms "8201" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8202" {
+                                platforms "8202-32" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8804" {
+                                platforms "8804" {
+                                    releases 7.5.1 {                                        
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8808" {
+                                platforms "8808" {
+                                    releases 7.5.1 {                                        
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "ASR" {
+                                platforms "ASR-9010" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9901" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9902" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9910" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/routing/collect-rsvp-cfg.rule
+++ b/juniper_official/routing/collect-rsvp-cfg.rule
@@ -57,33 +57,97 @@
                 supported-devices {  
                     other-vendor cisco {
                         vendor-name cisco;
-                        operating-systems iosxr {  
+                        operating-systems iosxr {
                             products "XRV Appliance" {
-                                platforms "XRV Appliance" {
-                                    sensors cisco-oc-lsp-cfg;
+                                platforms "XRV Appliance" {                                    
                                     releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                           
+                            }
                             products "XRv" {
                                 platforms "XRv 9000" {
-                                    sensors cisco-oc-lsp-cfg;
                                     releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                            
+                            }
                             products "NCS" {
                                 platforms "NCS-5504" {
-                                    sensors cisco-oc-lsp-cfg;
                                     releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms "NCS-5508" {
-                                    sensors cisco-oc-lsp-cfg;
                                     releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-57C3-MOD-SYS" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8201" {
+                                platforms "8201" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8202" {
+                                platforms "8202-32" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8804" {
+                                platforms "8804" {
+                                    releases 7.5.1 {                                        
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8808" {
+                                platforms "8808" {
+                                    releases 7.5.1 {                                        
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "ASR" {
+                                platforms "ASR-9010" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9901" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9902" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9910" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/routing/collect-rsvp-stats.rule
+++ b/juniper_official/routing/collect-rsvp-stats.rule
@@ -200,33 +200,97 @@
                     }                    
                     other-vendor cisco {
                         vendor-name cisco;
-                        operating-systems iosxr {     
+                        operating-systems iosxr {
                             products "XRV Appliance" {
                                 platforms "XRV Appliance" {
-                                    sensors cisco-oc-lsp-traffic;
                                     releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;
                                     }
                                 }
                             }                             
                             products "XRv" {
                                 platforms "XRv 9000" {
-                                    sensors cisco-oc-lsp-traffic;
                                     releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                             
+                            }
                             products "NCS" {
                                 platforms "NCS-5504" {
-                                    sensors cisco-oc-lsp-traffic;
                                     releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;
                                     }
                                 }
                                 platforms "NCS-5508" {
-                                    sensors cisco-oc-lsp-traffic;
                                     releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-57C3-MOD-SYS" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8201" {
+                                platforms "8201" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8202" {
+                                platforms "8202-32" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8804" {
+                                platforms "8804" {
+                                    releases 7.5.1 {                                        
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8808" {
+                                platforms "8808" {
+                                    releases 7.5.1 {                                        
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "ASR" {
+                                platforms "ASR-9010" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9901" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9902" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9910" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;
                                     }
                                 }

--- a/juniper_official/routing/collect-srte-interface-stats.rule
+++ b/juniper_official/routing/collect-srte-interface-stats.rule
@@ -72,33 +72,97 @@ healthbot {
                 supported-devices {
                     other-vendor cisco {
                         vendor-name cisco;
-                        operating-systems iosxr {     
+                        operating-systems iosxr {
                             products "XRV Appliance" {
-                                platforms "XRV Appliance" {                                    
-                                    sensors srte-interface-oc;
+                                platforms "XRV Appliance" {
                                     releases 7.5.1 {
+                                        sensors srte-interface-oc;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                            
+                            }
                             products "XRv" {
-                                platforms "XRv 9000" {                                    
-                                    sensors srte-interface-oc;
+                                platforms "XRv 9000" {
                                     releases 7.5.1 {
+                                        sensors srte-interface-oc;
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                            
+                            }
                             products "NCS" {
                                 platforms "NCS-5504" {
-                                    sensors srte-interface-oc;
                                     releases 7.5.1 {
+                                        sensors srte-interface-oc;
                                         release-support min-supported-release;
                                     }
                                 }
-                                platforms "NCS-5508" {                                    
-                                    sensors srte-interface-oc;
+                                platforms "NCS-5508" {
                                     releases 7.5.1 {
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "NCS-57C3-MOD-SYS" {
+                                    releases 7.5.1 {
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8201" {
+                                platforms "8201" {
+                                    releases 7.5.1 {
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8202" {
+                                platforms "8202-32" {
+                                    releases 7.5.1 {
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8804" {
+                                platforms "8804" {
+                                    releases 7.5.1 {                                        
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "8808" {
+                                platforms "8808" {
+                                    releases 7.5.1 {                                        
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "ASR" {
+                                platforms "ASR-9010" {
+                                    releases 7.5.1 {
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9901" {
+                                    releases 7.5.1 {
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9902" {
+                                    releases 7.5.1 {
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                                platforms "ASR-9910" {
+                                    releases 7.5.1 {
+                                        sensors srte-interface-oc;
                                         release-support min-supported-release;
                                     }
                                 }


### PR DESCRIPTION
Update the rule properties to include the updated list of Cisco products provided by PLM, for the existing devices the sensor as been moved under the release hierarchy as the intention is to allow the sensors to be deployed only starting from release mentioned in the rule. 

The setup in which the modified rules have been deployed is shared over email.

refs: PPF-2346