### PR TITLE
Updated sensor path for  ISIS rules

### DIFF
--- a/juniper_official/routing/check-isis-adjacency-status.rule
+++ b/juniper_official/routing/check-isis-adjacency-status.rule
@@ -21,7 +21,7 @@
             	synopsis "ISIS open-config sensor definition";
                 description "Open-config sensor to collect telemetry data from network device";
                 open-config {
-                    sensor-name /network-instances/network-instance/protocols/protocol/isis/interfaces;
+                    sensor-name /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/;
                     frequency 60s;
                 }
             }
@@ -29,7 +29,7 @@
             	synopsis "ISIS open-config sensor definition";
                 description "Open-config sensor to collect telemetry data from network device";
                 open-config {
-                    sensor-name /network-instances/network-instance/protocols/protocol/isis/interfaces;
+                    sensor-name /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/;
                     frequency 60s;
                 }
             }			

--- a/juniper_official/routing/check-isis-flap-detection.rule
+++ b/juniper_official/routing/check-isis-flap-detection.rule
@@ -19,7 +19,7 @@
             	synopsis "ISIS open-config sensor definition";
                 description "Open-config sensor to collect telemetry data from network device";
                 open-config {
-                    sensor-name /network-instances/network-instance/protocols/protocol/isis/interfaces;
+                    sensor-name /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/;
                     frequency 60s;
                 }
             }


### PR DESCRIPTION
Updated sensor paths of below ISIS rules from "/network-instances/network-instance/protocols/protocol/isis/interfaces/" to "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/".

check-isis-adjacency-status
check-isis-flap-detection