### PR TITLE
feat: rephrase anomalous message

### DIFF
--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -232,7 +232,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fan-name RPM percent is $rpm-percent% is normal";
+                            message "$fan-name RPM percent($rpm-percent%) is between the predicted range of ($rpm-percent-anomaly-lower-boundary% and $rpm-percent-anomaly-upper-boundary%)";
                         }
                     }
                 }
@@ -248,7 +248,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$fan-name RPM percent($rpm-percent%) is not between the predicted range of ($rpm-percent-anomaly-lower-boundary and $rpm-percent-anomaly-upper-boundary)";
+                            message "$fan-name RPM percent is anomalous";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -232,7 +232,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fan-name RPM percent($rpm-percent%) is between the predicted range of ($rpm-percent-anomaly-lower-boundary% and $rpm-percent-anomaly-upper-boundary%)";
+                            message "$fan-name RPM percent($rpm-percent%) is normal and the predicted range is ($rpm-percent-anomaly-lower-boundary% and $rpm-percent-anomaly-upper-boundary%)";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-fan-state-rpm.rule
+++ b/juniper_official/chassis/check-fan-state-rpm.rule
@@ -232,7 +232,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fan-name RPM percent($rpm-percent%) is normal and the predicted range is ($rpm-percent-anomaly-lower-boundary% and $rpm-percent-anomaly-upper-boundary%)";
+                            message "$fan-name RPM percent($rpm-percent%) is normal";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -244,7 +244,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$psm power usage($psm-power-usage%) is normal";
+                            message "$psm power usage($psm-power-usage%) is between the predicted range of ($psm-power-usage-anomaly-lower-boundary% and $psm-power-usage-anomaly-upper-boundary%)";
                         }
                     }
                 }
@@ -256,7 +256,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$psm input traffic:$psm-power-usage% is not between the predicted range of $psm-power-usage-anomaly-lower-boundary% and $psm-power-usage-anomaly-upper-boundary%";
+                            message "$psm power usage is anomalous";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -244,7 +244,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$psm power usage($psm-power-usage%) is between the predicted range of ($psm-power-usage-anomaly-lower-boundary% and $psm-power-usage-anomaly-upper-boundary%)";
+                            message "$psm power usage($psm-power-usage%) is normal and the predicted range is ($psm-power-usage-anomaly-lower-boundary% and $psm-power-usage-anomaly-upper-boundary%)";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-psm-power-usage-state.rule
+++ b/juniper_official/chassis/check-psm-power-usage-state.rule
@@ -244,7 +244,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$psm power usage($psm-power-usage%) is normal and the predicted range is ($psm-power-usage-anomaly-lower-boundary% and $psm-power-usage-anomaly-upper-boundary%)";
+                            message "$psm power usage($psm-power-usage%) is normal";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-routing-engine-temperature.rule
+++ b/juniper_official/chassis/check-routing-engine-temperature.rule
@@ -174,7 +174,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$routing-engine temperature($routing-engine-temperature degree C) is between the predicted range of ($routing-engine-temperature-anomaly-lower-boundary degree C and $routing-engine-temperature-anomaly-upper-boundary degree C)";
+                            message "$routing-engine temperature($routing-engine-temperature degree C) is normal and the predicted range is ($routing-engine-temperature-anomaly-lower-boundary degree C and $routing-engine-temperature-anomaly-upper-boundary degree C)";
                         }
                     }
                 }
@@ -257,7 +257,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$routing-engine CPU temperature($routing-engine-cpu-temperature degree C) is between the predicted range of ($routing-engine-cpu-temperature-anomaly-lower-boundary degree C and $routing-engine-cpu-temperature-anomaly-upper-boundary degree C)";
+                            message "$routing-engine CPU temperature($routing-engine-cpu-temperature degree C) is normal and the predicted range is ($routing-engine-cpu-temperature-anomaly-lower-boundary degree C and $routing-engine-cpu-temperature-anomaly-upper-boundary degree C)";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-routing-engine-temperature.rule
+++ b/juniper_official/chassis/check-routing-engine-temperature.rule
@@ -174,7 +174,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$routing-engine temperature($routing-engine-temperature degree C) is normal";
+                            message "$routing-engine temperature($routing-engine-temperature degree C) is between the predicted range of ($routing-engine-temperature-anomaly-lower-boundary degree C and $routing-engine-temperature-anomaly-upper-boundary degree C)";
                         }
                     }
                 }
