### PR TITLE
fix: PPF-4112: Add the XRv product and platform values dynamically learnt by EMS

### DIFF
--- a/juniper_official/interface/collect-logical-interface-stats.rule
+++ b/juniper_official/interface/collect-logical-interface-stats.rule
@@ -282,9 +282,17 @@
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                             
+                            }
                             products "XRv" {
                                 platforms "XRv 9000" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "R-IOSXRV" {
+                                platforms "R-IOSXRV9000-CC" {
                                     releases 7.5.1 {
                                         sensors interfaces-oc;
                                         release-support min-supported-release;

--- a/juniper_official/interface/collect-physical-interface-stats.rule
+++ b/juniper_official/interface/collect-physical-interface-stats.rule
@@ -273,6 +273,14 @@
                                     }
                                 }
                             }
+                            products "R-IOSXRV" {
+                                platforms "R-IOSXRV9000-CC" {
+                                    releases 7.5.1 {
+                                        sensors interfaces-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
                             products "NCS" {
                                 platforms "NCS-5504" {
                                     releases 7.5.1 {

--- a/juniper_official/routing/collect-rsvp-cfg.rule
+++ b/juniper_official/routing/collect-rsvp-cfg.rule
@@ -74,6 +74,14 @@
                                     }
                                 }
                             }
+                            products "R-IOSXRV" {
+                                platforms "R-IOSXRV9000-CC" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-cfg;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
                             products "NCS" {
                                 platforms "NCS-5504" {
                                     releases 7.5.1 {

--- a/juniper_official/routing/collect-rsvp-stats.rule
+++ b/juniper_official/routing/collect-rsvp-stats.rule
@@ -208,9 +208,17 @@
                                         release-support min-supported-release;
                                     }
                                 }
-                            }                             
+                            }
                             products "XRv" {
                                 platforms "XRv 9000" {
+                                    releases 7.5.1 {
+                                        sensors cisco-oc-lsp-traffic;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
+                            products "R-IOSXRV" {
+                                platforms "R-IOSXRV9000-CC" {
                                     releases 7.5.1 {
                                         sensors cisco-oc-lsp-traffic;
                                         release-support min-supported-release;

--- a/juniper_official/routing/collect-srte-interface-stats.rule
+++ b/juniper_official/routing/collect-srte-interface-stats.rule
@@ -89,6 +89,14 @@ healthbot {
                                     }
                                 }
                             }
+                            products "R-IOSXRV" {
+                                platforms "R-IOSXRV9000-CC" {
+                                    releases 7.5.1 {
+                                        sensors srte-interface-oc;
+                                        release-support min-supported-release;
+                                    }
+                                }
+                            }
                             products "NCS" {
                                 platforms "NCS-5504" {
                                     releases 7.5.1 {


### PR DESCRIPTION
fix: PPF-4112: Add the XRv product and platform values dynamically learnt by EMS

Update the following Cisco rules to include the product and platform that is dynamically learnt by EMS for XRv product.
* juniper_official/interface/collect-logical-interface-stats.rule
* juniper_official/interface/collect-physical-interface-stats.rule
* juniper_official/routing/collect-rsvp-cfg.rule
* juniper_official/routing/collect-rsvp-stats.rule
* juniper_official/routing/collect-srte-interface-stats.rule


refs: PPF-4112