### PR TITLE
Add remaining-lifetime field to collect-isis-lsdb-lsp rule

### DIFF
--- a/juniper_official/routing/collect-isis-lsdb-lsp.rule
+++ b/juniper_official/routing/collect-isis-lsdb-lsp.rule
@@ -1,6 +1,6 @@
 /*
  * Collects LSDB data for lsp-install-time and lsp sequence number
- * REQ: IGP RCA- https://paragon-automation.atlassian.net/browse/REQ-1349
+ * REQ: IGP RCA- https://paragon-automation.atlassian.net/browse/REQ-1349 ,https://paragon-automation.atlassian.net/browse/RBOT-1604
  */
  healthbot {
     topic routing.isis {
@@ -57,6 +57,13 @@
                 }
                 type integer;
                 description "lsp-sequence-number from the lsdb path";
+            }
+            field remaining-lifetime {
+                sensor isis-oc {
+                    path "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/state/remaining-lifetime";
+                }
+                type unsigned-integer;
+                description "remaining-lifetime from the lsdb path";
             }
             variable inst-name {
                 value .*;


### PR DESCRIPTION
Added remaining-lifetime field from lsp/state OC path to collect the LSP remaining lifetime from the LSDB.