### PR TITLE
EOPI-2391 , Updated trigger to match on active routes count

### DIFF
--- a/juniper_official/routing/collect-rib-table-protocol-routes.rule
+++ b/juniper_official/routing/collect-rib-table-protocol-routes.rule
@@ -22,6 +22,14 @@
                 }
                 type integer;
                 description "Protocol active route count";
+                plots protocol-routes-count {
+                    unit count;
+                    triggers protocol-routes-count;
+                    thresholds route-count-threshold {
+                        field-name "$threshold";
+                        severity critical;
+                    }
+                }				
             }
             field protocol-name {
                 sensor route-protocol-summary {
@@ -37,14 +45,6 @@
                 }
                 type integer;
                 description "Protocol route count";
-                plots protocol-total-route-count {
-                    unit count;
-                    triggers protocol-routes-count;
-                    thresholds route-count-threshold {
-                        field-name "$threshold";
-                        severity critical;
-                    }
-                }
             }
             field table-name {
                 sensor route-protocol-summary {
@@ -66,23 +66,23 @@
                 frequency 1offset;
                 term protocol-route-count-ok {
                     when {
-                        less-than "$protocol-total-route-count" "$threshold";
+                        less-than "$active-route-count" "$threshold";
                     }
                     then {
                         status {
                             color green;
-                            message "Protocol $protocol-name of route-table ($table-name) route count($protocol-total-route-count)is normal and active route count is ($active-route-count)";
+                            message "Protocol $protocol-name of route-table ($table-name) active route count($active-route-count)is normal and total route count is ($protocol-total-route-count)";
                         }
                     }
                 }
                 term above-static-threshold {
                     when {
-                        greater-than-or-equal-to "$protocol-total-route-count" "$threshold";
+                        greater-than-or-equal-to "$active-route-count" "$threshold";
                     }
                     then {
                         status {
                             color red;
-                            message "Protocol $protocol-name of route-table ($table-name) route count($protocol-total-route-count) is abnormal and active route count is ($active-route-count)";
+                            message "Protocol $protocol-name of route-table ($table-name) active route count($active-route-count) is abnormal and total route count is ($protocol-total-route-count)";
                         }
                     }
                 }

--- a/juniper_official/routing/collect-rib-table-routes.rule
+++ b/juniper_official/routing/collect-rib-table-routes.rule
@@ -24,7 +24,7 @@
                 description "Active route count";
                 plots active-route-count {
                     unit count;
-                    triggers route-table-total-routes-count;
+                    triggers route-table-routes-count;
                     thresholds route-count-threshold {
                         field-name "$threshold";
                         severity critical;
@@ -77,20 +77,20 @@
             /*
              * Anomaly detection logic.
              */			
-            trigger route-table-total-routes-count {
-                alert-type routing.rib.routes.count.route-table-total-routes-count;			
+            trigger route-table-routes-count {
+                alert-type routing.rib.routes.count.route-table-routes-count;			
                 frequency 1offset;
                 /*
                  * Sets color to green when route-count is less-than-or-equal-to than threshold
                  */				
                 term route-count-normal {
                     when {
-                        less-than "$table-total-route-count" "$threshold";
+                        less-than "$active-route-count" "$threshold";
                     }
                     then {
                         status {
                             color green;
-                            message "Route table($table-name) total route count($table-total-route-count) is normal and active route count is ($active-route-count)";
+                            message "Route table($table-name) active route count($active-route-count) is normal and total route count is ($table-total-route-count)";
                         }
                     }
                 }
@@ -99,12 +99,12 @@
                  */				
                 term is-route-count-abnormal {
                     when {
-                        greater-than-or-equal-to "$table-total-route-count" "$threshold";
+                        greater-than-or-equal-to "$active-route-count" "$threshold";
                     }
                     then {
                         status {
                             color red;
-                            message "Route table($table-name) total route count($table-total-route-count) is abnormal and active route count is ($active-route-count)";
+                            message "Route table($table-name) active route count($active-route-count) is abnormal and total route count is ($table-total-route-count)";
                         }
                     }
                 }


### PR DESCRIPTION
Updated trigger to match active routes count instead of total route count for below rules : 

collect-rib-table-protocol-routes
collect-rib-table-routes