@@ -190,7 +190,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$routing-engine temperature($routing-engine-temperature degree C) is not between the predicted range of ($routing-engine-temperature-anomaly-lower-boundary and $routing-engine-temperature-anomaly-upper-boundary)";
+                            message "$routing-engine temperature is anomalous";
                         }
                     }
                 }
@@ -257,7 +257,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$routing-engine CPU temperature($routing-engine-cpu-temperature degree C) is normal";
+                            message "$routing-engine CPU temperature($routing-engine-cpu-temperature degree C) is between the predicted range of ($routing-engine-cpu-temperature-anomaly-lower-boundary degree C and $routing-engine-cpu-temperature-anomaly-upper-boundary degree C)";
                         }
                     }
                 }
@@ -273,7 +273,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$routing-engine CPU temperature($routing-engine-cpu-temperature degree C) is not between the predicted range of ($routing-engine-cpu-temperature-anomaly-lower-boundary and $routing-engine-cpu-temperature-anomaly-upper-boundary)";
+                            message "$routing-engine CPU temperature is anomalous";
                         }
                     }
                 }

--- a/juniper_official/chassis/check-routing-engine-temperature.rule
+++ b/juniper_official/chassis/check-routing-engine-temperature.rule
@@ -174,7 +174,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$routing-engine temperature($routing-engine-temperature degree C) is normal and the predicted range is ($routing-engine-temperature-anomaly-lower-boundary degree C and $routing-engine-temperature-anomaly-upper-boundary degree C)";
+                            message "$routing-engine temperature($routing-engine-temperature degree C) is normal";
                         }
                     }
                 }
@@ -257,7 +257,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$routing-engine CPU temperature($routing-engine-cpu-temperature degree C) is normal and the predicted range is ($routing-engine-cpu-temperature-anomaly-lower-boundary degree C and $routing-engine-cpu-temperature-anomaly-upper-boundary degree C)";
+                            message "$routing-engine CPU temperature($routing-engine-cpu-temperature degree C) is normal";
                         }
                     }
                 }

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -307,7 +307,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is between the predicted range of $in-mbps-anomaly-lower-boundary and $in-mbps-anomaly-upper-boundary";
+                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is normal and the predicted range is $in-mbps-anomaly-lower-boundary and $in-mbps-anomaly-upper-boundary";
                         }
                     }
                 }
@@ -556,7 +556,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is between the predicted range of $out-mbps-anomaly-lower-boundary and $out-mbps-anomaly-upper-boundary";
+                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is normal and the predicted range is $out-mbps-anomaly-lower-boundary and $out-mbps-anomaly-upper-boundary";
                         }
                     }
                 }

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -307,7 +307,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is normal and the predicted range is $in-mbps-anomaly-lower-boundary and $in-mbps-anomaly-upper-boundary";
+                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is normal";
                         }
                     }
                 }
@@ -556,7 +556,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is normal and the predicted range is $out-mbps-anomaly-lower-boundary and $out-mbps-anomaly-upper-boundary";
+                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is normal";
                         }
                     }
                 }

--- a/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
+++ b/juniper_official/interface/check-interface-in-out-errors-traffic-state-flaps.rule
@@ -307,7 +307,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is normal";
+                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is between the predicted range of $in-mbps-anomaly-lower-boundary and $in-mbps-anomaly-upper-boundary";
                         }
                     }
                 }
@@ -322,7 +322,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name input traffic:$in-mbps mbps is $in-util % of interface speed $speed mbps is not between the predicted range of $in-mbps-anomaly-lower-boundary and $in-mbps-anomaly-upper-boundary";
+                            message "$interface-name input traffic is anomalous";
                         }
                     }
                 }
@@ -556,7 +556,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is normal";
+                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is between the predicted range of $out-mbps-anomaly-lower-boundary and $out-mbps-anomaly-upper-boundary";
                         }
                     }
                 }
@@ -571,7 +571,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name output traffic:$out-mbps mbps is $out-util % of interface speed $speed mbps is not between the predicted range of $out-mbps-anomaly-lower-boundary and $out-mbps-anomaly-upper-boundary";
+                            message "$interface-name output traffic is anomalous";
                         }
                     }
                 }

