### PR TITLE
Added enum INIT to adjacency-state field in "check-isis-adjacency-status" rule

### DIFF
--- a/juniper_official/routing/check-isis-adjacency-status.rule
+++ b/juniper_official/routing/check-isis-adjacency-status.rule
@@ -49,6 +49,7 @@
                 enumerate Rejected as -20;				
                 enumerate Down as -15;
                 enumerate New as -10;
+                enumerate INIT as -6;				
                 enumerate Initializing as -5;				
                 enumerate One-way as 0;
                 enumerate up as 1;


### PR DESCRIPTION
ISIS adjacency state is not consistent, OC sensor path shows as "Init" while CLI output and Documentation show as "Initializing"

Sensor Path :
/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/adjacencies/adjacency/state/adjacency-state:string_value:"INIT"

CLI : 
Interface             System         L State         Hold (secs) SNPA
et-0/0/1.0            Spirent-1      2  Up                    21  0:10:94:0:0:3
et-0/0/1.0            0010.9400.0004 2  Initializing          22  0:10:94:0:0:4

Added as fix for  EOPI-2302.