### PR TITLE
Removed domain name based on EOPI-2675 from check-pfe-discards

### DIFF
--- a/juniper_official/linecard/check-pfe-discards.rule
+++ b/juniper_official/linecard/check-pfe-discards.rule
@@ -208,7 +208,6 @@ healthbot {
             }
             rule-properties {
                 version 1;
-                domain-name fpc;
                 contributor juniper;
                 category advanced;
                 supported-healthbot-version 4.2.0;


### PR DESCRIPTION
Removed domain name based on EOPI-2675 from check-pfe-discards rule