--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -463,7 +463,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is normal and the predicted range is $optics-rx-power-anomaly-lower-boundary and $optics-rx-power-anomaly-upper-boundary";
+                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is normal";
                         }
                     }
                 }

--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -463,7 +463,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is normal";
+                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is between the predicted range of $optics-rx-power-anomaly-lower-boundary and $optics-rx-power-anomaly-upper-boundary";
                         }
                     }
                 }
@@ -479,7 +479,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is not between the predicted range of $optics-rx-power-anomaly-lower-boundary and $optics-rx-power-anomaly-upper-boundary";
+                            message "$interface-name,lane $lane-index Rx power is anomalous";
                         }
                     }
                 }
@@ -594,7 +594,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name, lane $lane-index Tx power  $optics-tx-power is not between the predicted range of $optics-tx-power-anomaly-lower-boundary and $optics-tx-power-anomaly-upper-boundary";
+                            message "$interface-name, lane $lane-index Tx power is anomalous";
                         }
                     }
                 }

--- a/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
+++ b/juniper_official/interface/check-optical-signal-loss-fec-tx-rx-power.rule
@@ -463,7 +463,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is between the predicted range of $optics-rx-power-anomaly-lower-boundary and $optics-rx-power-anomaly-upper-boundary";
+                            message "$interface-name,lane $lane-index Rx power $optics-rx-power is normal and the predicted range is $optics-rx-power-anomaly-lower-boundary and $optics-rx-power-anomaly-upper-boundary";
                         }
                     }
                 }

--- a/juniper_official/interface/check-optical-temp-thresholds.rule
+++ b/juniper_official/interface/check-optical-temp-thresholds.rule
@@ -107,7 +107,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name, temperature $optical-temp is normal.";
+                            message "$interface-name, temperature $optical-temp is between the predicted range of $optical-temp-anomaly-lower-boundary and $optical-temp-anomaly-upper-boundary";
                         }
                     }
                 }
@@ -122,7 +122,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$interface-name, temperature $optical-temp is not between the predicted range of $optical-temp-anomaly-lower-boundary and $optical-temp-anomaly-upper-boundary";
+                            message "$interface-name, temperature $optical-temp is anomalous";
                         }
                     }
                 }

--- a/juniper_official/interface/check-optical-temp-thresholds.rule
+++ b/juniper_official/interface/check-optical-temp-thresholds.rule
@@ -107,7 +107,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name, temperature $optical-temp is between the predicted range of $optical-temp-anomaly-lower-boundary and $optical-temp-anomaly-upper-boundary";
+                            message "$interface-name, temperature $optical-temp is normal and the predicted range is $optical-temp-anomaly-lower-boundary and $optical-temp-anomaly-upper-boundary";
                         }
                     }
                 }

--- a/juniper_official/interface/check-optical-temp-thresholds.rule
+++ b/juniper_official/interface/check-optical-temp-thresholds.rule
@@ -107,7 +107,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$interface-name, temperature $optical-temp is normal and the predicted range is $optical-temp-anomaly-lower-boundary and $optical-temp-anomaly-upper-boundary";
+                            message "$interface-name, temperature $optical-temp is normal.";
                         }
                     }
                 }

--- a/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
+++ b/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
@@ -327,7 +327,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc buffer memory utilization($fpc-memory-buffer%) is normal and the predicted range is ($fpc-memory-buffer-anomaly-lower-boundary% and $fpc-memory-buffer-anomaly-upper-boundary%)";
+                            message "$fpc buffer memory utilization($fpc-memory-buffer%) is normal";
                         }
                     }
                 }
@@ -390,7 +390,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc cpu utilization($fpc-cpu-utilization%) is normal and the predicted range is ($fpc-cpu-utilization-anomaly-lower-boundary% and $fpc-cpu-utilization-anomaly-upper-boundary%)";
+                            message "$fpc cpu utilization($fpc-cpu-utilization%) is normal";
                         }
                     }
                 }
@@ -497,7 +497,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc temperature($temperature degree C) is normal and the predicted range is ($temperature-anomaly-lower-boundary degree C and $temperature-anomaly-upper-boundary degree C)";
+                            message "$fpc temperature($temperature degree C) is normal";
                         }
                     }
                 }

