### PR TITLE
fix: update regex for port number

### DIFF
--- a/juniper_official/interface/interface-get-port-data.rule
+++ b/juniper_official/interface/interface-get-port-data.rule
@@ -31,7 +31,7 @@ healthbot {
             }
             field port-name {
                 sensor components-oc {
-                    where "/components/component/@name =~ /^FPC\d+:PIC\d+:PORT\d+$/";
+                    where "/components/component/@name =~ /^FPC\d+:PIC\d+:PORT\d+(:\w+)?$/";
                     path "/components/component/@name";
                 }
                 description "port name";


### PR DESCRIPTION
Modified the rule to capture below:

```
"/components/component/@name":"FPC0:PIC0:PORT11:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT12:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT13:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT14:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT15:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT1:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT2:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT3:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT48:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT49:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT50:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT51:Xcvr0"
"/components/component/@name":"FPC0:PIC0:PORT52:Xcvr0"
```