--- a/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
+++ b/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
@@ -303,7 +303,7 @@ healthbot {
                     }
                 }
                 /*
-                 * Sets color to yellow when fpc-memory-buffer utilization is below low threshold memory-low-threshold)
+                 * Sets color to yellow when fpc-memory-buffer utilization is below low threshold memory-low-threshold
                  * and the fpc-memory-buffer value is anomalous.
                  */ 
                 term is-fpc-memory-buffer-anomalous {
@@ -313,7 +313,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$fpc buffer memory utilization($fpc-memory-buffer%) is not between the predicted range of ($fpc-memory-buffer-anomaly-lower-boundary% and $fpc-memory-buffer-anomaly-upper-boundary%)";
+                            message "$fpc buffer memory utilization is anomalous";
                         }
                     }
                 }
@@ -327,7 +327,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc buffer memory utilization($fpc-memory-buffer%) is normal";
+                            message "$fpc buffer memory utilization($fpc-memory-buffer%) is between the predicted range of ($fpc-memory-buffer-anomaly-lower-boundary% and $fpc-memory-buffer-anomaly-upper-boundary%)";
                         }
                     }
                 }
@@ -376,7 +376,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$fpc cpu utilization($fpc-cpu-utilization%) is not between the predicted range of ($fpc-cpu-utilization-anomaly-lower-boundary% and $fpc-cpu-utilization-anomaly-upper-boundary%)";
+                            message "$fpc cpu utilization($fpc-cpu-utilization%) is anomalous";
                         }
                     }
                 }
@@ -390,7 +390,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc cpu utilization ($fpc-cpu-utilization%) is normal";
+                            message "$fpc cpu utilization($fpc-cpu-utilization%) is between the predicted range of ($fpc-cpu-utilization-anomaly-lower-boundary% and $fpc-cpu-utilization-anomaly-upper-boundary%)";
                         }
                     }
                 }
@@ -497,7 +497,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc temperature($temperature degree celsius) is normal";
+                            message "$fpc temperature($temperature degree C) is between the predicted range of ($temperature-anomaly-lower-boundary degree C and $temperature-anomaly-upper-boundary degree C)";
                         }
                     }
                 }
@@ -513,8 +513,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$fpc temperature($temperature degree C) is not between the predicted range of ($temperature-anomaly-lower-boundary and $temperature-anomaly-upper-boundary)";
-                            
+                            message "$fpc temperature($temperature degree C) is anomalous";
                         }
                     }
                 }

--- a/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
+++ b/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
@@ -376,7 +376,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$fpc cpu utilization($fpc-cpu-utilization%) is anomalous";
+                            message "$fpc cpu utilization is anomalous";
                         }
                     }
                 }
@@ -513,7 +513,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$fpc temperature($temperature degree C) is anomalous";
+                            message "$fpc temperature is anomalous";
                         }
                     }
                 }

--- a/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
+++ b/juniper_official/linecard/check-fpc-cpu-memory-state-temp.rule
@@ -327,7 +327,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc buffer memory utilization($fpc-memory-buffer%) is between the predicted range of ($fpc-memory-buffer-anomaly-lower-boundary% and $fpc-memory-buffer-anomaly-upper-boundary%)";
+                            message "$fpc buffer memory utilization($fpc-memory-buffer%) is normal and the predicted range is ($fpc-memory-buffer-anomaly-lower-boundary% and $fpc-memory-buffer-anomaly-upper-boundary%)";
                         }
                     }
                 }
@@ -390,7 +390,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc cpu utilization($fpc-cpu-utilization%) is between the predicted range of ($fpc-cpu-utilization-anomaly-lower-boundary% and $fpc-cpu-utilization-anomaly-upper-boundary%)";
+                            message "$fpc cpu utilization($fpc-cpu-utilization%) is normal and the predicted range is ($fpc-cpu-utilization-anomaly-lower-boundary% and $fpc-cpu-utilization-anomaly-upper-boundary%)";
                         }
                     }
                 }
@@ -497,7 +497,7 @@ healthbot {
                     then {
                         status {
                             color green;
-                            message "$fpc temperature($temperature degree C) is between the predicted range of ($temperature-anomaly-lower-boundary degree C and $temperature-anomaly-upper-boundary degree C)";
+                            message "$fpc temperature($temperature degree C) is normal and the predicted range is ($temperature-anomaly-lower-boundary degree C and $temperature-anomaly-upper-boundary degree C)";
                         }
                     }
                 }

--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -171,7 +171,7 @@ healthbot {
                      then {
                          status {
                              color green;
-                             message "$routing-engine CPU utilization($re-cpu-utilization%) is between the predicted range of ($re-cpu-utilization-anomaly-lower-boundary% and $re-cpu-utilization-anomaly-upper-boundary%)";
+                             message "$routing-engine CPU utilization($re-cpu-utilization%) is normal and the predicted range is ($re-cpu-utilization-anomaly-lower-boundary% and $re-cpu-utilization-anomaly-upper-boundary%)";
                          }
                      }
                  }	
@@ -254,7 +254,7 @@ healthbot {
                      then {
                          status {
                              color green;
-                             message "$routing-engine memory buffer utilization($re-memory-buffer%) is between the predicted range of ($re-memory-buffer-anomaly-lower-boundary% and $re-memory-buffer-anomaly-upper-boundary%)";
+                             message "$routing-engine memory buffer utilization($re-memory-buffer%) is normal and the predicted range is ($re-memory-buffer-anomaly-lower-boundary% and $re-memory-buffer-anomaly-upper-boundary%)";
                          }
                      }
                  }	

--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -171,7 +171,7 @@ healthbot {
                      then {
                          status {
                              color green;
-                             message "$routing-engine CPU utilization($re-cpu-utilization%) is normal and the predicted range is ($re-cpu-utilization-anomaly-lower-boundary% and $re-cpu-utilization-anomaly-upper-boundary%)";
+                             message "$routing-engine CPU utilization($re-cpu-utilization%) is normal";
                          }
                      }
                  }	
@@ -254,7 +254,7 @@ healthbot {
                      then {
                          status {
                              color green;
-                             message "$routing-engine memory buffer utilization($re-memory-buffer%) is normal and the predicted range is ($re-memory-buffer-anomaly-lower-boundary% and $re-memory-buffer-anomaly-upper-boundary%)";
+                             message "$routing-engine memory buffer utilization($re-memory-buffer%) is normal";
                          }
                      }
                  }	

--- a/juniper_official/system/check-system-cpu-memory.rule
+++ b/juniper_official/system/check-system-cpu-memory.rule
@@ -171,7 +171,7 @@ healthbot {
                      then {
                          status {
                              color green;
-                             message "$routing-engine CPU utilization($re-cpu-utilization%) is normal";
+                             message "$routing-engine CPU utilization($re-cpu-utilization%) is between the predicted range of ($re-cpu-utilization-anomaly-lower-boundary% and $re-cpu-utilization-anomaly-upper-boundary%)";
                          }
                      }
                  }	
@@ -188,7 +188,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$routing-engine CPU utilization($re-cpu-utilization%) is not between the predicted range of ($re-cpu-utilization-anomaly-lower-boundary% and $re-cpu-utilization-anomaly-upper-boundary%)";
+                            message "$routing-engine CPU utilization is anomalous";
                         }
                     }
                 }		
@@ -254,7 +254,7 @@ healthbot {
                      then {
                          status {
                              color green;
-                             message "$routing-engine memory buffer utilization($re-memory-buffer%) is normal";
+                             message "$routing-engine memory buffer utilization($re-memory-buffer%) is between the predicted range of ($re-memory-buffer-anomaly-lower-boundary% and $re-memory-buffer-anomaly-upper-boundary%)";
                          }
                      }
                  }	
@@ -270,7 +270,7 @@ healthbot {
                     then {
                         status {
                             color yellow;
-                            message "$routing-engine memory buffer utilization($re-memory-buffer%) is not between the predicted range of ($re-memory-buffer-anomaly-lower-boundary% and $re-memory-buffer-anomaly-upper-boundary%)";
+                            message "$routing-engine memory buffer utilization is anomalous";
                         }
                     }
                 }	


### PR DESCRIPTION
refs: [COL-1730](https://paragon-automation.atlassian.net/browse/COL-1730)


AIOps marks  anomaly data point within the dynamic threshold after a cool down period so the messages seen to customers in this period were misleading so rephrased it to not have upper boundary, lower boundary and value in it. During aggregation as well these messages were misleading so having a generic message addresses that aswell.

And as we need to preserve the upper boundary and lower boundary in TSDB so have move the message in the normal term so that analytical engine still picks it up and saves it.

